### PR TITLE
Skip backup stream search for CSAI-only ads

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -677,6 +677,33 @@ twitch-videoad.js text/javascript
                     key: 'ReloadPlayer'
                 });
             }
+            // CSAI fast path: if all segments in the main stream are live, skip backup search.
+            // CSAI ads are delivered outside the m3u8 — the main stream segments are clean.
+            // Just strip tracking URLs and return the main stream directly, avoiding the
+            // backup stream switch that causes a 20-40s rebuffer gap.
+            const mainStreamLines = textStr.split(/\r?\n/);
+            let hasNonLiveSegment = false;
+            for (let i = 0; i < mainStreamLines.length; i++) {
+                if (mainStreamLines[i].startsWith('#EXTINF') && !mainStreamLines[i].includes(',live')) {
+                    hasNonLiveSegment = true;
+                    break;
+                }
+            }
+            if (!hasNonLiveSegment && !streamInfo.IsUsingModifiedM3U8) {
+                console.log('[AD DEBUG] CSAI fast path — all segments live, skipping backup search');
+                if (IsAdStrippingEnabled) {
+                    textStr = stripAdSegments(textStr, false, streamInfo);
+                }
+                postMessage({
+                    key: 'UpdateAdBlockBanner',
+                    isMidroll: streamInfo.IsMidroll,
+                    hasAds: streamInfo.IsShowingAd,
+                    isStrippingAdSegments: streamInfo.IsStrippingAdSegments,
+                    numStrippedAdSegments: streamInfo.NumStrippedAdSegments,
+                    activeBackupPlayerType: null
+                });
+                return textStr;
+            }
             const backupSearchStart = Date.now();
             let backupPlayerType = null;
             let backupM3u8 = null;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -688,6 +688,33 @@
                     key: 'ReloadPlayer'
                 });
             }
+            // CSAI fast path: if all segments in the main stream are live, skip backup search.
+            // CSAI ads are delivered outside the m3u8 — the main stream segments are clean.
+            // Just strip tracking URLs and return the main stream directly, avoiding the
+            // backup stream switch that causes a 20-40s rebuffer gap.
+            const mainStreamLines = textStr.split(/\r?\n/);
+            let hasNonLiveSegment = false;
+            for (let i = 0; i < mainStreamLines.length; i++) {
+                if (mainStreamLines[i].startsWith('#EXTINF') && !mainStreamLines[i].includes(',live')) {
+                    hasNonLiveSegment = true;
+                    break;
+                }
+            }
+            if (!hasNonLiveSegment && !streamInfo.IsUsingModifiedM3U8) {
+                console.log('[AD DEBUG] CSAI fast path — all segments live, skipping backup search');
+                if (IsAdStrippingEnabled) {
+                    textStr = stripAdSegments(textStr, false, streamInfo);
+                }
+                postMessage({
+                    key: 'UpdateAdBlockBanner',
+                    isMidroll: streamInfo.IsMidroll,
+                    hasAds: streamInfo.IsShowingAd,
+                    isStrippingAdSegments: streamInfo.IsStrippingAdSegments,
+                    numStrippedAdSegments: streamInfo.NumStrippedAdSegments,
+                    activeBackupPlayerType: null
+                });
+                return textStr;
+            }
             const backupSearchStart = Date.now();
             let backupPlayerType = null;
             let backupM3u8 = null;


### PR DESCRIPTION
## Summary
- Before searching for backup streams, check if all segments in the main m3u8 are tagged `,live`
- If all live: ad is CSAI-delivered, no segments need stripping — strip tracking URLs from the main stream and return directly
- No backup stream switch = no buffer gap = no 20-40s rebuffer

## Before (CSAI ad break)
1. Ad tags detected in main stream
2. Search backup streams (50-1000ms)
3. Backup also has ads → take it
4. Strip 0 segments from backup
5. Player switches from backup back to main stream
6. **20-40s rebuffer gap** while player fetches new segments at live position
7. Clear as CSAI-only

## After
1. Ad tags detected in main stream
2. Check: all segments are `,live` → CSAI fast path
3. Strip tracking URLs from main stream
4. Return main stream directly — **no stream switch, no rebuffer**

## Safety
- Only triggers when ALL `#EXTINF` segments are `,live` — any non-live segment falls through to normal backup search (SSAI handling)
- `stripAdSegments` still runs on the main stream — tracking URLs are rewritten, prefetch lines removed
- `IsUsingModifiedM3U8` check prevents interference with HEVC codec swap

## Test plan
- [ ] Verify CSAI-only ad breaks show no buffer gap (no `<video> Buffer start:` lines in console)
- [ ] Verify SSAI ad breaks (non-live segments) still use backup stream and strip correctly
- [ ] Verify ad tracking URLs are still rewritten on CSAI fast path

🤖 Generated with [Claude Code](https://claude.com/claude-code)