### PR TITLE
Retry play() after stuck pause/play cycle in vaft buffer monitor

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -998,13 +998,19 @@ twitch-videoad.js text/javascript
             return;
         }
         if (player.isPaused() || player.core?.paused) {
+            // If WE recently called pause/play and player is still paused, retry play (stuck from autoplay policy or ad-state interference)
+            if (playerBufferState.weJustPaused && (Date.now() - playerBufferState.weJustPaused) < 10000) {
+                try { player.play(); } catch {}
+            }
             return;
         }
+        playerBufferState.weJustPaused = 0;
         playerBufferState.lastFixTime = Date.now();
         playerBufferState.numSame = 0;
         if (isPausePlay) {
             player.pause();
             player.play();
+            playerBufferState.weJustPaused = Date.now();
             return;
         }
         if (isReload) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1009,13 +1009,19 @@
             return;
         }
         if (player.isPaused() || player.core?.paused) {
+            // If WE recently called pause/play and player is still paused, retry play (stuck from autoplay policy or ad-state interference)
+            if (playerBufferState.weJustPaused && (Date.now() - playerBufferState.weJustPaused) < 10000) {
+                try { player.play(); } catch {}
+            }
             return;
         }
+        playerBufferState.weJustPaused = 0;
         playerBufferState.lastFixTime = Date.now();
         playerBufferState.numSame = 0;
         if (isPausePlay) {
             player.pause();
             player.play();
+            playerBufferState.weJustPaused = Date.now();
             return;
         }
         if (isReload) {


### PR DESCRIPTION
doTwitchPlayerTask early-returns when player is paused, which prevents recovery when our own pause/play cycle left the player stuck paused (Chrome autoplay policy or ad-state interference can make play() no-op, requiring manual user press-play to resume).

Track weJustPaused timestamp; on next buffer-fix tick, if still paused within 10s window of our pause attempt, retry play(). After 10s, assume user-initiated pause and leave alone.

Graduating from testing scripts (already merged via direct commit) to release scripts via PR.