### PR TITLE
Cycle backup player types during recovery freeze (hybrid)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -794,6 +794,9 @@ twitch-videoad.js text/javascript
                                         fallbackM3u8 = m3u8Text;
                                     }
                                     if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
+                                        if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !hasAdTags(m3u8Text)) {
+                                            console.log('[AD DEBUG] Found clean backup (' + playerType + ') during freeze — recovered without reload');
+                                        }
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;
                                         break;
@@ -805,9 +808,18 @@ twitch-videoad.js text/javascript
                                             console.log('[AD DEBUG] Backup stream (' + playerType + ') also has ads');
                                         }
                                     }
-                                    // If backup also has ads, take it immediately — trying other
-                                    // player types won't help (Twitch serves ads across all types)
-                                    if (hasAdTags(m3u8Text) || isFullyCachedPlayerType || isDoingMinimalRequests) {
+                                    if (isFullyCachedPlayerType || isDoingMinimalRequests) {
+                                        backupPlayerType = playerType;
+                                        backupM3u8 = m3u8Text;
+                                        break;
+                                    }
+                                    // Hybrid: take first ad-laden backup unless we're already in
+                                    // a recovery freeze (ConsecutiveAllStrippedPolls >= 1). During
+                                    // a freeze, keep cycling other player types in case one is clean —
+                                    // a successful switch avoids the early-reload disruption entirely.
+                                    // Final type is taken as last resort either way.
+                                    const inFreeze = (streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1;
+                                    if (hasAdTags(m3u8Text) && (!inFreeze || playerTypeIndex >= playerTypesToTry.length - 1)) {
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;
                                         break;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -805,6 +805,9 @@
                                         fallbackM3u8 = m3u8Text;
                                     }
                                     if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
+                                        if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !hasAdTags(m3u8Text)) {
+                                            console.log('[AD DEBUG] Found clean backup (' + playerType + ') during freeze — recovered without reload');
+                                        }
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;
                                         break;
@@ -816,9 +819,18 @@
                                             console.log('[AD DEBUG] Backup stream (' + playerType + ') also has ads');
                                         }
                                     }
-                                    // If backup also has ads, take it immediately — trying other
-                                    // player types won't help (Twitch serves ads across all types)
-                                    if (hasAdTags(m3u8Text) || isFullyCachedPlayerType || isDoingMinimalRequests) {
+                                    if (isFullyCachedPlayerType || isDoingMinimalRequests) {
+                                        backupPlayerType = playerType;
+                                        backupM3u8 = m3u8Text;
+                                        break;
+                                    }
+                                    // Hybrid: take first ad-laden backup unless we're already in
+                                    // a recovery freeze (ConsecutiveAllStrippedPolls >= 1). During
+                                    // a freeze, keep cycling other player types in case one is clean —
+                                    // a successful switch avoids the early-reload disruption entirely.
+                                    // Final type is taken as last resort either way.
+                                    const inFreeze = (streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1;
+                                    if (hasAdTags(m3u8Text) && (!inFreeze || playerTypeIndex >= playerTypesToTry.length - 1)) {
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;
                                         break;


### PR DESCRIPTION
## Summary
Restores the cycle-during-freeze rescue path that PR #87 added and PR #89 removed, but only activates it during a recovery freeze — keeping #89's fast-exit behavior in the common case.

## Background
- **PR #87** changed the backup loop to iterate through all player types looking for a clean one before committing an ad-laden backup.
- **PR #89** reverted that, on the assumption that "Twitch serves ads across all player types simultaneously — cycling is always pointless."
- **Test data showed #89's premise isn't always true.** The `[AD DEBUG] Found clean backup (X) during freeze — recovered without reload` log fired in real tests, proving alternate types are sometimes clean even when the first try wasn't.

## Hybrid approach
Take the first ad-laden backup *unless* we're already in a recovery freeze (`ConsecutiveAllStrippedPolls >= 1`). During a freeze, cycle through remaining types looking for clean.

```js
const inFreeze = (streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1;
if (hasAdTags(m3u8Text) && (!inFreeze || playerTypeIndex >= playerTypesToTry.length - 1)) {
    // commit ad-laden as last resort
    break;
}
// otherwise: keep iterating other player types
```

## Behavior matrix
| Scenario | PR #89 (current) | This PR |
|---|---|---|
| First poll, first type clean | 1 fetch ✓ | 1 fetch ✓ |
| First poll, first type ad-laden | 1 fetch, commit, enter strip loop | 1 fetch, commit, enter strip loop |
| Subsequent polls in freeze, alternate type clean | Still committed to first (no rescue) | **Cycle finds clean → freeze ends, no reload** |
| Subsequent polls in freeze, all types ad-laden | Continue strip loop until early reload | Continue strip loop until early reload |

## Logs to watch
- `[AD DEBUG] Found clean backup (X) during freeze — recovered without reload` — cycling rescue worked
- `[AD DEBUG] Early reload triggered ... [N/M]` (PR #94) — fallback when all types ad-laden

## Tradeoffs
- **Network cost:** zero in the common case (no freeze). During a freeze, up to N additional token+usher+stream fetches per poll where N = remaining player types. Since freezes are rare, total impact is minimal.
- **Recovery time:** in the mixed case (one type clean, others ad-laden), recovery is ~0s instead of waiting ~10s for early reload.

## Test plan
- [ ] Verify common case: ad detected → committed first backup → strip loop or natural end (no behavior change vs #89)
- [ ] Verify freeze case: 5+ all-stripped polls → cycle finds clean alternate → 'Found clean backup during freeze' log → freeze ends without reload
- [ ] Verify all-ad-laden freeze: cycle finds nothing clean → falls through to early reload (PR #94)

🤖 Generated with [Claude Code](https://claude.com/claude-code)