### PR TITLE
Invalidate cached player reference on reload (release)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1080,6 +1080,7 @@ twitch-videoad.js text/javascript
                 }
             } catch {}
             playerBufferState.lastReloadAt = Date.now();
+            playerForMonitoringBuffering = null;// Force re-acquire player ref after reload — old ref reads stale buffer state
             console.log('Reloading Twitch player');
             playerState.setSrc({ isNewMediaPlayerInstance: true, refreshAccessToken: true });
             postTwitchWorkerMessage('TriggeredPlayerReload');

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1091,6 +1091,7 @@
                 }
             } catch {}
             playerBufferState.lastReloadAt = Date.now();
+            playerForMonitoringBuffering = null;// Force re-acquire player ref after reload — old ref reads stale buffer state
             console.log('Reloading Twitch player');
             playerState.setSrc({ isNewMediaPlayerInstance: true, refreshAccessToken: true });
             postTwitchWorkerMessage('TriggeredPlayerReload');


### PR DESCRIPTION
After setSrc creates a new player instance, the cached playerForMonitoringBuffering still pointed at the OLD player. The old player reported stale buffer state (e.g., 242s buffer at position 0), causing the buffer monitor to detect false stalls and fire pause/play on the wrong player instance — root cause of black screen after reload.