### PR TITLE
Add reload cap and visibility backoff to buffer monitor (release)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -936,9 +936,9 @@ twitch-videoad.js text/javascript
                 if (!document.hidden) setTimeout(monitorPlayerBuffering, 100);
             });
         }
-        // Visibility-aware backoff: poll 5x slower when tab is hidden (but NOT during PiP — user is still watching)
+        // Visibility-aware backoff: poll 3x slower when tab is hidden (but NOT during PiP — user is still watching)
         const shouldThrottle = typeof document !== 'undefined' && document.hidden && !document.pictureInPictureElement;
-        const nextDelay = shouldThrottle ? PlayerBufferingDelay * 5 : PlayerBufferingDelay;
+        const nextDelay = shouldThrottle ? PlayerBufferingDelay * 3 : PlayerBufferingDelay;
         setTimeout(monitorPlayerBuffering, nextDelay);
     }
     function updateAdblockBanner(data) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -947,9 +947,9 @@
                 if (!document.hidden) setTimeout(monitorPlayerBuffering, 100);
             });
         }
-        // Visibility-aware backoff: poll 5x slower when tab is hidden (but NOT during PiP — user is still watching)
+        // Visibility-aware backoff: poll 3x slower when tab is hidden (but NOT during PiP — user is still watching)
         const shouldThrottle = typeof document !== 'undefined' && document.hidden && !document.pictureInPictureElement;
-        const nextDelay = shouldThrottle ? PlayerBufferingDelay * 5 : PlayerBufferingDelay;
+        const nextDelay = shouldThrottle ? PlayerBufferingDelay * 3 : PlayerBufferingDelay;
         setTimeout(monitorPlayerBuffering, nextDelay);
     }
     function updateAdblockBanner(data) {


### PR DESCRIPTION
Inspired by TTV-AB v5.1.4 stability improvements:

1. One-reload-per-recovery cap: after buffer monitor escalates to a player reload once, subsequent buffer fixes stay on pause/play until playback resumes healthily. Prevents reload cascades during persistent stalls. The recoveryReloadUsed flag resets when playback advances.

2. Visibility-aware poll backoff: when document.hidden is true, poll 5x slower (5s instead of 1s). Reduces background CPU on multi-tab users. Returns to normal poll rate on next tick after visibility restored.

Graduating from testing scripts to release.