### PR TITLE
Improve freeze debug logging: cycle vs natural recovery, wall-clock duration, reload-skipped

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -243,13 +243,18 @@ twitch-videoad.js text/javascript
                         } else if (e.data.key == 'ReloadSkipped') {
                             // Main thread refused the reload (player healthy) — clear the
                             // early-reload flags so we can re-fire if the player later stalls
+                            let cleared = false;
                             for (const channel in StreamInfos) {
                                 const si = StreamInfos[channel];
                                 if (si && si.EarlyReloadTriggered) {
                                     si.EarlyReloadTriggered = false;
                                     si.EarlyReloadAwaitingResult = false;
                                     si.EarlyReloadCount = Math.max(0, (si.EarlyReloadCount || 0) - 1);
+                                    cleared = true;
                                 }
+                            }
+                            if (cleared) {
+                                console.log('[AD DEBUG] Reload skipped by main thread (player healthy) — early reload state cleared, can retry');
                             }
                         } else if (e.data.key == 'SimulateAds') {
                             SimulatedAdsDepth = e.data.value;
@@ -578,6 +583,7 @@ twitch-videoad.js text/javascript
         if (hasStrippedAdSegments && liveSegments.length === 0 && streamInfo.RecoverySegments && streamInfo.RecoverySegments.length > 0) {
             streamInfo.ConsecutiveAllStrippedPolls = (streamInfo.ConsecutiveAllStrippedPolls || 0) + 1;
             streamInfo.TotalAllStrippedPolls = (streamInfo.TotalAllStrippedPolls || 0) + 1;
+            if (!streamInfo.FreezeStartedAt) streamInfo.FreezeStartedAt = Date.now();
             console.log('[AD DEBUG] All segments stripped — restoring ' + streamInfo.RecoverySegments.length + ' recovery segments');
             if (streamInfo.RecoveryStartSeq !== undefined) {
                 for (let j = 0; j < lines.length; j++) {
@@ -674,6 +680,8 @@ twitch-videoad.js text/javascript
                 // Track high-confidence ad markers to distinguish real ads from false-positive signifier matches
                 streamInfo.HasConfirmedAdAttrs = textStr.includes('X-TV-TWITCH-AD-AD-SESSION-ID') || textStr.includes('X-TV-TWITCH-AD-RADS-TOKEN');
                 streamInfo.CycleRescuedThisBreak = false;
+                streamInfo.LastCommittedBackupPlayerType = null;
+                streamInfo.FreezeStartedAt = 0;
                 console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName + ', pod: ' + podLength + ' ad(s) (~' + (podLength * 30) + 's expected), signifiers: ' + getMatchedAdSignifiers(textStr).join(', '));
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -811,7 +819,12 @@ twitch-videoad.js text/javascript
                                     }
                                     if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
                                         if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !hasAdTags(m3u8Text)) {
-                                            console.log('[AD DEBUG] Found clean backup (' + playerType + ') during freeze — recovered without reload');
+                                            const prevType = streamInfo.LastCommittedBackupPlayerType;
+                                            if (prevType && prevType !== playerType) {
+                                                console.log('[AD DEBUG] Cycle switched to different clean type (' + playerType + ', was ' + prevType + ') during freeze — recovered without reload');
+                                            } else {
+                                                console.log('[AD DEBUG] Same backup type (' + playerType + ') became clean during freeze — natural recovery');
+                                            }
                                             streamInfo.CycleRescuedThisBreak = true;
                                         }
                                         backupPlayerType = playerType;
@@ -861,6 +874,7 @@ twitch-videoad.js text/javascript
             }
             if (backupM3u8) {
                 textStr = backupM3u8;
+                streamInfo.LastCommittedBackupPlayerType = backupPlayerType;
                 if (streamInfo.ActiveBackupPlayerType != backupPlayerType) {
                     streamInfo.ActiveBackupPlayerType = backupPlayerType;
                     const sourceQualityTypes = ['embed', 'site', 'popout'];
@@ -924,9 +938,9 @@ twitch-videoad.js text/javascript
                 const adBreakDurationSec = streamInfo.AdBreakStartedAt ? ((Date.now() - streamInfo.AdBreakStartedAt) / 1000).toFixed(1) : '?';
                 console.log('Finished blocking ads — stripped ' + streamInfo.NumStrippedAdSegments + ' ad segments, duration: ' + adBreakDurationSec + 's');
                 if (streamInfo.TotalAllStrippedPolls > 0) {
-                    const freezeDuration = streamInfo.TotalAllStrippedPolls * 2;
                     const reloadInfo = streamInfo.EarlyReloadAtPoll ? ', early reload at poll ' + streamInfo.EarlyReloadAtPoll : '';
-                    console.log('[AD DEBUG] Ad break stats: ' + streamInfo.TotalAllStrippedPolls + ' all-stripped polls (~' + freezeDuration + 's freeze)' + reloadInfo);
+                    const wallClockFreeze = streamInfo.FreezeStartedAt ? ((Date.now() - streamInfo.FreezeStartedAt) / 1000).toFixed(1) + 's wall-clock' : 'unknown';
+                    console.log('[AD DEBUG] Ad break stats: ' + streamInfo.TotalAllStrippedPolls + ' all-stripped polls, freeze duration: ' + wallClockFreeze + reloadInfo);
                 }
                 const hadStrippedSegments = streamInfo.NumStrippedAdSegments > 0;
                 // Only count toward false-positive guard if the m3u8 lacked high-confidence ad markers.

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -254,13 +254,18 @@
                         } else if (e.data.key == 'ReloadSkipped') {
                             // Main thread refused the reload (player healthy) — clear the
                             // early-reload flags so we can re-fire if the player later stalls
+                            let cleared = false;
                             for (const channel in StreamInfos) {
                                 const si = StreamInfos[channel];
                                 if (si && si.EarlyReloadTriggered) {
                                     si.EarlyReloadTriggered = false;
                                     si.EarlyReloadAwaitingResult = false;
                                     si.EarlyReloadCount = Math.max(0, (si.EarlyReloadCount || 0) - 1);
+                                    cleared = true;
                                 }
+                            }
+                            if (cleared) {
+                                console.log('[AD DEBUG] Reload skipped by main thread (player healthy) — early reload state cleared, can retry');
                             }
                         } else if (e.data.key == 'SimulateAds') {
                             SimulatedAdsDepth = e.data.value;
@@ -589,6 +594,7 @@
         if (hasStrippedAdSegments && liveSegments.length === 0 && streamInfo.RecoverySegments && streamInfo.RecoverySegments.length > 0) {
             streamInfo.ConsecutiveAllStrippedPolls = (streamInfo.ConsecutiveAllStrippedPolls || 0) + 1;
             streamInfo.TotalAllStrippedPolls = (streamInfo.TotalAllStrippedPolls || 0) + 1;
+            if (!streamInfo.FreezeStartedAt) streamInfo.FreezeStartedAt = Date.now();
             console.log('[AD DEBUG] All segments stripped — restoring ' + streamInfo.RecoverySegments.length + ' recovery segments');
             if (streamInfo.RecoveryStartSeq !== undefined) {
                 for (let j = 0; j < lines.length; j++) {
@@ -685,6 +691,8 @@
                 // Track high-confidence ad markers to distinguish real ads from false-positive signifier matches
                 streamInfo.HasConfirmedAdAttrs = textStr.includes('X-TV-TWITCH-AD-AD-SESSION-ID') || textStr.includes('X-TV-TWITCH-AD-RADS-TOKEN');
                 streamInfo.CycleRescuedThisBreak = false;
+                streamInfo.LastCommittedBackupPlayerType = null;
+                streamInfo.FreezeStartedAt = 0;
                 console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName + ', pod: ' + podLength + ' ad(s) (~' + (podLength * 30) + 's expected), signifiers: ' + getMatchedAdSignifiers(textStr).join(', '));
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -822,7 +830,12 @@
                                     }
                                     if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
                                         if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !hasAdTags(m3u8Text)) {
-                                            console.log('[AD DEBUG] Found clean backup (' + playerType + ') during freeze — recovered without reload');
+                                            const prevType = streamInfo.LastCommittedBackupPlayerType;
+                                            if (prevType && prevType !== playerType) {
+                                                console.log('[AD DEBUG] Cycle switched to different clean type (' + playerType + ', was ' + prevType + ') during freeze — recovered without reload');
+                                            } else {
+                                                console.log('[AD DEBUG] Same backup type (' + playerType + ') became clean during freeze — natural recovery');
+                                            }
                                             streamInfo.CycleRescuedThisBreak = true;
                                         }
                                         backupPlayerType = playerType;
@@ -872,6 +885,7 @@
             }
             if (backupM3u8) {
                 textStr = backupM3u8;
+                streamInfo.LastCommittedBackupPlayerType = backupPlayerType;
                 if (streamInfo.ActiveBackupPlayerType != backupPlayerType) {
                     streamInfo.ActiveBackupPlayerType = backupPlayerType;
                     const sourceQualityTypes = ['embed', 'site', 'popout'];
@@ -935,9 +949,9 @@
                 const adBreakDurationSec = streamInfo.AdBreakStartedAt ? ((Date.now() - streamInfo.AdBreakStartedAt) / 1000).toFixed(1) : '?';
                 console.log('Finished blocking ads — stripped ' + streamInfo.NumStrippedAdSegments + ' ad segments, duration: ' + adBreakDurationSec + 's');
                 if (streamInfo.TotalAllStrippedPolls > 0) {
-                    const freezeDuration = streamInfo.TotalAllStrippedPolls * 2;
                     const reloadInfo = streamInfo.EarlyReloadAtPoll ? ', early reload at poll ' + streamInfo.EarlyReloadAtPoll : '';
-                    console.log('[AD DEBUG] Ad break stats: ' + streamInfo.TotalAllStrippedPolls + ' all-stripped polls (~' + freezeDuration + 's freeze)' + reloadInfo);
+                    const wallClockFreeze = streamInfo.FreezeStartedAt ? ((Date.now() - streamInfo.FreezeStartedAt) / 1000).toFixed(1) + 's wall-clock' : 'unknown';
+                    console.log('[AD DEBUG] Ad break stats: ' + streamInfo.TotalAllStrippedPolls + ' all-stripped polls, freeze duration: ' + wallClockFreeze + reloadInfo);
                 }
                 const hadStrippedSegments = streamInfo.NumStrippedAdSegments > 0;
                 // Only count toward false-positive guard if the m3u8 lacked high-confidence ad markers.


### PR DESCRIPTION
## Summary
Three small but high-value debug log improvements for diagnosing loading-circle issues during ad breaks.

## 1. Distinguish cycle rescue from natural recovery
The \`Found clean backup (X) during freeze\` log was misleading — it fired whether cycle actually switched to a different clean player type, OR the same type just naturally became clean on the next poll. These are fundamentally different and only the first is a real PR #95 win.

Track \`LastCommittedBackupPlayerType\` and compare in the log:

- **Real cycle rescue:** \`Cycle switched to different clean type (popout, was embed) during freeze — recovered without reload\`
- **Natural recovery (was misreported as cycle):** \`Same backup type (embed) became clean during freeze — natural recovery\`

This will let us see how often cycling is *actually* helping vs just attributing natural recovery to itself.

## 2. Wall-clock freeze duration
The \`Ad break stats: N polls (~Xs freeze)\` line used a poll-count estimate (\`polls × 2s\`) that significantly underreported actual user-visible stalls. Real example from testing: log said \`~2s freeze\` but user observed 10-15s of loading circle.

Track \`Date.now()\` at first all-stripped poll, report wall-clock at end:

\`\`\`
[AD DEBUG] Ad break stats: 1 all-stripped polls, freeze duration: 8.3s wall-clock
\`\`\`

## 3. Worker-side ReloadSkipped log
The new \`ReloadSkipped\` feedback loop silently cleared early-reload flags when the main-thread player health guard refused a reload. Now visibly logs:

\`\`\`
[AD DEBUG] Reload skipped by main thread (player healthy) — early reload state cleared, can retry
\`\`\`

Helps verify the feedback loop is working without inspecting state.

## Test plan
- [ ] Watch for the new \`Cycle switched to different clean type\` vs \`Same backup type became clean\` distinction across multiple breaks — expect mostly natural recovery
- [ ] Compare \`freeze duration: Xs wall-clock\` against perceived loading-circle duration in subsequent tests
- [ ] Trigger thin-cache fast path with healthy player (e.g. ad break with prior buffered content) and verify the \`Reload skipped by main thread\` log fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)