### PR TITLE
Spoof ad completion events to clear Twitch's ad state

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -178,6 +178,7 @@ twitch-videoad.js text/javascript
                     const pendingFetchRequests = new Map();
                     ${hasAdTags.toString()}
                     ${getMatchedAdSignifiers.toString()}
+                    ${notifyAdComplete.toString()}
                     ${stripAdSegments.toString()}
                     ${getStreamUrlForResolution.toString()}
                     ${processM3U8.toString()}
@@ -486,6 +487,58 @@ twitch-videoad.js text/javascript
     function getMatchedAdSignifiers(textStr) {
         return AdSignifiers.filter((s) => textStr.includes(s));
     }
+    // Spoof ad completion events to Twitch's backend to clear the ad state
+    function notifyAdComplete(textStr) {
+        try {
+            const matches = textStr.match(/#EXT-X-DATERANGE:(ID="stitched-ad-[^\n]+)\n/);
+            if (!matches || matches.length <= 1) {
+                if (!notifyAdComplete.loggedNoMatch) {
+                    notifyAdComplete.loggedNoMatch = true;
+                    const dateRangeLine = textStr.match(/#EXT-X-DATERANGE:[^\n]{0,200}/);
+                    console.log('[AD DEBUG] notifyAdComplete: no stitched-ad DATERANGE match. Sample DATERANGE: ' + (dateRangeLine ? dateRangeLine[0] : 'none found'));
+                }
+                return;
+            }
+            const attr = parseAttributes(matches[1]);
+            const radToken = attr['X-TV-TWITCH-AD-RADS-TOKEN'];
+            if (!radToken) {
+                if (!notifyAdComplete.loggedNoToken) {
+                    notifyAdComplete.loggedNoToken = true;
+                    console.log('[AD DEBUG] notifyAdComplete: matched DATERANGE but no RADS token. Attributes: ' + Object.keys(attr).join(', '));
+                }
+                return;
+            }
+            const baseData = {
+                stitched: true,
+                ad_id: attr['X-TV-TWITCH-AD-ADVERTISER-ID'] || '',
+                roll_type: (attr['X-TV-TWITCH-AD-ROLL-TYPE'] || '').toLowerCase(),
+                creative_id: attr['X-TV-TWITCH-AD-CREATIVE-ID'] || '',
+                order_id: attr['X-TV-TWITCH-AD-ORDER-ID'] || '',
+                line_item_id: attr['X-TV-TWITCH-AD-LINE-ITEM-ID'] || '',
+                player_mute: true,
+                player_volume: 0.0,
+                visible: false,
+                duration: 0
+            };
+            const podLength = parseInt(attr['X-TV-TWITCH-AD-POD-LENGTH'] || '1', 10);
+            for (let podPosition = 0; podPosition < podLength; podPosition++) {
+                const payload = { ...baseData, ad_position: podPosition, total_ads: podLength };
+                const makePacket = (event, extra) => [{
+                    operationName: 'ClientSideAdEventHandling_RecordAdEvent',
+                    variables: { input: { eventName: event, eventPayload: JSON.stringify({ ...payload, ...extra }), radToken } },
+                    extensions: { persistedQuery: { version: 1, sha256Hash: '7e6c69e6eb59f8ccb97ab73686f3d8b7d85a72a0298745ccd8bfc68e4054ca5b' } }
+                }];
+                gqlRequest(makePacket('video_ad_impression')).catch(() => {});
+                for (let q = 1; q <= 4; q++) {
+                    gqlRequest(makePacket('video_ad_quartile_complete', { quartile: q })).catch(() => {});
+                }
+                gqlRequest(makePacket('video_ad_pod_complete')).catch(() => {});
+            }
+            console.log('[AD DEBUG] Spoofed ad completion for ' + podLength + ' ad(s) — roll: ' + baseData.roll_type);
+        } catch (err) {
+            console.log('[AD DEBUG] Ad completion spoof failed: ' + err.message);
+        }
+    }
     // Remove ad segments from an m3u8 playlist and cache their URLs for replacement
     function stripAdSegments(textStr, stripAllSegments, streamInfo) {
         let hasStrippedAdSegments = false;
@@ -642,6 +695,7 @@ twitch-videoad.js text/javascript
             if (!streamInfo.IsShowingAd) {
                 streamInfo.IsShowingAd = true;
                 console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName + ', signifiers: ' + getMatchedAdSignifiers(textStr).join(', '));
+                notifyAdComplete(textStr);
                 postMessage({
                     key: 'UpdateAdBlockBanner',
                     isMidroll: streamInfo.IsMidroll,

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -189,6 +189,7 @@
                     const pendingFetchRequests = new Map();
                     ${hasAdTags.toString()}
                     ${getMatchedAdSignifiers.toString()}
+                    ${notifyAdComplete.toString()}
                     ${stripAdSegments.toString()}
                     ${getStreamUrlForResolution.toString()}
                     ${processM3U8.toString()}
@@ -497,6 +498,58 @@
     function getMatchedAdSignifiers(textStr) {
         return AdSignifiers.filter((s) => textStr.includes(s));
     }
+    // Spoof ad completion events to Twitch's backend to clear the ad state
+    function notifyAdComplete(textStr) {
+        try {
+            const matches = textStr.match(/#EXT-X-DATERANGE:(ID="stitched-ad-[^\n]+)\n/);
+            if (!matches || matches.length <= 1) {
+                if (!notifyAdComplete.loggedNoMatch) {
+                    notifyAdComplete.loggedNoMatch = true;
+                    const dateRangeLine = textStr.match(/#EXT-X-DATERANGE:[^\n]{0,200}/);
+                    console.log('[AD DEBUG] notifyAdComplete: no stitched-ad DATERANGE match. Sample DATERANGE: ' + (dateRangeLine ? dateRangeLine[0] : 'none found'));
+                }
+                return;
+            }
+            const attr = parseAttributes(matches[1]);
+            const radToken = attr['X-TV-TWITCH-AD-RADS-TOKEN'];
+            if (!radToken) {
+                if (!notifyAdComplete.loggedNoToken) {
+                    notifyAdComplete.loggedNoToken = true;
+                    console.log('[AD DEBUG] notifyAdComplete: matched DATERANGE but no RADS token. Attributes: ' + Object.keys(attr).join(', '));
+                }
+                return;
+            }
+            const baseData = {
+                stitched: true,
+                ad_id: attr['X-TV-TWITCH-AD-ADVERTISER-ID'] || '',
+                roll_type: (attr['X-TV-TWITCH-AD-ROLL-TYPE'] || '').toLowerCase(),
+                creative_id: attr['X-TV-TWITCH-AD-CREATIVE-ID'] || '',
+                order_id: attr['X-TV-TWITCH-AD-ORDER-ID'] || '',
+                line_item_id: attr['X-TV-TWITCH-AD-LINE-ITEM-ID'] || '',
+                player_mute: true,
+                player_volume: 0.0,
+                visible: false,
+                duration: 0
+            };
+            const podLength = parseInt(attr['X-TV-TWITCH-AD-POD-LENGTH'] || '1', 10);
+            for (let podPosition = 0; podPosition < podLength; podPosition++) {
+                const payload = { ...baseData, ad_position: podPosition, total_ads: podLength };
+                const makePacket = (event, extra) => [{
+                    operationName: 'ClientSideAdEventHandling_RecordAdEvent',
+                    variables: { input: { eventName: event, eventPayload: JSON.stringify({ ...payload, ...extra }), radToken } },
+                    extensions: { persistedQuery: { version: 1, sha256Hash: '7e6c69e6eb59f8ccb97ab73686f3d8b7d85a72a0298745ccd8bfc68e4054ca5b' } }
+                }];
+                gqlRequest(makePacket('video_ad_impression')).catch(() => {});
+                for (let q = 1; q <= 4; q++) {
+                    gqlRequest(makePacket('video_ad_quartile_complete', { quartile: q })).catch(() => {});
+                }
+                gqlRequest(makePacket('video_ad_pod_complete')).catch(() => {});
+            }
+            console.log('[AD DEBUG] Spoofed ad completion for ' + podLength + ' ad(s) — roll: ' + baseData.roll_type);
+        } catch (err) {
+            console.log('[AD DEBUG] Ad completion spoof failed: ' + err.message);
+        }
+    }
     // Remove ad segments from an m3u8 playlist and cache their URLs for replacement
     function stripAdSegments(textStr, stripAllSegments, streamInfo) {
         let hasStrippedAdSegments = false;
@@ -653,6 +706,7 @@
             if (!streamInfo.IsShowingAd) {
                 streamInfo.IsShowingAd = true;
                 console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName + ', signifiers: ' + getMatchedAdSignifiers(textStr).join(', '));
+                notifyAdComplete(textStr);
                 postMessage({
                     key: 'UpdateAdBlockBanner',
                     isMidroll: streamInfo.IsMidroll,


### PR DESCRIPTION
## Summary
- Add `notifyAdComplete` function that parses ad metadata from m3u8 EXT-X-DATERANGE tags
- Sends fake `video_ad_impression`, `video_ad_quartile_complete` (×4), and `video_ad_pod_complete` GQL events to Twitch's `ClientSideAdEventHandling_RecordAdEvent` endpoint
- Tells Twitch's backend the ad was "watched" — may help clear pre-roll loops and reduce ad break frequency/duration
- Inspired by AdGuard Extra's `tryNotifyTwitch` implementation

## How it works
1. On ad detection, parse `#EXT-X-DATERANGE:ID="stitched-ad-..."` line for:
   - `X-TV-TWITCH-AD-RADS-TOKEN` (required for the events)
   - `X-TV-TWITCH-AD-POD-LENGTH` (number of ads in the pod)
   - Ad ID, creative ID, order ID, line item ID, roll type
2. For each ad position in the pod, send:
   - 1 × `video_ad_impression`
   - 4 × `video_ad_quartile_complete` (q=1,2,3,4)
   - 1 × `video_ad_pod_complete`
3. Total: 6 GQL events per ad in the pod (e.g. 18 events for a 3-ad pod)

## Why
Twitch's pre-roll/midroll system tracks which ads have been "viewed". If we never report viewing the ad, Twitch may continue serving it on subsequent reloads, causing reload loops on heavy-ad channels. By spoofing the completion events, we tell Twitch the ad was viewed and the user shouldn't see it again immediately.

## Test plan
- [ ] Verify `Spoofed ad completion for N ad(s)` log appears on ad detection
- [ ] Verify GQL events sent successfully (no Access token HTTP 4xx errors)
- [ ] Compare ad break frequency before/after on heavy-ad channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)