### PR TITLE
Loading-circle health check during ad break

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1223,6 +1223,35 @@ twitch-videoad.js text/javascript
                 playerForMonitoringBuffering = null;
             }
         }
+        // Loading-circle health check: during an ad strip+recovery loop the normal buffer monitor
+        // is gated off (isActivelyStrippingAds), so a visibly stalled player would otherwise wait
+        // for the worker's poll-based early reload (~10s). This catches the visible stall ~3s after
+        // it starts and triggers a reload directly, eliminating most of the loading-circle window.
+        if (isActivelyStrippingAds && playerForMonitoringBuffering) {
+            try {
+                const player = playerForMonitoringBuffering.player;
+                const video = player?.getHTMLVideoElement?.();
+                if (video && !video.ended && !playerBufferState.userPauseIntent) {
+                    const isStalled = video.readyState < 3 && (video.paused || video.networkState === 2);
+                    const stallReloadCooldown = 15000;
+                    const cooldownExpired = !playerBufferState.lastAdStallReloadAt || (Date.now() - playerBufferState.lastAdStallReloadAt) > stallReloadCooldown;
+                    if (isStalled && cooldownExpired) {
+                        if (!playerBufferState.adStallStartAt) {
+                            playerBufferState.adStallStartAt = Date.now();
+                        } else if ((Date.now() - playerBufferState.adStallStartAt) > 3000) {
+                            console.log('[AD DEBUG] Loading circle detected during ad break (' + ((Date.now() - playerBufferState.adStallStartAt) / 1000).toFixed(1) + 's stall, readyState=' + video.readyState + ') — early reload');
+                            playerBufferState.lastAdStallReloadAt = Date.now();
+                            playerBufferState.adStallStartAt = 0;
+                            doTwitchPlayerTask(false, true);
+                        }
+                    } else if (!isStalled) {
+                        playerBufferState.adStallStartAt = 0;
+                    }
+                }
+            } catch {}
+        } else if (!isActivelyStrippingAds && playerBufferState.adStallStartAt) {
+            playerBufferState.adStallStartAt = 0;
+        }
         const isLive = playerForMonitoringBuffering?.state?.props?.content?.type === 'live';
         if (playerBufferState.isLive && !isLive) {
             updateAdblockBanner({

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1234,6 +1234,35 @@
                 playerForMonitoringBuffering = null;
             }
         }
+        // Loading-circle health check: during an ad strip+recovery loop the normal buffer monitor
+        // is gated off (isActivelyStrippingAds), so a visibly stalled player would otherwise wait
+        // for the worker's poll-based early reload (~10s). This catches the visible stall ~3s after
+        // it starts and triggers a reload directly, eliminating most of the loading-circle window.
+        if (isActivelyStrippingAds && playerForMonitoringBuffering) {
+            try {
+                const player = playerForMonitoringBuffering.player;
+                const video = player?.getHTMLVideoElement?.();
+                if (video && !video.ended && !playerBufferState.userPauseIntent) {
+                    const isStalled = video.readyState < 3 && (video.paused || video.networkState === 2);
+                    const stallReloadCooldown = 15000;
+                    const cooldownExpired = !playerBufferState.lastAdStallReloadAt || (Date.now() - playerBufferState.lastAdStallReloadAt) > stallReloadCooldown;
+                    if (isStalled && cooldownExpired) {
+                        if (!playerBufferState.adStallStartAt) {
+                            playerBufferState.adStallStartAt = Date.now();
+                        } else if ((Date.now() - playerBufferState.adStallStartAt) > 3000) {
+                            console.log('[AD DEBUG] Loading circle detected during ad break (' + ((Date.now() - playerBufferState.adStallStartAt) / 1000).toFixed(1) + 's stall, readyState=' + video.readyState + ') — early reload');
+                            playerBufferState.lastAdStallReloadAt = Date.now();
+                            playerBufferState.adStallStartAt = 0;
+                            doTwitchPlayerTask(false, true);
+                        }
+                    } else if (!isStalled) {
+                        playerBufferState.adStallStartAt = 0;
+                    }
+                }
+            } catch {}
+        } else if (!isActivelyStrippingAds && playerBufferState.adStallStartAt) {
+            playerBufferState.adStallStartAt = 0;
+        }
         const isLive = playerForMonitoringBuffering?.state?.props?.content?.type === 'live';
         if (playerBufferState.isLive && !isLive) {
             updateAdblockBanner({


### PR DESCRIPTION
## Summary
Catches the visible loading-circle case during an ad strip+recovery freeze ~3s after it starts, instead of waiting ~10s for the worker's poll-based early reload (PR #94).

## Why
The normal buffer monitor is gated off during ad strip (`isActivelyStrippingAds && ...` check at the entry of the main monitor body). So when the player visibly stalls during the recovery loop — the loading circle the user sees — the buffer monitor does nothing and recovery has to wait for the poll-based early reload at ~10s.

This change adds a **separate stall check that only runs during ad strip**, specifically targeting the loading-circle case.

## Detection
```js
if (isActivelyStrippingAds && playerForMonitoringBuffering) {
    const isStalled = video.readyState < 3 && (video.paused || video.networkState === 2);
    if (isStalled && cooldownExpired) {
        if (!playerBufferState.adStallStartAt) {
            playerBufferState.adStallStartAt = Date.now();
        } else if ((Date.now() - playerBufferState.adStallStartAt) > 3000) {
            console.log('[AD DEBUG] Loading circle detected during ad break (Xs stall, readyState=N) — early reload');
            doTwitchPlayerTask(false, true);
        }
    }
}
```

- `readyState < 3` (HAVE_FUTURE_DATA not met) AND paused or no network activity = visible loading circle
- 3s confirmation window prevents firing on transient stalls
- 15s cooldown prevents cascade
- Resets when stall clears or ad break ends
- Skipped if user paused intentionally

## How it stacks with existing recovery
| Mechanism | Detect time | Triggered by |
|---|---|---|
| **PR #95 cycle-during-freeze** (proposed) | ~2s | First poll after freeze starts, cycles backups |
| **This PR loading-circle health** | ~3s | Visible video stall (readyState/paused) |
| **PR #94 early reload (poll-based)** | ~10s | 5 polls of all-stripped recovery loop |

#95 + this PR + #94 form layered recovery: cycling tries to avoid the freeze entirely; loading-circle health catches visible stalls fast; early reload is the final fallback for invisible stalls (long-buffered freezes).

## Test plan
- [ ] Verify loading circle on warn/ml7support/6cyx during long midrolls triggers `Loading circle detected during ad break` log within ~3-4s
- [ ] Verify cooldown prevents repeated reloads within 15s
- [ ] Verify no false positives during normal playback (gate is `isActivelyStrippingAds`)
- [ ] Verify `userPauseIntent` blocks the reload when user paused

🤖 Generated with [Claude Code](https://claude.com/claude-code)