### PR TITLE
Strip #EXT-X-PRELOAD-HINT during ad block

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -551,7 +551,7 @@ twitch-videoad.js text/javascript
         if (hasStrippedAdSegments) {
             for (let i = 0; i < lines.length; i++) {
                 // No low latency during ads (otherwise it's possible for the player to prefetch and display ad segments)
-                if (lines[i].startsWith('#EXT-X-TWITCH-PREFETCH:')) {
+                if (lines[i].startsWith('#EXT-X-TWITCH-PREFETCH:') || lines[i].startsWith('#EXT-X-PRELOAD-HINT:')) {
                     lines[i] = '';
                 }
             }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -562,7 +562,7 @@
         if (hasStrippedAdSegments) {
             for (let i = 0; i < lines.length; i++) {
                 // No low latency during ads (otherwise it's possible for the player to prefetch and display ad segments)
-                if (lines[i].startsWith('#EXT-X-TWITCH-PREFETCH:')) {
+                if (lines[i].startsWith('#EXT-X-TWITCH-PREFETCH:') || lines[i].startsWith('#EXT-X-PRELOAD-HINT:')) {
                     lines[i] = '';
                 }
             }

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -467,7 +467,7 @@ twitch-videoad.js text/javascript
         if (hasStrippedAdSegments) {
             for (let i = 0; i < lines.length; i++) {
                 // No low latency during ads (otherwise it's possible for the player to prefetch and display ad segments)
-                if (lines[i].startsWith('#EXT-X-TWITCH-PREFETCH:')) {
+                if (lines[i].startsWith('#EXT-X-TWITCH-PREFETCH:') || lines[i].startsWith('#EXT-X-PRELOAD-HINT:')) {
                     lines[i] = '';
                 }
             }

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -479,7 +479,7 @@
         if (hasStrippedAdSegments) {
             for (let i = 0; i < lines.length; i++) {
                 // No low latency during ads (otherwise it's possible for the player to prefetch and display ad segments)
-                if (lines[i].startsWith('#EXT-X-TWITCH-PREFETCH:')) {
+                if (lines[i].startsWith('#EXT-X-TWITCH-PREFETCH:') || lines[i].startsWith('#EXT-X-PRELOAD-HINT:')) {
                     lines[i] = '';
                 }
             }


### PR DESCRIPTION
## Summary
Adds \`#EXT-X-PRELOAD-HINT\` to the lines stripped during ad blocking, alongside the existing \`#EXT-X-TWITCH-PREFETCH\` removal. Ports TTV-AB 6.1.9 (commit a81ac73 — 'fix(playback): harden prefetch ad stripping').

## Why
vaft and video-swap-new already strip the Twitch-proprietary \`#EXT-X-TWITCH-PREFETCH\` lines from m3u8 playlists during ad blocking, to prevent the low-latency prefetch path from leaking ad segments into playback. The HLS standard equivalent is \`#EXT-X-PRELOAD-HINT\`. If Twitch transitions to the standard tag (which they may, given they're moving toward standard LL-HLS), the existing strip would miss it and ad media could be prefetched.

This is a forward-compatibility hardening — it costs nothing if the tag isn't present, and protects against the case where it appears.

## Change
One-line addition in all four release files:

\`\`\`diff
- if (lines[i].startsWith('#EXT-X-TWITCH-PREFETCH:')) {
+ if (lines[i].startsWith('#EXT-X-TWITCH-PREFETCH:') || lines[i].startsWith('#EXT-X-PRELOAD-HINT:')) {
      lines[i] = '';
  }
\`\`\`

Files touched:
- \`vaft/vaft.user.js\`
- \`vaft/vaft-ublock-origin.js\`
- \`video-swap-new/video-swap-new.user.js\`
- \`video-swap-new/video-swap-new-ublock-origin.js\`

## Test plan
- [ ] Verify normal playback isn't affected
- [ ] Watch debug logs for any \`EXT-X-PRELOAD-HINT\` references during ad breaks (currently rare on Twitch but worth observing)

## Risk
Minimal. The change only fires when the strip path is already running (during ad blocking) and only blanks a specific line type that shouldn't be present in normal playback content. No new state, no new code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)