### PR TITLE
Add user pause intent tracking via video element events (release)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -875,6 +875,7 @@ twitch-videoad.js text/javascript
                               playerBufferState.fixAttempts = 0;
                               playerBufferState.recoveryReloadUsed = false;
                               playerBufferState.userPauseIntent = false;
+                              playerBufferState.loggedPauseIntent = false;
                               //console.log('Channel changed to ' + channelName);
                           }
                       }
@@ -949,6 +950,7 @@ twitch-videoad.js text/javascript
                     });
                     video.addEventListener('play', () => {
                         playerBufferState.userPauseIntent = false;
+                        playerBufferState.loggedPauseIntent = false;
                     });
                 }
             }
@@ -1074,6 +1076,10 @@ twitch-videoad.js text/javascript
         if (player.isPaused() || player.core?.paused) {
             // User deliberately paused — respect their intent, don't auto-resume
             if (playerBufferState.userPauseIntent) {
+                if (!playerBufferState.loggedPauseIntent) {
+                    playerBufferState.loggedPauseIntent = true;
+                    console.log('[AD DEBUG] Respecting user pause intent — skipping auto-resume');
+                }
                 return;
             }
             // If WE recently called pause/play and player is still paused, retry play (stuck from autoplay policy or ad-state interference)

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -886,6 +886,7 @@
                               playerBufferState.fixAttempts = 0;
                               playerBufferState.recoveryReloadUsed = false;
                               playerBufferState.userPauseIntent = false;
+                              playerBufferState.loggedPauseIntent = false;
                               //console.log('Channel changed to ' + channelName);
                           }
                       }
@@ -960,6 +961,7 @@
                     });
                     video.addEventListener('play', () => {
                         playerBufferState.userPauseIntent = false;
+                        playerBufferState.loggedPauseIntent = false;
                     });
                 }
             }
@@ -1085,6 +1087,10 @@
         if (player.isPaused() || player.core?.paused) {
             // User deliberately paused — respect their intent, don't auto-resume
             if (playerBufferState.userPauseIntent) {
+                if (!playerBufferState.loggedPauseIntent) {
+                    playerBufferState.loggedPauseIntent = true;
+                    console.log('[AD DEBUG] Respecting user pause intent — skipping auto-resume');
+                }
                 return;
             }
             // If WE recently called pause/play and player is still paused, retry play (stuck from autoplay policy or ad-state interference)


### PR DESCRIPTION
Hooks pause/play events on the HTML video element to distinguish user-initiated pauses from script/system pauses.

- If pause fires >2s after our last weJustPaused: userPauseIntent=true
- If play fires: userPauseIntent=false
- doTwitchPlayerTask respects intent: won't auto-resume user pauses
- Intent cleared on reload (new player) and channel change