### PR TITLE
Dedupe 'Backup stream also has ads' logs per ad break

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -653,7 +653,11 @@ twitch-videoad.js text/javascript
                                         break;
                                     }
                                     if (hasAdTags(m3u8Text)) {
-                                        console.log('[AD DEBUG] Backup stream (' + playerType + ') also has ads');
+                                        if (!streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType = new Set();
+                                        if (!streamInfo.LoggedBackupAdsByType.has(playerType)) {
+                                            streamInfo.LoggedBackupAdsByType.add(playerType);
+                                            console.log('[AD DEBUG] Backup stream (' + playerType + ') also has ads');
+                                        }
                                     }
                                     if (isFullyCachedPlayerType) {
                                         break;
@@ -708,6 +712,7 @@ twitch-videoad.js text/javascript
             streamInfo.ActiveBackupPlayerType = null;
             streamInfo.RequestedAds.clear();
             streamInfo.FailedBackupPlayerTypes.clear();
+            if (streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType.clear();
             if (streamInfo.IsUsingModifiedM3U8 || ReloadPlayerAfterAd) {
                 streamInfo.IsUsingModifiedM3U8 = false;
                 streamInfo.LastPlayerReload = Date.now();
@@ -960,7 +965,10 @@ twitch-videoad.js text/javascript
         }
         const reactRootNode = findReactRootNode();
         if (!reactRootNode) {
-            console.log('[AD DEBUG] React root node not found — Twitch may have changed their React setup');
+            if (!getPlayerAndState.loggedNoRoot) {
+                getPlayerAndState.loggedNoRoot = true;
+                console.log('[AD DEBUG] React root node not found — Twitch may have changed their React setup');
+            }
             return null;
         }
         let player = findReactNode(reactRootNode, node => node.setPlayerActive && node.props && node.props.mediaPlayerInstance);
@@ -969,10 +977,12 @@ twitch-videoad.js text/javascript
             player = player.playerInstance;
         }
         const playerState = findReactNode(reactRootNode, node => node.setSrc && node.setInitialPlaybackSettings);
-        if (!player) {
+        if (!player && !getPlayerAndState.loggedNoPlayer) {
+            getPlayerAndState.loggedNoPlayer = true;
             console.log('[AD DEBUG] Player not found — Twitch may have renamed setPlayerActive/mediaPlayerInstance');
         }
-        if (!playerState) {
+        if (!playerState && !getPlayerAndState.loggedNoState) {
+            getPlayerAndState.loggedNoState = true;
             console.log('[AD DEBUG] Player state not found — Twitch may have renamed setSrc/setInitialPlaybackSettings');
         }
         return  {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -664,7 +664,11 @@
                                         break;
                                     }
                                     if (hasAdTags(m3u8Text)) {
-                                        console.log('[AD DEBUG] Backup stream (' + playerType + ') also has ads');
+                                        if (!streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType = new Set();
+                                        if (!streamInfo.LoggedBackupAdsByType.has(playerType)) {
+                                            streamInfo.LoggedBackupAdsByType.add(playerType);
+                                            console.log('[AD DEBUG] Backup stream (' + playerType + ') also has ads');
+                                        }
                                     }
                                     if (isFullyCachedPlayerType) {
                                         break;
@@ -719,6 +723,7 @@
             streamInfo.ActiveBackupPlayerType = null;
             streamInfo.RequestedAds.clear();
             streamInfo.FailedBackupPlayerTypes.clear();
+            if (streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType.clear();
             if (streamInfo.IsUsingModifiedM3U8 || ReloadPlayerAfterAd) {
                 streamInfo.IsUsingModifiedM3U8 = false;
                 streamInfo.LastPlayerReload = Date.now();
@@ -971,7 +976,10 @@
         }
         const reactRootNode = findReactRootNode();
         if (!reactRootNode) {
-            console.log('[AD DEBUG] React root node not found — Twitch may have changed their React setup');
+            if (!getPlayerAndState.loggedNoRoot) {
+                getPlayerAndState.loggedNoRoot = true;
+                console.log('[AD DEBUG] React root node not found — Twitch may have changed their React setup');
+            }
             return null;
         }
         let player = findReactNode(reactRootNode, node => node.setPlayerActive && node.props && node.props.mediaPlayerInstance);
@@ -980,10 +988,12 @@
             player = player.playerInstance;
         }
         const playerState = findReactNode(reactRootNode, node => node.setSrc && node.setInitialPlaybackSettings);
-        if (!player) {
+        if (!player && !getPlayerAndState.loggedNoPlayer) {
+            getPlayerAndState.loggedNoPlayer = true;
             console.log('[AD DEBUG] Player not found — Twitch may have renamed setPlayerActive/mediaPlayerInstance');
         }
-        if (!playerState) {
+        if (!playerState && !getPlayerAndState.loggedNoState) {
+            getPlayerAndState.loggedNoState = true;
             console.log('[AD DEBUG] Player state not found — Twitch may have renamed setSrc/setInitialPlaybackSettings');
         }
         return  {


### PR DESCRIPTION
Each player type's ad status was logged on every backup search iteration, and the search re-runs on each main m3u8 poll during an ad break. This produced 40+ repeated log lines per ad break on heavily ad-loaded channels.

Track logged player types per streamInfo; log each type at most once per ad break. Set clears when the ad break ends.