### PR TITLE
Remove MutationObserver for non-Twitch video element detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 - Add twitch-stream-source, twitch-trigger, twitch-maf-ad, twitch-ad-quartile DATERANGE class signifiers (adopted from uBO playlist replace rule)
 
 ### Debug Logging
-- Detect and log CSAI (client-side ad insertion) requests via fetch, XHR, and DOM injection
-- Monitor for non-Twitch video elements to identify ad delivery paths
+- Detect and log CSAI (client-side ad insertion) requests via fetch, XHR
 
 ## v45.0.0
 

--- a/strip/strip.user.js
+++ b/strip/strip.user.js
@@ -541,21 +541,6 @@
         }
         return realXHROpen.apply(this, arguments);
     };
-    new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-            for (const node of mutation.addedNodes) {
-                if (node.nodeType === 1) {
-                    const videos = node.tagName === 'VIDEO' ? [node] : node.querySelectorAll ? Array.from(node.querySelectorAll('video, source')) : [];
-                    for (const el of videos) {
-                        const src = el.src || el.getAttribute('src') || '';
-                        if (src && !src.includes('.ttvnw.net') && !src.includes('blob:') && !src.includes('data:')) {
-                            console.log('[AD DEBUG] Non-Twitch video element detected — src: ' + src);
-                        }
-                    }
-                }
-            }
-        }
-    }).observe(document.documentElement, { childList: true, subtree: true });
     if (document.readyState === "complete" || document.readyState === "interactive") {
         onContentLoaded();
     } else {

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1259,21 +1259,6 @@ twitch-videoad.js text/javascript
         }
         return realXHROpen.apply(this, arguments);
     };
-    new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-            for (const node of mutation.addedNodes) {
-                if (node.nodeType === 1) {
-                    const videos = node.tagName === 'VIDEO' ? [node] : node.querySelectorAll ? Array.from(node.querySelectorAll('video, source')) : [];
-                    for (const el of videos) {
-                        const src = el.src || el.getAttribute('src') || '';
-                        if (src && !src.includes('.ttvnw.net') && !src.includes('blob:') && !src.includes('data:')) {
-                            console.log('[AD DEBUG] Non-Twitch video element detected — src: ' + src);
-                        }
-                    }
-                }
-            }
-        }
-    }).observe(document.documentElement, { childList: true, subtree: true });
     if (PlayerBufferingFix) {
         monitorPlayerBuffering();
     }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1271,22 +1271,6 @@
         }
         return realXHROpen.apply(this, arguments);
     };
-    // Detect ad video elements injected into DOM
-    new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-            for (const node of mutation.addedNodes) {
-                if (node.nodeType === 1) {
-                    const videos = node.tagName === 'VIDEO' ? [node] : node.querySelectorAll ? Array.from(node.querySelectorAll('video, source')) : [];
-                    for (const el of videos) {
-                        const src = el.src || el.getAttribute('src') || '';
-                        if (src && !src.includes('.ttvnw.net') && !src.includes('blob:') && !src.includes('data:')) {
-                            console.log('[AD DEBUG] Non-Twitch video element detected — src: ' + src);
-                        }
-                    }
-                }
-            }
-        }
-    }).observe(document.documentElement, { childList: true, subtree: true });
     if (PlayerBufferingFix) {
         monitorPlayerBuffering();
     }

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -1062,21 +1062,6 @@ twitch-videoad.js text/javascript
         }
         return realXHROpen.apply(this, arguments);
     };
-    new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-            for (const node of mutation.addedNodes) {
-                if (node.nodeType === 1) {
-                    const videos = node.tagName === 'VIDEO' ? [node] : node.querySelectorAll ? Array.from(node.querySelectorAll('video, source')) : [];
-                    for (const el of videos) {
-                        const src = el.src || el.getAttribute('src') || '';
-                        if (src && !src.includes('.ttvnw.net') && !src.includes('blob:') && !src.includes('data:')) {
-                            console.log('[AD DEBUG] Non-Twitch video element detected — src: ' + src);
-                        }
-                    }
-                }
-            }
-        }
-    }).observe(document.documentElement, { childList: true, subtree: true });
     monitorLiveStatus();
     if (document.readyState === "complete" || document.readyState === "interactive") {
         onContentLoaded();

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -1074,21 +1074,6 @@
         }
         return realXHROpen.apply(this, arguments);
     };
-    new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-            for (const node of mutation.addedNodes) {
-                if (node.nodeType === 1) {
-                    const videos = node.tagName === 'VIDEO' ? [node] : node.querySelectorAll ? Array.from(node.querySelectorAll('video, source')) : [];
-                    for (const el of videos) {
-                        const src = el.src || el.getAttribute('src') || '';
-                        if (src && !src.includes('.ttvnw.net') && !src.includes('blob:') && !src.includes('data:')) {
-                            console.log('[AD DEBUG] Non-Twitch video element detected — src: ' + src);
-                        }
-                    }
-                }
-            }
-        }
-    }).observe(document.documentElement, { childList: true, subtree: true });
     monitorLiveStatus();
     if (document.readyState === "complete" || document.readyState === "interactive") {
         onContentLoaded();


### PR DESCRIPTION
Addresses reviewer concern: observer watched document.documentElement with subtree:true, firing on every DOM mutation in Twitch's React app. Possible contributor to reported loading issues during CSAI testing.

The observer only logged debug info — it never blocked anything. CSAI detection via fetch/XHR hooks is retained and catches the actual ad request traffic. Net observability loss is minimal.