### PR TITLE
Smooth drift correction via playback rate (release)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -212,9 +212,9 @@ twitch-videoad.js text/javascript
                     if (e.data.key == 'UpdateAdBlockBanner') {
                         updateAdblockBanner(e.data);
                         // Clear drift catch-up when ads start — don't run 1.1x during ad handling
-                        if (e.data.hasAds && driftCatchUpInterval) {
-                            clearInterval(driftCatchUpInterval);
-                            driftCatchUpInterval = null;
+                        if (e.data.hasAds && (driftCatchUpInterval || driftCatchUpTimeout)) {
+                            if (driftCatchUpInterval) { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; }
+                            if (driftCatchUpTimeout) { clearTimeout(driftCatchUpTimeout); driftCatchUpTimeout = null; }
                             try { document.querySelector('video').playbackRate = 1.0; } catch {}
                         }
                     } else if (e.data.key == 'PauseResumePlayer') {
@@ -835,6 +835,7 @@ twitch-videoad.js text/javascript
     }
     let playerForMonitoringBuffering = null;
     let driftCatchUpInterval = null;
+    let driftCatchUpTimeout = null;
     const playerBufferState = {
         channelName: null,
         hasStreamStarted: false,
@@ -1115,7 +1116,8 @@ twitch-videoad.js text/javascript
                             const drift = liveEdge - videos[0].currentTime;
                             if (drift > 2) {
                                 console.log('[AD DEBUG] Post-reload live drift correction: ' + drift.toFixed(1) + 's behind — catching up at ' + DriftCorrectionRate + 'x');
-                                if (driftCatchUpInterval) clearInterval(driftCatchUpInterval);
+                                if (driftCatchUpInterval) { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; }
+                                if (driftCatchUpTimeout) { clearTimeout(driftCatchUpTimeout); driftCatchUpTimeout = null; }
                                 videos[0].playbackRate = DriftCorrectionRate;
                                 driftCatchUpInterval = setInterval(() => {
                                     try {
@@ -1127,11 +1129,12 @@ twitch-videoad.js text/javascript
                                                 console.log('[AD DEBUG] Drift correction complete — resumed normal playback speed');
                                                 clearInterval(driftCatchUpInterval);
                                                 driftCatchUpInterval = null;
+                                                if (driftCatchUpTimeout) { clearTimeout(driftCatchUpTimeout); driftCatchUpTimeout = null; }
                                             }
                                         }
                                     } catch { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; }
                                 }, 500);
-                                setTimeout(() => { try { videos[0].playbackRate = 1.0; } catch {} if (driftCatchUpInterval) { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; } }, 30000);
+                                driftCatchUpTimeout = setTimeout(() => { try { videos[0].playbackRate = 1.0; } catch {} if (driftCatchUpInterval) { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; } driftCatchUpTimeout = null; }, 30000);
                             }
                         }
                     } catch {}

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -223,9 +223,9 @@
                     if (e.data.key == 'UpdateAdBlockBanner') {
                         updateAdblockBanner(e.data);
                         // Clear drift catch-up when ads start — don't run 1.1x during ad handling
-                        if (e.data.hasAds && driftCatchUpInterval) {
-                            clearInterval(driftCatchUpInterval);
-                            driftCatchUpInterval = null;
+                        if (e.data.hasAds && (driftCatchUpInterval || driftCatchUpTimeout)) {
+                            if (driftCatchUpInterval) { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; }
+                            if (driftCatchUpTimeout) { clearTimeout(driftCatchUpTimeout); driftCatchUpTimeout = null; }
                             try { document.querySelector('video').playbackRate = 1.0; } catch {}
                         }
                     } else if (e.data.key == 'PauseResumePlayer') {
@@ -846,6 +846,7 @@
     }
     let playerForMonitoringBuffering = null;
     let driftCatchUpInterval = null;
+    let driftCatchUpTimeout = null;
     const playerBufferState = {
         channelName: null,
         hasStreamStarted: false,
@@ -1126,7 +1127,8 @@
                             const drift = liveEdge - videos[0].currentTime;
                             if (drift > 2) {
                                 console.log('[AD DEBUG] Post-reload live drift correction: ' + drift.toFixed(1) + 's behind — catching up at ' + DriftCorrectionRate + 'x');
-                                if (driftCatchUpInterval) clearInterval(driftCatchUpInterval);
+                                if (driftCatchUpInterval) { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; }
+                                if (driftCatchUpTimeout) { clearTimeout(driftCatchUpTimeout); driftCatchUpTimeout = null; }
                                 videos[0].playbackRate = DriftCorrectionRate;
                                 driftCatchUpInterval = setInterval(() => {
                                     try {
@@ -1138,11 +1140,12 @@
                                                 console.log('[AD DEBUG] Drift correction complete — resumed normal playback speed');
                                                 clearInterval(driftCatchUpInterval);
                                                 driftCatchUpInterval = null;
+                                                if (driftCatchUpTimeout) { clearTimeout(driftCatchUpTimeout); driftCatchUpTimeout = null; }
                                             }
                                         }
                                     } catch { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; }
                                 }, 500);
-                                setTimeout(() => { try { videos[0].playbackRate = 1.0; } catch {} if (driftCatchUpInterval) { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; } }, 30000);
+                                driftCatchUpTimeout = setTimeout(() => { try { videos[0].playbackRate = 1.0; } catch {} if (driftCatchUpInterval) { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; } driftCatchUpTimeout = null; }, 30000);
                             }
                         }
                     } catch {}


### PR DESCRIPTION
Replace instant seek (jarring video jump) with gradual catch-up via playback rate after reload. Default 1.1x — nearly imperceptible.

New localStorage option twitchAdSolutions_driftCorrectionRate:
- Default 1.1 (catch up ~3s drift in ~30s)
- Set higher for faster catch-up (e.g., 1.2 = ~15s)
- Set to 0 to disable drift correction entirely