### PR TITLE
Strengthen reload decision, retry failed backup types, document config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ The scripts support runtime configuration via `localStorage`. Set values in the 
 - `true` - hide the "Blocking ads" banner overlay on the video player
 - Not set - banner is visible during ad blocking (default)
 
+**`twitchAdSolutions_pinBackupPlayerType`** (default: `false`)
+- `true` - remember which backup player type worked and try it first on next ad break (saves backup search time)
+- `false` - always iterate through backup types fresh (default)
+- ⚠ **Quality caveat**: if the pinned type is `autoplay`, backups during ad breaks stay at 360p even when a source-quality backup would have worked. Only enable if you prefer consistent ad-break experience over backup quality.
+
+**`twitchAdSolutions_reloadCooldownSeconds`** (default: `30`)
+- Minimum seconds between player reloads after ad breaks
+- Prevents CSAI (client-side ad insertion) cascades where a reload triggers Twitch to serve another ad
+- Set to `0` to disable cooldown
+
+**`twitchAdSolutions_disableReloadCap`** (default: not set)
+- `true` - buffer monitor reloads unlimited times (pre-v47 behavior, risk of reload loops)
+- Not set - buffer monitor reloads at most once per recovery window (default)
+- Only enable if you're seeing genuinely stuck playback that a single reload doesn't fix
+
 ```js
 // Faster post-ad transition
 localStorage.setItem('twitchAdSolutions_reloadPlayerAfterAd', 'false');
@@ -97,6 +112,9 @@ localStorage.setItem('twitchAdSolutions_hideAdOverlay', 'true');
 localStorage.removeItem('twitchAdSolutions_reloadPlayerAfterAd');
 localStorage.removeItem('twitchAdSolutions_playerType');
 localStorage.removeItem('twitchAdSolutions_hideAdOverlay');
+localStorage.removeItem('twitchAdSolutions_pinBackupPlayerType');
+localStorage.removeItem('twitchAdSolutions_reloadCooldownSeconds');
+localStorage.removeItem('twitchAdSolutions_disableReloadCap');
 ```
 
 ## Known Extension Conflicts

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -313,7 +313,7 @@ twitch-videoad.js text/javascript
                                         IsStrippingAdSegments: false,
                                         NumStrippedAdSegments: 0,
                                         RecoverySegments: [],
