### PR TITLE
Tune visibility backoff from 5x to 3x

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -936,9 +936,9 @@ twitch-videoad.js text/javascript
                 if (!document.hidden) setTimeout(monitorPlayerBuffering, 100);
             });
         }
-        // Visibility-aware backoff: poll 5x slower when tab is hidden (but NOT during PiP — user is still watching)
+        // Visibility-aware backoff: poll 3x slower when tab is hidden (but NOT during PiP — user is still watching)
         const shouldThrottle = typeof document !== 'undefined' && document.hidden && !document.pictureInPictureElement;
-        const nextDelay = shouldThrottle ? PlayerBufferingDelay * 5 : PlayerBufferingDelay;
+        const nextDelay = shouldThrottle ? PlayerBufferingDelay * 3 : PlayerBufferingDelay;
         setTimeout(monitorPlayerBuffering, nextDelay);
     }
     function updateAdblockBanner(data) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -947,9 +947,9 @@
                 if (!document.hidden) setTimeout(monitorPlayerBuffering, 100);
             });
         }
-        // Visibility-aware backoff: poll 5x slower when tab is hidden (but NOT during PiP — user is still watching)
+        // Visibility-aware backoff: poll 3x slower when tab is hidden (but NOT during PiP — user is still watching)
         const shouldThrottle = typeof document !== 'undefined' && document.hidden && !document.pictureInPictureElement;
-        const nextDelay = shouldThrottle ? PlayerBufferingDelay * 5 : PlayerBufferingDelay;
+        const nextDelay = shouldThrottle ? PlayerBufferingDelay * 3 : PlayerBufferingDelay;
         setTimeout(monitorPlayerBuffering, nextDelay);
     }
     function updateAdblockBanner(data) {


### PR DESCRIPTION
After initial sizing, 5x delay gives 4s worst-case stall detection on hidden tabs. Tuning to 3x keeps CPU savings meaningful (~67% fewer monitor iterations vs ~80% at 5x) while reducing worst-case delay to 2s, which stays below the user-perception threshold for "something broke" (typically ~3s).

Better trade for users with background audio streams — 2-3s silence window on stall instead of 4-5s.

Chained off feat/reload-cap-visibility-backoff — merge that first.