### PR TITLE
Skip end-of-break reload when cycle rescue handled the break cleanly

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -662,6 +662,7 @@ twitch-videoad.js text/javascript
                 streamInfo.EarlyReloadAtPoll = 0;
                 // Track high-confidence ad markers to distinguish real ads from false-positive signifier matches
                 streamInfo.HasConfirmedAdAttrs = textStr.includes('X-TV-TWITCH-AD-AD-SESSION-ID') || textStr.includes('X-TV-TWITCH-AD-RADS-TOKEN');
+                streamInfo.CycleRescuedThisBreak = false;
                 console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName + ', pod: ' + podLength + ' ad(s) (~' + (podLength * 30) + 's expected), signifiers: ' + getMatchedAdSignifiers(textStr).join(', '));
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -800,6 +801,7 @@ twitch-videoad.js text/javascript
                                     if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
                                         if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !hasAdTags(m3u8Text)) {
                                             console.log('[AD DEBUG] Found clean backup (' + playerType + ') during freeze — recovered without reload');
+                                            streamInfo.CycleRescuedThisBreak = true;
                                         }
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;
@@ -943,7 +945,18 @@ twitch-videoad.js text/javascript
                 const recentReloads = streamInfo.ReloadTimestamps.filter(t => Date.now() - t < 300000).length;
                 const effectiveCooldown = recentReloads >= 3 ? ReloadCooldownSeconds * 3 : ReloadCooldownSeconds;
                 const tooSoonSinceLastReload = streamInfo.LastPlayerReload && (Date.now() - streamInfo.LastPlayerReload) < (effectiveCooldown * 1000);
-                const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments && !tooSoonSinceLastReload);
+                // Skip end-of-break reload when cycle rescue handled the break cleanly:
+                // a freeze of ≤2 polls (~4s) was resolved by switching to a clean backup,
+                // and no early reload was needed. The player is on a healthy backup stream
+                // — reloading just to return to the canonical player type causes an unnecessary
+                // ~1-2s loading circle.
+                const cycleRescuedCleanly = streamInfo.CycleRescuedThisBreak &&
+                    (streamInfo.TotalAllStrippedPolls || 0) <= 2 &&
+                    (streamInfo.EarlyReloadCount || 0) === 0;
+                if (cycleRescuedCleanly) {
+                    console.log('[AD DEBUG] Cycle rescue handled the break cleanly — skipping end-of-break reload');
+                }
+                const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments && !tooSoonSinceLastReload && !cycleRescuedCleanly);
                 if (shouldReload) {
                     streamInfo.ReloadTimestamps.push(Date.now());
                     streamInfo.IsUsingModifiedM3U8 = false;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -673,6 +673,7 @@
                 streamInfo.EarlyReloadAtPoll = 0;
                 // Track high-confidence ad markers to distinguish real ads from false-positive signifier matches
                 streamInfo.HasConfirmedAdAttrs = textStr.includes('X-TV-TWITCH-AD-AD-SESSION-ID') || textStr.includes('X-TV-TWITCH-AD-RADS-TOKEN');
+                streamInfo.CycleRescuedThisBreak = false;
                 console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName + ', pod: ' + podLength + ' ad(s) (~' + (podLength * 30) + 's expected), signifiers: ' + getMatchedAdSignifiers(textStr).join(', '));
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -811,6 +812,7 @@
                                     if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
                                         if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !hasAdTags(m3u8Text)) {
                                             console.log('[AD DEBUG] Found clean backup (' + playerType + ') during freeze — recovered without reload');
+                                            streamInfo.CycleRescuedThisBreak = true;
                                         }
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;
@@ -954,7 +956,18 @@
                 const recentReloads = streamInfo.ReloadTimestamps.filter(t => Date.now() - t < 300000).length;
                 const effectiveCooldown = recentReloads >= 3 ? ReloadCooldownSeconds * 3 : ReloadCooldownSeconds;
                 const tooSoonSinceLastReload = streamInfo.LastPlayerReload && (Date.now() - streamInfo.LastPlayerReload) < (effectiveCooldown * 1000);
-                const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments && !tooSoonSinceLastReload);
+                // Skip end-of-break reload when cycle rescue handled the break cleanly:
+                // a freeze of ≤2 polls (~4s) was resolved by switching to a clean backup,
+                // and no early reload was needed. The player is on a healthy backup stream
+                // — reloading just to return to the canonical player type causes an unnecessary
+                // ~1-2s loading circle.
+                const cycleRescuedCleanly = streamInfo.CycleRescuedThisBreak &&
+                    (streamInfo.TotalAllStrippedPolls || 0) <= 2 &&
+                    (streamInfo.EarlyReloadCount || 0) === 0;
+                if (cycleRescuedCleanly) {
+                    console.log('[AD DEBUG] Cycle rescue handled the break cleanly — skipping end-of-break reload');
+                }
+                const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments && !tooSoonSinceLastReload && !cycleRescuedCleanly);
                 if (shouldReload) {
                     streamInfo.ReloadTimestamps.push(Date.now());
                     streamInfo.IsUsingModifiedM3U8 = false;


### PR DESCRIPTION
## Summary
Eliminates the unnecessary loading circle that appears after a successful PR #95 cycle rescue. When cycling switches to a clean backup mid-break, the player is already healthy — the end-of-break reload just causes a ~1-2s loading circle to return to the canonical player type, which isn't worth the disruption.

## Repro
1. Ad break starts on a heavy-ad channel (e.g. aspen)
2. Backup search → first type has ads → committed (PR #89)
3. Strip+recovery loop briefly
4. Cycle finds clean alternate (PR #95): \`Found clean backup (X) during freeze — recovered without reload\`
5. Ad break ends with stripped > 0 → end-of-break reload fires
6. **Visible loading circle for ~1-2s** while player reloads
7. \`Replaced 'site' with 'popout' player type\`

The reload disruption is the only thing the user actually sees in the entire ad break.

## Fix
Skip the end-of-break reload when ALL conditions hold:
- \`CycleRescuedThisBreak\` — cycle rescue actually fired this break
- \`TotalAllStrippedPolls <= 2\` — freeze was minimal (~4s or less)
- \`EarlyReloadCount === 0\` — no early reload was needed

```js
const cycleRescuedCleanly = streamInfo.CycleRescuedThisBreak &&
    (streamInfo.TotalAllStrippedPolls || 0) <= 2 &&
    (streamInfo.EarlyReloadCount || 0) === 0;
const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments && !tooSoonSinceLastReload && !cycleRescuedCleanly);
```

If any condition fails (longer freeze, early reload fired, all-types-ad-laden), the normal end-of-break reload still happens.

## Tradeoff
Player stays on the cycle-rescued backup stream (embed/popout/site — all source quality) until the next page load, channel change, or next ad break. No quality regression in practice since these are all source-quality types just routed differently.

## New log
\`[AD DEBUG] Cycle rescue handled the break cleanly — skipping end-of-break reload\`

## Test plan
- [ ] Verify a clean cycle-rescued break no longer shows a loading circle
- [ ] Verify breaks where cycle didn't fire (early reload triggered, all types ad-laden) still get end-of-break reload
- [ ] Verify breaks with long freezes (>2 polls) still get end-of-break reload as a hedge
- [ ] Verify the new \`Cycle rescue handled the break cleanly\` log appears in the expected case

🤖 Generated with [Claude Code](https://claude.com/claude-code)