### PR TITLE
Cache isLiveSegment in stripAdSegments + init streamInfo properties (…

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -315,7 +315,11 @@ twitch-videoad.js text/javascript
                                         IsStrippingAdSegments: false,
                                         NumStrippedAdSegments: 0,
                                         RecoverySegments: [],
-                                        FailedBackupPlayerTypes: new Map()// Map<playerType, timestamp> — failures expire after 15s for retry
+                                        FailedBackupPlayerTypes: new Map(),// Map<playerType, timestamp> — failures expire after 15s for retry
+                                        HasCheckedUnknownTags: false,
+                                        HasLoggedAdAttributes: false,
+                                        LoggedBackupAdsByType: null,
+                                        RecoveryStartSeq: undefined
                                     };
                                     const lines = encodingsM3u8.split(/\r?\n/);
                                     for (let i = 0; i < lines.length - 1; i++) {
@@ -435,7 +439,8 @@ twitch-videoad.js text/javascript
             // Remove tracking urls which appear in the overlay UI
             lines[i] = line
                 .replaceAll(/(X-TV-TWITCH-AD(?:-[A-Z]+)*-URLS?=")[^"]*(")/g, `$1${newAdUrl}$2`);
-            if (i < lines.length - 1 && line.startsWith('#EXTINF') && (!line.includes(',live') || stripAllSegments || AllSegmentsAreAdSegments || inCueOut)) {
+            const isLiveSegment = line.includes(',live');
+            if (i < lines.length - 1 && line.startsWith('#EXTINF') && (!isLiveSegment || stripAllSegments || AllSegmentsAreAdSegments || inCueOut)) {
                 const segmentUrl = lines[i + 1];
                 if (!AdSegmentCache.has(segmentUrl)) {
                     streamInfo.NumStrippedAdSegments++;
@@ -447,7 +452,7 @@ twitch-videoad.js text/javascript
                 AdSegmentCache.set(lines[i + 1], Date.now());
                 hasStrippedAdSegments = true;
                 streamInfo.NumStrippedAdSegments++;
-            } else if (i < lines.length - 1 && line.startsWith('#EXTINF') && line.includes(',live')) {
+            } else if (i < lines.length - 1 && line.startsWith('#EXTINF') && isLiveSegment) {
                 liveSegments.push({ extinf: line, url: lines[i + 1] });
             }
             if (AdSignifiers.some((s) => line.includes(s))) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -326,7 +326,11 @@
                                         IsStrippingAdSegments: false,
                                         NumStrippedAdSegments: 0,
                                         RecoverySegments: [],
-                                        FailedBackupPlayerTypes: new Map()// Map<playerType, timestamp> — failures expire after 15s for retry
+                                        FailedBackupPlayerTypes: new Map(),// Map<playerType, timestamp> — failures expire after 15s for retry
+                                        HasCheckedUnknownTags: false,
+                                        HasLoggedAdAttributes: false,
+                                        LoggedBackupAdsByType: null,
+                                        RecoveryStartSeq: undefined
                                     };
                                     const lines = encodingsM3u8.split(/\r?\n/);
                                     for (let i = 0; i < lines.length - 1; i++) {
@@ -446,7 +450,8 @@
             // Remove tracking urls which appear in the overlay UI
             lines[i] = line
                 .replaceAll(/(X-TV-TWITCH-AD(?:-[A-Z]+)*-URLS?=")[^"]*(")/g, `$1${newAdUrl}$2`);
-            if (i < lines.length - 1 && line.startsWith('#EXTINF') && (!line.includes(',live') || stripAllSegments || AllSegmentsAreAdSegments || inCueOut)) {
+            const isLiveSegment = line.includes(',live');
+            if (i < lines.length - 1 && line.startsWith('#EXTINF') && (!isLiveSegment || stripAllSegments || AllSegmentsAreAdSegments || inCueOut)) {
                 const segmentUrl = lines[i + 1];
                 if (!AdSegmentCache.has(segmentUrl)) {
                     streamInfo.NumStrippedAdSegments++;
@@ -458,7 +463,7 @@
                 AdSegmentCache.set(lines[i + 1], Date.now());
                 hasStrippedAdSegments = true;
                 streamInfo.NumStrippedAdSegments++;
-            } else if (i < lines.length - 1 && line.startsWith('#EXTINF') && line.includes(',live')) {
+            } else if (i < lines.length - 1 && line.startsWith('#EXTINF') && isLiveSegment) {
                 liveSegments.push({ extinf: line, url: lines[i + 1] });
             }
             if (AdSignifiers.some((s) => line.includes(s))) {


### PR DESCRIPTION
…release)

V8 micro-optimizations:
1. Cache line.includes(',live') result per line in stripAdSegments hot loop — avoids repeated string scan on same line across if/else-if.
2. Initialize HasCheckedUnknownTags, HasLoggedAdAttributes, LoggedBackupAdsByType, RecoveryStartSeq on streamInfo constructor — stabilizes V8 hidden class (no shape transitions on first ad break).