### PR TITLE
Always take first backup with ads instead of cycling all player types

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -761,10 +761,9 @@ twitch-videoad.js text/javascript
                                             console.log('[AD DEBUG] Backup stream (' + playerType + ') also has ads');
                                         }
                                     }
-                                    if (isFullyCachedPlayerType) {
-                                        break;
-                                    }
-                                    if (isDoingMinimalRequests || streamInfo.ConsecutiveZeroStripBreaks >= 3) {
+                                    // If backup also has ads, take it immediately — trying other
+                                    // player types won't help (Twitch serves ads across all types)
+                                    if (hasAdTags(m3u8Text) || isFullyCachedPlayerType || isDoingMinimalRequests) {
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;
                                         break;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -772,10 +772,9 @@
                                             console.log('[AD DEBUG] Backup stream (' + playerType + ') also has ads');
                                         }
                                     }
-                                    if (isFullyCachedPlayerType) {
-                                        break;
-                                    }
-                                    if (isDoingMinimalRequests || streamInfo.ConsecutiveZeroStripBreaks >= 3) {
+                                    // If backup also has ads, take it immediately — trying other
+                                    // player types won't help (Twitch serves ads across all types)
+                                    if (hasAdTags(m3u8Text) || isFullyCachedPlayerType || isDoingMinimalRequests) {
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;
                                         break;


### PR DESCRIPTION
## Summary
- When a backup stream has ad tags, take it immediately instead of trying other player types
- Replaces the `ConsecutiveZeroStripBreaks >= 3` condition from PR #87 — that required 3 consecutive CSAI-only breaks before activating, which never triggered on channels that alternate SSAI/CSAI
- Twitch serves ads across all player types simultaneously — if embed has ads, all others will too

## Before
First backup has ads → try site (ads) → try popout (ads) → try mobile_web (ads) → try autoplay (ads) → give up. Player stalled for 2+ minutes.

## After
First backup has ads → take it. ~50ms. Stripping logic handles it the same way.

## Test plan
- [ ] Verify CSAI-only ad breaks resolve instantly (backup found in ~50ms)
- [ ] Verify SSAI ad breaks still find clean backups when available
- [ ] Verify no loading circle during ad breaks on emongg/august/hiimsky

🤖 Generated with [Claude Code](https://claude.com/claude-code)