### PR TITLE
Prevent duplicate monitorPlayerBuffering scheduling on tab return (re…

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -936,7 +936,10 @@ twitch-videoad.js text/javascript
         if (typeof document !== 'undefined' && !monitorPlayerBuffering.visibilityHooked) {
             monitorPlayerBuffering.visibilityHooked = true;
             document.addEventListener('visibilitychange', () => {
-                if (!document.hidden) setTimeout(monitorPlayerBuffering, 100);
+                if (!document.hidden && !monitorPlayerBuffering.pendingTick) {
+                    monitorPlayerBuffering.pendingTick = true;
+                    setTimeout(() => { monitorPlayerBuffering.pendingTick = false; monitorPlayerBuffering(); }, 100);
+                }
             });
         }
         // Visibility-aware backoff: poll 3x slower when tab is hidden (but NOT during PiP — user is still watching)

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -947,7 +947,10 @@
         if (typeof document !== 'undefined' && !monitorPlayerBuffering.visibilityHooked) {
             monitorPlayerBuffering.visibilityHooked = true;
             document.addEventListener('visibilitychange', () => {
-                if (!document.hidden) setTimeout(monitorPlayerBuffering, 100);
+                if (!document.hidden && !monitorPlayerBuffering.pendingTick) {
+                    monitorPlayerBuffering.pendingTick = true;
+                    setTimeout(() => { monitorPlayerBuffering.pendingTick = false; monitorPlayerBuffering(); }, 100);
+                }
             });
         }
         // Visibility-aware backoff: poll 3x slower when tab is hidden (but NOT during PiP — user is still watching)


### PR DESCRIPTION
…lease)

The visibilitychange listener scheduled setTimeout(monitorPlayerBuffering, 100) while the normal polling loop also had a pending setTimeout. Both fired on tab return, causing the monitor to run twice in quick succession.

Add pendingTick guard so the visibility listener only schedules if no immediate tick is already queued.