### PR TITLE
Tighten PR #98: only skip end-of-break reload on REAL cycle switch

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -806,10 +806,14 @@ twitch-videoad.js text/javascript
                                             const prevType = streamInfo.LastCommittedBackupPlayerType;
                                             if (prevType && prevType !== playerType) {
                                                 console.log('[AD DEBUG] Cycle switched to different clean type (' + playerType + ', was ' + prevType + ') during freeze — recovered without reload');
+                                                // Only mark as cycle-rescued when we ACTUALLY switched player types.
+                                                // Natural recovery (same type became clean) still needs the end-of-break
+                                                // reload to refresh the player buffer — skipping it leaves the player
+                                                // stuck with low buffer and the buffer monitor unable to recover.
+                                                streamInfo.CycleRescuedThisBreak = true;
                                             } else {
                                                 console.log('[AD DEBUG] Same backup type (' + playerType + ') became clean during freeze — natural recovery');
                                             }
-                                            streamInfo.CycleRescuedThisBreak = true;
                                         }
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -817,10 +817,14 @@
                                             const prevType = streamInfo.LastCommittedBackupPlayerType;
                                             if (prevType && prevType !== playerType) {
                                                 console.log('[AD DEBUG] Cycle switched to different clean type (' + playerType + ', was ' + prevType + ') during freeze — recovered without reload');
+                                                // Only mark as cycle-rescued when we ACTUALLY switched player types.
+                                                // Natural recovery (same type became clean) still needs the end-of-break
+                                                // reload to refresh the player buffer — skipping it leaves the player
+                                                // stuck with low buffer and the buffer monitor unable to recover.
+                                                streamInfo.CycleRescuedThisBreak = true;
                                             } else {
                                                 console.log('[AD DEBUG] Same backup type (' + playerType + ') became clean during freeze — natural recovery');
                                             }
-                                            streamInfo.CycleRescuedThisBreak = true;
                                         }
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;


### PR DESCRIPTION
## Summary
Fixes a regression introduced by PR #98 that was exposed by PR #99's improved logging.

## Problem
PR #98 skipped the end-of-break reload whenever \`CycleRescuedThisBreak\` was true. But that flag was being set on **any** clean backup found during a freeze — including natural recovery (same player type became clean on its own), not just real cycle switches to a different player type.

PR #99 logging made this visible:
\`\`\`
Same backup type (embed) became clean during freeze — natural recovery
Cycle rescue handled the break cleanly — skipping end-of-break reload
\`\`\`
The script identified the recovery as natural, then immediately attributed it to cycling and skipped the reload.

## Real-world impact (pge4 test)
After PR #98 incorrectly skipped the end-of-break reload, the buffer dropped to ~0.003s and the buffer monitor fired multiple pause/play attempts that couldn't recover:
\`\`\`
Cycle rescue handled the break cleanly — skipping end-of-break reload
Attempt to fix buffering ... bufferDuration:0.048
Attempt to fix buffering ... bufferDuration:0.003
Attempt to fix buffering ... bufferDuration:0.003
Position jumped 6.0s — starting drift correction
\`\`\`
The end-of-break reload would have refreshed the player buffer cleanly. PR #98 prevented exactly that.

## Fix
Only set \`CycleRescuedThisBreak\` when \`prevType !== playerType\` (real cycle switch to a different player type). Natural recovery on the same type falls through to the normal end-of-break reload.

\`\`\`js
const prevType = streamInfo.LastCommittedBackupPlayerType;
if (prevType && prevType !== playerType) {
    console.log('[AD DEBUG] Cycle switched to different clean type ...');
    streamInfo.CycleRescuedThisBreak = true;  // ← only here
} else {
    console.log('[AD DEBUG] Same backup type ... — natural recovery');
    // No flag set — end-of-break reload still fires
}
\`\`\`

## Tradeoff
Natural recovery cases now get an end-of-break reload (~1-2s loading circle), as they did before PR #98. This is the correct behavior — the reload refreshes the player buffer and prevents the stuck-low-buffer scenario the user reported. The loading circle from the reload is shorter and more predictable than the indefinite stall from a stuck buffer.

PR #98's optimization is preserved for the case it was actually designed for: when cycle finds a *different* clean player type and we're confident the player is on a healthy backup stream.

## Test plan
- [ ] Verify a natural-recovery break (same player type becomes clean) now fires the end-of-break reload
- [ ] Verify a real cycle switch (different player type) still skips the end-of-break reload
- [ ] Verify the buffer monitor no longer fires multiple unsuccessful pause/play attempts post-rescue

🤖 Generated with [Claude Code](https://claude.com/claude-code)