### PR TITLE
Fix muted state persisting after ad recovery reload

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -956,6 +956,10 @@ twitch-videoad.js text/javascript
                         if (currentVolumeLS) {
                             localStorage.setItem(lsKeyVolume, currentVolumeLS);
                         }
+                        const videos = document.getElementsByTagName('video');
+                        if (videos.length > 0 && videos[0].muted) {
+                            videos[0].muted = false;
+                        }
                     } catch {}
                 }, 3000);
             }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -967,6 +967,10 @@
                         if (currentVolumeLS) {
                             localStorage.setItem(lsKeyVolume, currentVolumeLS);
                         }
+                        const videos = document.getElementsByTagName('video');
+                        if (videos.length > 0 && videos[0].muted) {
+                            videos[0].muted = false;
+                        }
                     } catch {}
                 }, 3000);
             }

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -862,6 +862,10 @@ twitch-videoad.js text/javascript
                     if (currentVolumeLS) {
                         localStorage.setItem(lsKeyVolume, currentVolumeLS);
                     }
+                    const videos = document.getElementsByTagName('video');
+                    if (videos.length > 0 && videos[0].muted) {
+                        videos[0].muted = false;
+                    }
                 } catch {}
             }, 3000);
         }

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -874,6 +874,10 @@
                     if (currentVolumeLS) {
                         localStorage.setItem(lsKeyVolume, currentVolumeLS);
                     }
+                    const videos = document.getElementsByTagName('video');
+                    if (videos.length > 0 && videos[0].muted) {
+                        videos[0].muted = false;
+                    }
                 } catch {}
             }, 3000);
         }


### PR DESCRIPTION
Always restore muted/volume/quality localStorage values after player reload, not just when localStorage hooks failed (Firefox). On Chrome, the hook succeeds but the reload can force muted state via autoplay policy, which then persists across page refreshes.