### PR TITLE
Remove 'React root node not found' log (release)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1002,10 +1002,6 @@ twitch-videoad.js text/javascript
         }
         const reactRootNode = findReactRootNode();
         if (!reactRootNode) {
-            if (!getPlayerAndState.loggedNoRoot) {
-                getPlayerAndState.loggedNoRoot = true;
-                console.log('[AD DEBUG] React root node not found — Twitch may have changed their React setup');
-            }
             return null;
         }
         let player = findReactNode(reactRootNode, node => node.setPlayerActive && node.props && node.props.mediaPlayerInstance);

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1013,10 +1013,6 @@
         }
         const reactRootNode = findReactRootNode();
         if (!reactRootNode) {
-            if (!getPlayerAndState.loggedNoRoot) {
-                getPlayerAndState.loggedNoRoot = true;
-                console.log('[AD DEBUG] React root node not found — Twitch may have changed their React setup');
-            }
             return null;
         }
         let player = findReactNode(reactRootNode, node => node.setPlayerActive && node.props && node.props.mediaPlayerInstance);


### PR DESCRIPTION
Fires on every page load before React mounts — timing artifact, not a real error. All callers already handle the null return. The log was misleading (implied Twitch changed their setup when React just hadn't loaded yet).