### PR TITLE
Add ad-end grace period to prevent premature ad-end detection

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -737,7 +737,12 @@ twitch-videoad.js text/javascript
             }
         } else if (streamInfo.IsShowingAd) {
             streamInfo.CleanPlaylistCount++;
-            if (streamInfo.CleanPlaylistCount >= 2) {
+            // Check if the current playlist has live segments — if not, backup stream is dead
+            const hasLiveSegments = textStr.includes(',live');
+            if (streamInfo.CleanPlaylistCount >= 2 || !hasLiveSegments) {
+                if (!hasLiveSegments) {
+                    console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
+                }
                 console.log('Finished blocking ads — stripped ' + streamInfo.NumStrippedAdSegments + ' ad segments');
                 const hadStrippedSegments = streamInfo.NumStrippedAdSegments > 0;
                 streamInfo.IsShowingAd = false;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -748,7 +748,12 @@
             }
         } else if (streamInfo.IsShowingAd) {
             streamInfo.CleanPlaylistCount++;
-            if (streamInfo.CleanPlaylistCount >= 2) {
+            // Check if the current playlist has live segments — if not, backup stream is dead
+            const hasLiveSegments = textStr.includes(',live');
+            if (streamInfo.CleanPlaylistCount >= 2 || !hasLiveSegments) {
+                if (!hasLiveSegments) {
+                    console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
+                }
                 console.log('Finished blocking ads — stripped ' + streamInfo.NumStrippedAdSegments + ' ad segments');
                 const hadStrippedSegments = streamInfo.NumStrippedAdSegments > 0;
                 streamInfo.IsShowingAd = false;

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -467,7 +467,12 @@ twitch-videoad.js text/javascript
                 if (streamM3u8 != null) {
                     if (!hasAdTags(streamM3u8) && SimulatedAdsDepth == 0) {
                         streamInfo.CleanPlaylistCount++;
-                        if (streamInfo.CleanPlaylistCount >= 2) {
+                        // Check if the current playlist has live segments — if not, backup stream is dead
+                        const hasLiveSegments = textStr.includes(LIVE_SIGNIFIER);
+                        if (streamInfo.CleanPlaylistCount >= 2 || !hasLiveSegments) {
+                            if (!hasLiveSegments) {
+                                console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
+                            }
                             console.log('No more ads on main stream. ' + (ReloadPlayerAfterAd ? 'Triggering player reload to go back to main stream...' : 'Resuming playback...'));
                             streamInfo.IsMovingOffBackupEncodings = true;
                             streamInfo.BackupEncodings = null;

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -479,7 +479,12 @@
                 if (streamM3u8 != null) {
                     if (!hasAdTags(streamM3u8) && SimulatedAdsDepth == 0) {
                         streamInfo.CleanPlaylistCount++;
-                        if (streamInfo.CleanPlaylistCount >= 2) {
+                        // Check if the current playlist has live segments — if not, backup stream is dead
+                        const hasLiveSegments = textStr.includes(LIVE_SIGNIFIER);
+                        if (streamInfo.CleanPlaylistCount >= 2 || !hasLiveSegments) {
+                            if (!hasLiveSegments) {
+                                console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
+                            }
                             console.log('No more ads on main stream. ' + (ReloadPlayerAfterAd ? 'Triggering player reload to go back to main stream...' : 'Resuming playback...'));
                             streamInfo.IsMovingOffBackupEncodings = true;
                             streamInfo.BackupEncodings = null;


### PR DESCRIPTION
Require 3 consecutive clean playlists before confirming ads have ended. Prevents reload/flicker when a single clean playlist appears between ad segments.

Applied to vaft and video-swap-new scripts.