### PR TITLE
Skip buffer monitor when player has no data loaded (readyState >= 1)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1036,7 +1036,7 @@ twitch-videoad.js text/javascript
                 const state = playerForMonitoringBuffering.state;
                 if (!player.core) {
                     playerForMonitoringBuffering = null;
-                } else if (state.props?.content?.type === 'live' && !player.isPaused() && !player.getHTMLVideoElement()?.ended && playerBufferState.lastFixTime <= Date.now() - PlayerBufferingMinRepeatDelay && !isActivelyStrippingAds && !playerBufferState.inAdBreak && (!playerBufferState.lastReloadAt || Date.now() - playerBufferState.lastReloadAt >= 15000) && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000)) {
+                } else if (state.props?.content?.type === 'live' && !player.isPaused() && !player.getHTMLVideoElement()?.ended && (player.getHTMLVideoElement()?.readyState ?? 0) >= 1 && playerBufferState.lastFixTime <= Date.now() - PlayerBufferingMinRepeatDelay && !isActivelyStrippingAds && !playerBufferState.inAdBreak && (!playerBufferState.lastReloadAt || Date.now() - playerBufferState.lastReloadAt >= 15000) && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000)) {
                     const m3u8Url = player.core?.state?.path;
                     if (m3u8Url) {
                       const lastSlash = m3u8Url.lastIndexOf('/');

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1047,7 +1047,7 @@
                 const state = playerForMonitoringBuffering.state;
                 if (!player.core) {
                     playerForMonitoringBuffering = null;
-                } else if (state.props?.content?.type === 'live' && !player.isPaused() && !player.getHTMLVideoElement()?.ended && playerBufferState.lastFixTime <= Date.now() - PlayerBufferingMinRepeatDelay && !isActivelyStrippingAds && !playerBufferState.inAdBreak && (!playerBufferState.lastReloadAt || Date.now() - playerBufferState.lastReloadAt >= 15000) && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000)) {
+                } else if (state.props?.content?.type === 'live' && !player.isPaused() && !player.getHTMLVideoElement()?.ended && (player.getHTMLVideoElement()?.readyState ?? 0) >= 1 && playerBufferState.lastFixTime <= Date.now() - PlayerBufferingMinRepeatDelay && !isActivelyStrippingAds && !playerBufferState.inAdBreak && (!playerBufferState.lastReloadAt || Date.now() - playerBufferState.lastReloadAt >= 15000) && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000)) {
                     const m3u8Url = player.core?.state?.path;
                     if (m3u8Url) {
                       const lastSlash = m3u8Url.lastIndexOf('/');


### PR DESCRIPTION
## Summary
- Add `readyState >= 1` (HAVE_METADATA) guard to the buffer monitor's main check
- Prevents pause/play attempts when the player has no source loaded yet (readyState=0, HAVE_NOTHING)

## Problem
After a reload (`setSrc` with `isNewMediaPlayerInstance: true`), the player briefly has `readyState=0` while the new instance loads metadata. The buffer monitor would fire on this state with `position:0 bufferedPosition:0.642 bufferDuration:0.642`, calling pause/play on an empty player. This caused extra disruption during the post-reload window.

Observed in console logs:
```
Attempt to fix buffering position:0 bufferedPosition:0.642 bufferDuration:0.642
Video state: readyState=0 networkState=0 buffered=0 currentTime=0.0 paused=true
```

## Fix
Add `(player.getHTMLVideoElement()?.readyState ?? 0) >= 1` to the buffer monitor condition. The 15s post-reload grace already handles most cases, but this catches the brief window where the player has been reloaded but hasn't loaded metadata yet.

## Test plan
- [ ] Verify buffer monitor doesn't fire with `readyState=0` in the Video state debug log
- [ ] Verify buffer monitor still fires for genuine stalls (readyState >= 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)