### PR TITLE
Fix real cross-channel cooldown leak — don't set LastPlayerReload on new stream session

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -455,7 +455,11 @@ twitch-videoad.js text/javascript
                                     }
                                 }
                                 streamInfo.LastSeenAt = Date.now();
-                                streamInfo.LastPlayerReload = Date.now();
+                                // Note: do NOT set streamInfo.LastPlayerReload here. It was previously
+                                // set unconditionally on new stream session creation, which caused the
+                                // first end-of-break reload of every new channel to be blocked by
+                                // cooldown — the cooldown check treated the session-creation timestamp
+                                // as a recent reload, even though no reload had actually occurred.
                                 resolve(new Response(replaceServerTimeInM3u8(streamInfo.IsUsingModifiedM3U8 ? streamInfo.ModifiedM3U8 : streamInfo.EncodingsM3U8, serverTime)));
                             } else {
                                 resolve(response);

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -466,7 +466,11 @@
                                     }
                                 }
                                 streamInfo.LastSeenAt = Date.now();
-                                streamInfo.LastPlayerReload = Date.now();
+                                // Note: do NOT set streamInfo.LastPlayerReload here. It was previously
+                                // set unconditionally on new stream session creation, which caused the
+                                // first end-of-break reload of every new channel to be blocked by
+                                // cooldown — the cooldown check treated the session-creation timestamp
+                                // as a recent reload, even though no reload had actually occurred.
                                 resolve(new Response(replaceServerTimeInM3u8(streamInfo.IsUsingModifiedM3U8 ? streamInfo.ModifiedM3U8 : streamInfo.EncodingsM3U8, serverTime)));
                             } else {
                                 resolve(response);


### PR DESCRIPTION
## Summary
Fixes the **actual** cross-channel cooldown leak. PR #97 fixed a related bug (HasTriggeredPlayerReload bleeding) but missed a more direct source of the same symptom: an unconditional \`streamInfo.LastPlayerReload = Date.now()\` on every new stream session creation.

## Evidence
Real test log on pge4, with PR #97 + #100 already applied:

\`\`\`
[AD DEBUG] New stream session — channel: pge4, API: v2
[AD DEBUG] Ad detected — type: preroll, channel: pge4, pod: 1 ad(s)
[AD DEBUG] Backup stream (popout) also has ads
Blocking ads (popout) — backup found in 976ms
Finished blocking ads — stripped 12 ad segments, duration: 44.5s
[AD DEBUG] Skipping reload — last reload was 46s ago (cooldown: 120s)
\`\`\`

This is the **first** ad break on pge4 — no reload could possibly have happened. The "46s ago" matches session creation time + break duration.

## Root cause
\`vaft.user.js\` line 469 (added upstream pixeltris/TwitchAdSolutions commit 464b11b1 on 2025-11-21):

\`\`\`js
streamInfo.LastSeenAt = Date.now();
streamInfo.LastPlayerReload = Date.now();   // ← ALWAYS runs on new stream session
resolve(new Response(...));
\`\`\`

The intent was probably "treat fresh page load as recently reloaded to avoid disruption" — reasonable in the page-load case, harmful in the channel-switch case. Either way, it causes the first end-of-break reload on every new stream session to be skipped by cooldown.

## Fix
Remove the unconditional set. \`LastPlayerReload\` stays at \`0\` initially. The cooldown check already handles this:

\`\`\`js
const tooSoonSinceLastReload = streamInfo.LastPlayerReload && (Date.now() - streamInfo.LastPlayerReload) < (effectiveCooldown * 1000);
\`\`\`

The \`&&\` short-circuits on \`LastPlayerReload = 0\`, so \`tooSoonSinceLastReload = false\` and the reload is allowed.

## Test plan
- [ ] Navigate to a fresh channel, run an ad break, verify no \`Skipping reload — last reload was Xs ago\` line on the first break
- [ ] Verify subsequent reloads still respect the cooldown (set correctly when actual reloads happen)
- [ ] Verify no regression in the page-load scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)