### PR TITLE
video-swap-new: port CSAI fast path + HasConfirmedAdAttrs false-positive guard

### DIFF
--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -303,6 +303,12 @@ twitch-videoad.js text/javascript
     async function onFoundAd(streamInfo, textStr, reloadPlayer, realFetch, url, resolutionInfo) {
         let result = textStr;
         streamInfo.IsMidroll = textStr.includes('"MIDROLL"') || textStr.includes('"midroll"');
+        // Track high-confidence ad markers to distinguish real ads from false-positive signifier matches.
+        // These attributes are present on every real Twitch ad and absent from anything that could
+        // false-positive (e.g. metadata containing the word 'stitched').
+        if (!streamInfo.HasConfirmedAdAttrs) {
+            streamInfo.HasConfirmedAdAttrs = textStr.includes('X-TV-TWITCH-AD-AD-SESSION-ID') || textStr.includes('X-TV-TWITCH-AD-RADS-TOKEN');
+        }
         const playerTypes = [...OPT_BACKUP_PLAYER_TYPES];
         // Try pinned backup player type first if available
         if (PinBackupPlayerType && streamInfo.PinnedBackupPlayerType) {
@@ -543,14 +549,19 @@ twitch-videoad.js text/javascript
                                 console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
                             }
                             console.log('No more ads on main stream. Stripped ' + streamInfo.NumStrippedAdSegments + ' ad segments. ' + (ReloadPlayerAfterAd ? 'Triggering player reload to go back to main stream...' : 'Resuming playback...'));
-                            if (streamInfo.NumStrippedAdSegments === 0) {
+                            // Only count toward false-positive guard if the m3u8 lacked high-confidence ad markers.
+                            // Confirmed ads (with X-TV-TWITCH-AD-AD-SESSION-ID etc.) that produce 0 strips are real
+                            // ads we successfully avoided via clean backup — not false positives.
+                            if (streamInfo.NumStrippedAdSegments === 0 && !streamInfo.HasConfirmedAdAttrs) {
                                 streamInfo.ConsecutiveZeroStripBreaks++;
                                 if (streamInfo.ConsecutiveZeroStripBreaks >= 3) {
-                                    console.log('[AD DEBUG] Warning: ' + streamInfo.ConsecutiveZeroStripBreaks + ' consecutive ad breaks with 0 segments stripped — possible false positive from ad signifiers');
+                                    console.log('[AD DEBUG] Warning: ' + streamInfo.ConsecutiveZeroStripBreaks + ' consecutive unconfirmed ad breaks with 0 segments stripped — possible false positive from ad signifiers');
                                 }
-                            } else {
+                            } else if (streamInfo.NumStrippedAdSegments > 0) {
                                 streamInfo.ConsecutiveZeroStripBreaks = 0;
                             }
+                            streamInfo.HasConfirmedAdAttrs = false;
+                            streamInfo.HasLoggedCsaiFastPath = false;
                             streamInfo.IsMovingOffBackupEncodings = true;
                             streamInfo.BackupEncodings = null;
                             streamInfo.BackupEncodingsStatus.clear();
@@ -582,7 +593,26 @@ twitch-videoad.js text/javascript
                 textStr = await onFoundAd(streamInfo, textStr, true, realFetch, url, currentResolution);
             }
         } else if (haveAdTags && !streamInfo.IsMovingOffBackupEncodings) {
-            textStr = await onFoundAd(streamInfo, textStr, true, realFetch, url, currentResolution);
+            // CSAI fast path: if all segments in the main stream are live, skip backup search.
+            // CSAI ads are delivered outside the m3u8 — the main stream segments are clean.
+            // Return the main stream directly, avoiding the backup stream switch that causes
+            // a 20-40s rebuffer gap.
+            const mainStreamLines = textStr.split(/\r?\n/);
+            let hasNonLiveSegment = false;
+            for (let i = 0; i < mainStreamLines.length; i++) {
+                if (mainStreamLines[i].startsWith('#EXTINF') && !mainStreamLines[i].includes(LIVE_SIGNIFIER)) {
+                    hasNonLiveSegment = true;
+                    break;
+                }
+            }
+            if (!hasNonLiveSegment) {
+                if (!streamInfo.HasLoggedCsaiFastPath) {
+                    streamInfo.HasLoggedCsaiFastPath = true;
+                    console.log('[AD DEBUG] CSAI fast path — all segments live, skipping backup search');
+                }
+            } else {
+                textStr = await onFoundAd(streamInfo, textStr, true, realFetch, url, currentResolution);
+            }
         }
         if (IsAdStrippingEnabled) {
             textStr = stripAdSegments(textStr, false, streamInfo);

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -315,6 +315,12 @@
     async function onFoundAd(streamInfo, textStr, reloadPlayer, realFetch, url, resolutionInfo) {
         let result = textStr;
         streamInfo.IsMidroll = textStr.includes('"MIDROLL"') || textStr.includes('"midroll"');
+        // Track high-confidence ad markers to distinguish real ads from false-positive signifier matches.
+        // These attributes are present on every real Twitch ad and absent from anything that could
+        // false-positive (e.g. metadata containing the word 'stitched').
+        if (!streamInfo.HasConfirmedAdAttrs) {
+            streamInfo.HasConfirmedAdAttrs = textStr.includes('X-TV-TWITCH-AD-AD-SESSION-ID') || textStr.includes('X-TV-TWITCH-AD-RADS-TOKEN');
+        }
         const playerTypes = [...OPT_BACKUP_PLAYER_TYPES];
         // Try pinned backup player type first if available
         if (PinBackupPlayerType && streamInfo.PinnedBackupPlayerType) {
@@ -555,14 +561,19 @@
                                 console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
                             }
                             console.log('No more ads on main stream. Stripped ' + streamInfo.NumStrippedAdSegments + ' ad segments. ' + (ReloadPlayerAfterAd ? 'Triggering player reload to go back to main stream...' : 'Resuming playback...'));
-                            if (streamInfo.NumStrippedAdSegments === 0) {
+                            // Only count toward false-positive guard if the m3u8 lacked high-confidence ad markers.
+                            // Confirmed ads (with X-TV-TWITCH-AD-AD-SESSION-ID etc.) that produce 0 strips are real
+                            // ads we successfully avoided via clean backup — not false positives.
+                            if (streamInfo.NumStrippedAdSegments === 0 && !streamInfo.HasConfirmedAdAttrs) {
                                 streamInfo.ConsecutiveZeroStripBreaks++;
                                 if (streamInfo.ConsecutiveZeroStripBreaks >= 3) {
-                                    console.log('[AD DEBUG] Warning: ' + streamInfo.ConsecutiveZeroStripBreaks + ' consecutive ad breaks with 0 segments stripped — possible false positive from ad signifiers');
+                                    console.log('[AD DEBUG] Warning: ' + streamInfo.ConsecutiveZeroStripBreaks + ' consecutive unconfirmed ad breaks with 0 segments stripped — possible false positive from ad signifiers');
                                 }
-                            } else {
+                            } else if (streamInfo.NumStrippedAdSegments > 0) {
                                 streamInfo.ConsecutiveZeroStripBreaks = 0;
                             }
+                            streamInfo.HasConfirmedAdAttrs = false;
+                            streamInfo.HasLoggedCsaiFastPath = false;
                             streamInfo.IsMovingOffBackupEncodings = true;
                             streamInfo.BackupEncodings = null;
                             streamInfo.BackupEncodingsStatus.clear();
@@ -594,7 +605,26 @@
                 textStr = await onFoundAd(streamInfo, textStr, true, realFetch, url, currentResolution);
             }
         } else if (haveAdTags && !streamInfo.IsMovingOffBackupEncodings) {
-            textStr = await onFoundAd(streamInfo, textStr, true, realFetch, url, currentResolution);
+            // CSAI fast path: if all segments in the main stream are live, skip backup search.
+            // CSAI ads are delivered outside the m3u8 — the main stream segments are clean.
+            // Return the main stream directly, avoiding the backup stream switch that causes
+            // a 20-40s rebuffer gap.
+            const mainStreamLines = textStr.split(/\r?\n/);
+            let hasNonLiveSegment = false;
+            for (let i = 0; i < mainStreamLines.length; i++) {
+                if (mainStreamLines[i].startsWith('#EXTINF') && !mainStreamLines[i].includes(LIVE_SIGNIFIER)) {
+                    hasNonLiveSegment = true;
+                    break;
+                }
+            }
+            if (!hasNonLiveSegment) {
+                if (!streamInfo.HasLoggedCsaiFastPath) {
+                    streamInfo.HasLoggedCsaiFastPath = true;
+                    console.log('[AD DEBUG] CSAI fast path — all segments live, skipping backup search');
+                }
+            } else {
+                textStr = await onFoundAd(streamInfo, textStr, true, realFetch, url, currentResolution);
+            }
         }
         if (IsAdStrippingEnabled) {
             textStr = stripAdSegments(textStr, false, streamInfo);


### PR DESCRIPTION
## Summary
Ports the two recent vaft fixes that apply cleanly to video-swap-new's architecture. Most of vaft's recovery layers require freeze tracking infrastructure (\`ConsecutiveAllStrippedPolls\`, \`isActivelyStrippingAds\`, \`LastPlayerReload\` cooldown system) that video-swap-new doesn't have, so they're not portable. These two are the only changes that translate.

## CSAI fast path (port of vaft #90)
When the main stream's m3u8 has only live segments (no ad segments to strip), CSAI ads are being delivered outside the m3u8 — the main stream is fine to play as-is. Skip the backup stream search entirely and return the main stream directly.

**Benefit:** eliminates the 20-40s rebuffer gap on pure-CSAI ad breaks. Same UX win that vaft has been getting since #90.

\`\`\`js
} else if (haveAdTags && !streamInfo.IsMovingOffBackupEncodings) {
    // CSAI fast path: if all segments are live, skip backup search
    const mainStreamLines = textStr.split(/\r?\n/);
    let hasNonLiveSegment = false;
    for (let i = 0; i < mainStreamLines.length; i++) {
        if (mainStreamLines[i].startsWith('#EXTINF') && !mainStreamLines[i].includes(LIVE_SIGNIFIER)) {
            hasNonLiveSegment = true;
            break;
        }
    }
    if (!hasNonLiveSegment) {
        // CSAI-only — log once per session and return main stream
    } else {
        textStr = await onFoundAd(...);
    }
}
\`\`\`

## HasConfirmedAdAttrs false-positive guard (port of recent vaft fix)
The 'consecutive ad breaks with 0 segments stripped' warning was firing on real ads that we successfully avoided via clean backup, treating them as false positives. Track high-confidence ad markers (\`X-TV-TWITCH-AD-AD-SESSION-ID\`, \`X-TV-TWITCH-AD-RADS-TOKEN\`) at ad detection; skip incrementing the counter when these were seen.

Real false positives (signifier match without these attributes) still get caught.

\`\`\`js
// In onFoundAd:
if (!streamInfo.HasConfirmedAdAttrs) {
    streamInfo.HasConfirmedAdAttrs = textStr.includes('X-TV-TWITCH-AD-AD-SESSION-ID') || textStr.includes('X-TV-TWITCH-AD-RADS-TOKEN');
}

// At end-of-break:
if (streamInfo.NumStrippedAdSegments === 0 && !streamInfo.HasConfirmedAdAttrs) {
    streamInfo.ConsecutiveZeroStripBreaks++;
    // ... warning logic
}
\`\`\`

## What is NOT being ported (and why)
- Early reload mechanism (#94) — requires \`ConsecutiveAllStrippedPolls\` infrastructure
- Cycle backup during freeze (#95) — requires same
- Loading-circle health check (#96) — requires \`isActivelyStrippingAds\` infrastructure
- Cross-channel cooldown leak fix (#102) — video-swap-new has no \`LastPlayerReload\` cooldown system
- TotalAllStrippedPolls fix — counter doesn't exist in video-swap-new
- Skip end-of-break reload on cycle switch (#101) — no cycle infrastructure

These would require significant architectural additions to video-swap-new and are out of scope for this PR.

## Test plan
- [ ] Verify CSAI fast path log fires on a CSAI-only break: \`[AD DEBUG] CSAI fast path — all segments live, skipping backup search\`
- [ ] Verify backup search no longer runs on pure-CSAI breaks
- [ ] Verify the false-positive warning no longer fires on confirmed-ad breaks with 0 strips

🤖 Generated with [Claude Code](https://claude.com/claude-code)