### PR TITLE
Fix cross-channel reload cooldown leak + buffer-critical reload bypass

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -366,6 +366,10 @@ twitch-videoad.js text/javascript
                                     streamInfo = null;
                                 }
                                 if (streamInfo == null || streamInfo.EncodingsM3U8 == null) {
+                                    // Clear reload-pending flag from a prior stream session — without this,
+                                    // a reload triggered on the previous channel bleeds into the new channel's
+                                    // cooldown calculation, blocking legitimate end-of-break reloads.
+                                    HasTriggeredPlayerReload = false;
                                     console.log('[AD DEBUG] New stream session — channel: ' + channelName + ', API: ' + (V2API ? 'v2' : 'v1'));
                                     StreamInfos[channelName] = streamInfo = {
                                         ChannelName: channelName,
@@ -1171,8 +1175,14 @@ twitch-videoad.js text/javascript
                                 playerBufferState.fixAttempts++;
                                 // Cap: at most ONE reload per recovery window. After reloading once,
                                 // stay on pause/play until playback recovers. Prevents reload cascades.
-                                const wouldEscalate = playerBufferState.fixAttempts >= 3;
-                                const escalateToReload = wouldEscalate && (DisableReloadCap || !playerBufferState.recoveryReloadUsed);
+                                // Exception: when buffer is dangerously low (< 0.5s), pause/play won't help —
+                                // only fresh data will. Force escalate to reload regardless of recoveryReloadUsed.
+                                const bufferCritical = bufferDuration < 0.5;
+                                const wouldEscalate = playerBufferState.fixAttempts >= 3 || bufferCritical;
+                                const escalateToReload = wouldEscalate && (DisableReloadCap || !playerBufferState.recoveryReloadUsed || bufferCritical);
+                                if (bufferCritical && playerBufferState.recoveryReloadUsed) {
+                                    console.log('[AD DEBUG] Buffer critical (' + bufferDuration.toFixed(2) + 's) — bypassing reload cap');
+                                }
                                 const reloadCapNote = wouldEscalate && !escalateToReload ? ' (reload cap reached, pause/play only — set twitchAdSolutions_disableReloadCap=true to bypass)' : (escalateToReload ? ' (escalating to reload)' : '');
                                 console.log('Attempt to fix buffering position:' + playerBufferState.position + ' bufferedPosition:' + playerBufferState.bufferedPosition + ' bufferDuration:' + playerBufferState.bufferDuration + reloadCapNote);
                                 // Seek past buffer gap instead of stalling + drift to recover

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -377,6 +377,10 @@
                                     streamInfo = null;
                                 }
                                 if (streamInfo == null || streamInfo.EncodingsM3U8 == null) {
+                                    // Clear reload-pending flag from a prior stream session — without this,
+                                    // a reload triggered on the previous channel bleeds into the new channel's
+                                    // cooldown calculation, blocking legitimate end-of-break reloads.
+                                    HasTriggeredPlayerReload = false;
                                     console.log('[AD DEBUG] New stream session — channel: ' + channelName + ', API: ' + (V2API ? 'v2' : 'v1'));
                                     StreamInfos[channelName] = streamInfo = {
                                         ChannelName: channelName,
@@ -1182,8 +1186,14 @@
                                 playerBufferState.fixAttempts++;
                                 // Cap: at most ONE reload per recovery window. After reloading once,
                                 // stay on pause/play until playback recovers. Prevents reload cascades.
-                                const wouldEscalate = playerBufferState.fixAttempts >= 3;
-                                const escalateToReload = wouldEscalate && (DisableReloadCap || !playerBufferState.recoveryReloadUsed);
+                                // Exception: when buffer is dangerously low (< 0.5s), pause/play won't help —
+                                // only fresh data will. Force escalate to reload regardless of recoveryReloadUsed.
+                                const bufferCritical = bufferDuration < 0.5;
+                                const wouldEscalate = playerBufferState.fixAttempts >= 3 || bufferCritical;
+                                const escalateToReload = wouldEscalate && (DisableReloadCap || !playerBufferState.recoveryReloadUsed || bufferCritical);
+                                if (bufferCritical && playerBufferState.recoveryReloadUsed) {
+                                    console.log('[AD DEBUG] Buffer critical (' + bufferDuration.toFixed(2) + 's) — bypassing reload cap');
+                                }
                                 const reloadCapNote = wouldEscalate && !escalateToReload ? ' (reload cap reached, pause/play only — set twitchAdSolutions_disableReloadCap=true to bypass)' : (escalateToReload ? ' (escalating to reload)' : '');
                                 console.log('Attempt to fix buffering position:' + playerBufferState.position + ' bufferedPosition:' + playerBufferState.bufferedPosition + ' bufferDuration:' + playerBufferState.bufferDuration + reloadCapNote);
                                 // Seek past buffer gap instead of stalling + drift to recover


### PR DESCRIPTION
## Summary
Fixes two related issues that combined to leave a stream paused/stuck after a successful ad-break recovery on a freshly-navigated channel.

## Issue 1: Cross-channel cooldown leak
When a reload happens on channel A and the user navigates to channel B, the worker's \`HasTriggeredPlayerReload\` flag (set by main thread post-reload) gets consumed by channel B's first poll, stamping channel B's \`LastPlayerReload\` with the current time. Channel B then thinks it just reloaded and blocks legitimate end-of-break reloads for the full cooldown window (30s, or 90-120s when auto-escalated).

## Issue 2: Buffer-critical reload cap stalemate
The buffer monitor caps itself to one reload per recovery window (\`recoveryReloadUsed\`). After that, only pause/play. But when \`bufferDuration < 0.5s\`, pause/play cannot recover — we don't have data to play. The player gets stuck.

## Repro
1. Channel A has an ad break, early reload fires
2. Navigate to channel B
3. Channel B starts an ad break
4. Channel B's freeze recovers (e.g. via PR #95 cycle), but ends with low buffer
5. End-of-break reload blocked: \`Skipping reload — last reload was 54s ago (cooldown: 120s)\` ← actually channel A's reload
6. Buffer drops to ~0
7. Buffer monitor pause/play loop forever, player stuck

## Fix 1: clear HasTriggeredPlayerReload on new stream session
\`\`\`js
if (streamInfo == null || streamInfo.EncodingsM3U8 == null) {
    HasTriggeredPlayerReload = false;  // ← new
    StreamInfos[channelName] = streamInfo = { ... };
}
\`\`\`

The flag was set for the prior session — a fresh \`streamInfo\` should not inherit its reload timestamp.

## Fix 2: bypass cap when buffer is critical
\`\`\`js
const bufferCritical = bufferDuration < 0.5;
const wouldEscalate = playerBufferState.fixAttempts >= 3 || bufferCritical;
const escalateToReload = wouldEscalate && (DisableReloadCap || !playerBufferState.recoveryReloadUsed || bufferCritical);
\`\`\`

When buffer is critically low, pause/play is hopeless. Allow the buffer monitor to reload regardless of cap state. Logged as \`Buffer critical (Xs) — bypassing reload cap\`.

## Test plan
- [ ] Channel-switch test: reload on channel A, navigate to channel B, run an ad break, verify channel B's end-of-break reload is NOT blocked by channel A's cooldown
- [ ] Verify \`Skipping reload — last reload was Xs ago\` no longer appears immediately after a fresh stream session
- [ ] Verify \`Buffer critical — bypassing reload cap\` log appears when player stalls with near-zero buffer post ad-break
- [ ] Verify no false positives in normal playback (gate is \`bufferDuration < 0.5\` AND existing same-state checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)