-                                        FailedBackupPlayerTypes: new Set()
+                                        FailedBackupPlayerTypes: new Map()// Map<playerType, timestamp> — failures expire after 15s for retry
                                     };
                                     const lines = encodingsM3u8.split(/\r?\n/);
                                     for (let i = 0; i < lines.length - 1; i++) {
@@ -612,7 +612,8 @@ twitch-videoad.js text/javascript
             for (let playerTypeIndex = startIndex; !backupM3u8 && playerTypeIndex < playerTypesToTry.length; playerTypeIndex++) {
                 const playerType = playerTypesToTry[playerTypeIndex];
                 const realPlayerType = playerType.replace('-CACHED', '');
-                if (streamInfo.FailedBackupPlayerTypes.has(realPlayerType)) {
+                const failedAt = streamInfo.FailedBackupPlayerTypes.get(realPlayerType);
+                if (failedAt && (Date.now() - failedAt) < 15000) {
                     continue;
                 }
                 const isFullyCachedPlayerType = playerType != realPlayerType;
@@ -639,11 +640,11 @@ twitch-videoad.js text/javascript
                                 }
                             } else {
                                 console.log('[AD DEBUG] Access token HTTP ' + accessTokenResponse.status + ' for ' + realPlayerType);
-                                streamInfo.FailedBackupPlayerTypes.add(realPlayerType);
+                                streamInfo.FailedBackupPlayerTypes.set(realPlayerType, Date.now());
                             }
                         } catch (err) {
                             console.log('[AD DEBUG] Access token failed for ' + realPlayerType + ': ' + err.message);
-                            streamInfo.FailedBackupPlayerTypes.add(realPlayerType);
+                            streamInfo.FailedBackupPlayerTypes.set(realPlayerType, Date.now());
                         }
                     }
                     if (encodingsM3u8) {
@@ -715,6 +716,7 @@ twitch-videoad.js text/javascript
             }
         } else if (streamInfo.IsShowingAd) {
             console.log('Finished blocking ads — stripped ' + streamInfo.NumStrippedAdSegments + ' ad segments');
+            const hadStrippedSegments = streamInfo.NumStrippedAdSegments > 0;
             streamInfo.IsShowingAd = false;
             streamInfo.IsStrippingAdSegments = false;
             streamInfo.NumStrippedAdSegments = 0;
@@ -723,7 +725,8 @@ twitch-videoad.js text/javascript
             streamInfo.FailedBackupPlayerTypes.clear();
             if (streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType.clear();
             const tooSoonSinceLastReload = streamInfo.LastPlayerReload && (Date.now() - streamInfo.LastPlayerReload) < (ReloadCooldownSeconds * 1000);
-            const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && !tooSoonSinceLastReload);
+            // Reload if backup was used (need to swap back). Otherwise, respect ReloadPlayerAfterAd — stripped segments bypass cooldown but not the user's preference.
+            const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && (hadStrippedSegments || !tooSoonSinceLastReload));
             if (shouldReload) {
                 streamInfo.IsUsingModifiedM3U8 = false;
                 streamInfo.LastPlayerReload = Date.now();

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -324,7 +324,7 @@
                                         IsStrippingAdSegments: false,
                                         NumStrippedAdSegments: 0,
                                         RecoverySegments: [],
-                                        FailedBackupPlayerTypes: new Set()
+                                        FailedBackupPlayerTypes: new Map()// Map<playerType, timestamp> — failures expire after 15s for retry
                                     };
                                     const lines = encodingsM3u8.split(/\r?\n/);
                                     for (let i = 0; i < lines.length - 1; i++) {
@@ -623,7 +623,8 @@
             for (let playerTypeIndex = startIndex; !backupM3u8 && playerTypeIndex < playerTypesToTry.length; playerTypeIndex++) {
                 const playerType = playerTypesToTry[playerTypeIndex];
                 const realPlayerType = playerType.replace('-CACHED', '');
-                if (streamInfo.FailedBackupPlayerTypes.has(realPlayerType)) {
+                const failedAt = streamInfo.FailedBackupPlayerTypes.get(realPlayerType);
+                if (failedAt && (Date.now() - failedAt) < 15000) {
                     continue;
                 }
                 const isFullyCachedPlayerType = playerType != realPlayerType;
@@ -650,11 +651,11 @@
                                 }
                             } else {
                                 console.log('[AD DEBUG] Access token HTTP ' + accessTokenResponse.status + ' for ' + realPlayerType);
-                                streamInfo.FailedBackupPlayerTypes.add(realPlayerType);
+                                streamInfo.FailedBackupPlayerTypes.set(realPlayerType, Date.now());
                             }
                         } catch (err) {
                             console.log('[AD DEBUG] Access token failed for ' + realPlayerType + ': ' + err.message);
-                            streamInfo.FailedBackupPlayerTypes.add(realPlayerType);
+                            streamInfo.FailedBackupPlayerTypes.set(realPlayerType, Date.now());
                         }
                     }
                     if (encodingsM3u8) {
@@ -726,6 +727,7 @@
             }
         } else if (streamInfo.IsShowingAd) {
             console.log('Finished blocking ads — stripped ' + streamInfo.NumStrippedAdSegments + ' ad segments');
+            const hadStrippedSegments = streamInfo.NumStrippedAdSegments > 0;
             streamInfo.IsShowingAd = false;
             streamInfo.IsStrippingAdSegments = false;
             streamInfo.NumStrippedAdSegments = 0;
@@ -734,7 +736,8 @@
             streamInfo.FailedBackupPlayerTypes.clear();
             if (streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType.clear();
             const tooSoonSinceLastReload = streamInfo.LastPlayerReload && (Date.now() - streamInfo.LastPlayerReload) < (ReloadCooldownSeconds * 1000);
-            const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && !tooSoonSinceLastReload);
+            // Reload if backup was used (need to swap back). Otherwise, respect ReloadPlayerAfterAd — stripped segments bypass cooldown but not the user's preference.
+            const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && (hadStrippedSegments || !tooSoonSinceLastReload));
             if (shouldReload) {
                 streamInfo.IsUsingModifiedM3U8 = false;
                 streamInfo.LastPlayerReload = Date.now();


### PR DESCRIPTION
Addresses reviewer concerns on the stable release:

1. Reload after ad-end now also triggers when real segments were stripped (hadStrippedSegments), even within cooldown window. Fresh token/manifest cleans up player state more thoroughly than pause/play — reduces risk of ads leaking through when cooldown would have skipped the reload.

2. FailedBackupPlayerTypes changed from Set to Map<type, timestamp>. Failures expire after 15s so transient network issues (GQL errors, connection blips) don't blacklist a player type for the entire ad break.

3. README updates: document PinBackupPlayerType quality caveat (360p lock when autoplay gets pinned), ReloadCooldownSeconds, DisableReloadCap.