### PR TITLE
Add localStorage option to hide Twitch ad overlay text

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1175,7 +1175,7 @@ twitch-videoad.js text/javascript
         const lsHideAdOverlay = localStorage.getItem('twitchAdSolutions_hideAdOverlay');
         if (lsHideAdOverlay === 'true') {
             const style = document.createElement('style');
-            style.textContent = '[data-a-target="player-overlay-content-gate"], .ad-banner, [data-a-target="player-ad-countdown"], [class*="ad-overlay"], [data-a-target="player-overlay-click-handler"] { display: none !important; }';
+            style.textContent = '.adblock-overlay { display: none !important; }';
             (document.head || document.documentElement).appendChild(style);
         }
     } catch {}

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1186,7 +1186,7 @@
         const lsHideAdOverlay = localStorage.getItem('twitchAdSolutions_hideAdOverlay');
         if (lsHideAdOverlay === 'true') {
             const style = document.createElement('style');
-            style.textContent = '[data-a-target="player-overlay-content-gate"], .ad-banner, [data-a-target="player-ad-countdown"], [class*="ad-overlay"], [data-a-target="player-overlay-click-handler"] { display: none !important; }';
+            style.textContent = '.adblock-overlay { display: none !important; }';
             (document.head || document.documentElement).appendChild(style);
         }
     } catch {}

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -995,7 +995,7 @@ twitch-videoad.js text/javascript
         const lsHideAdOverlay = localStorage.getItem('twitchAdSolutions_hideAdOverlay');
         if (lsHideAdOverlay === 'true') {
             const style = document.createElement('style');
-            style.textContent = '[data-a-target="player-overlay-content-gate"], .ad-banner, [data-a-target="player-ad-countdown"], [class*="ad-overlay"], [data-a-target="player-overlay-click-handler"] { display: none !important; }';
+            style.textContent = '.adblock-overlay { display: none !important; }';
             (document.head || document.documentElement).appendChild(style);
         }
     } catch {}

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -1007,7 +1007,7 @@
         const lsHideAdOverlay = localStorage.getItem('twitchAdSolutions_hideAdOverlay');
         if (lsHideAdOverlay === 'true') {
             const style = document.createElement('style');
-            style.textContent = '[data-a-target="player-overlay-content-gate"], .ad-banner, [data-a-target="player-ad-countdown"], [class*="ad-overlay"], [data-a-target="player-overlay-click-handler"] { display: none !important; }';
+            style.textContent = '.adblock-overlay { display: none !important; }';
             (document.head || document.documentElement).appendChild(style);
         }
     } catch {}


### PR DESCRIPTION
Inject CSS to hide ad-related overlays on the video player when enabled. Hides content gate, ad banner, countdown, and click handler overlays.

Enable: localStorage.setItem('twitchAdSolutions_hideAdOverlay', 'true')