### PR TITLE
Strip LL-HLS #EXT-X-PART: ad lines (minimum viable port of TTV-AB 6.2.1)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -543,6 +543,17 @@ twitch-videoad.js text/javascript
                 streamInfo.NumStrippedAdSegments++;
             } else if (i < lines.length - 1 && line.startsWith('#EXTINF') && isLiveSegment) {
                 liveSegments.push({ extinf: line, url: lines[i + 1] });
+            } else if (line.startsWith('#EXT-X-PART:')) {
+                // LL-HLS part: URI is inline as an attribute. Strip if it matches a known
+                // ad URL (already in cache from a parallel EXTINF strip, or matches a URL pattern).
+                // Without this, the player may use the parts path to fetch ad media via low-latency.
+                const partUriMatch = line.match(/URI="([^"]+)"/);
+                const partUri = partUriMatch ? partUriMatch[1] : '';
+                if (partUri && (AdSegmentCache.has(partUri) || AdSegmentURLPatterns.some((p) => partUri.includes(p)))) {
+                    AdSegmentCache.set(partUri, Date.now());
+                    lines[i] = '';
+                    hasStrippedAdSegments = true;
+                }
             }
             if (AdSignifiers.some((s) => line.includes(s))) {
                 hasStrippedAdSegments = true;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -554,6 +554,17 @@
                 streamInfo.NumStrippedAdSegments++;
             } else if (i < lines.length - 1 && line.startsWith('#EXTINF') && isLiveSegment) {
                 liveSegments.push({ extinf: line, url: lines[i + 1] });
+            } else if (line.startsWith('#EXT-X-PART:')) {
+                // LL-HLS part: URI is inline as an attribute. Strip if it matches a known
+                // ad URL (already in cache from a parallel EXTINF strip, or matches a URL pattern).
+                // Without this, the player may use the parts path to fetch ad media via low-latency.
+                const partUriMatch = line.match(/URI="([^"]+)"/);
+                const partUri = partUriMatch ? partUriMatch[1] : '';
+                if (partUri && (AdSegmentCache.has(partUri) || AdSegmentURLPatterns.some((p) => partUri.includes(p)))) {
+                    AdSegmentCache.set(partUri, Date.now());
+                    lines[i] = '';
+                    hasStrippedAdSegments = true;
+                }
             }
             if (AdSignifiers.some((s) => line.includes(s))) {
                 hasStrippedAdSegments = true;

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -459,6 +459,17 @@ twitch-videoad.js text/javascript
                 streamInfo.NumStrippedAdSegments++;
             } else if (i < lines.length - 1 && line.startsWith('#EXTINF') && line.includes(',live')) {
                 liveSegments.push({ extinf: line, url: lines[i + 1] });
+            } else if (line.startsWith('#EXT-X-PART:')) {
+                // LL-HLS part: URI is inline as an attribute. Strip if it matches a known
+                // ad URL (already in cache from a parallel EXTINF strip, or matches a URL pattern).
+                // Without this, the player may use the parts path to fetch ad media via low-latency.
+                const partUriMatch = line.match(/URI="([^"]+)"/);
+                const partUri = partUriMatch ? partUriMatch[1] : '';
+                if (partUri && (AdSegmentCache.has(partUri) || AD_SEGMENT_URL_PATTERNS.some((p) => partUri.includes(p)))) {
+                    AdSegmentCache.set(partUri, Date.now());
+                    lines[i] = '';
+                    hasStrippedAdSegments = true;
+                }
             }
             if (AD_SIGNIFIERS.some((s) => line.includes(s))) {
                 hasStrippedAdSegments = true;

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -471,6 +471,17 @@
                 streamInfo.NumStrippedAdSegments++;
             } else if (i < lines.length - 1 && line.startsWith('#EXTINF') && line.includes(',live')) {
                 liveSegments.push({ extinf: line, url: lines[i + 1] });
+            } else if (line.startsWith('#EXT-X-PART:')) {
+                // LL-HLS part: URI is inline as an attribute. Strip if it matches a known
+                // ad URL (already in cache from a parallel EXTINF strip, or matches a URL pattern).
+                // Without this, the player may use the parts path to fetch ad media via low-latency.
+                const partUriMatch = line.match(/URI="([^"]+)"/);
+                const partUri = partUriMatch ? partUriMatch[1] : '';
+                if (partUri && (AdSegmentCache.has(partUri) || AD_SEGMENT_URL_PATTERNS.some((p) => partUri.includes(p)))) {
+                    AdSegmentCache.set(partUri, Date.now());
+                    lines[i] = '';
+                    hasStrippedAdSegments = true;
+                }
             }
             if (AD_SIGNIFIERS.some((s) => line.includes(s))) {
                 hasStrippedAdSegments = true;


### PR DESCRIPTION
## Summary
Adds handling for HLS Low-Latency \`#EXT-X-PART:\` lines in the ad strip path, alongside the existing \`#EXTINF\` segment handling. Minimum viable port of TTV-AB 6.2.1 (commit 8fe37a5 'fix(playback): harden low-latency playlist recovery').

Builds on PR #104 which strips \`#EXT-X-PRELOAD-HINT:\` (the related part-prefetch tag).

## Why
Twitch delivers media via two parallel paths in LL-HLS playlists:
- **Standard path**: \`#EXTINF\` + segment URL on next line
- **Low-latency path**: \`#EXT-X-PART:URI="...",DURATION=..."\` (single line, URI inline)

vaft and video-swap-new already strip ad-laden \`#EXTINF\` segments, but parts referring to the same ad URLs were leaking through. If the player chose the low-latency path for a given chunk, ad media could still play.

## Change
When the strip loop encounters a \`#EXT-X-PART:\` line, extract the URI and check against:
- \`AdSegmentCache\` (populated by parallel \`#EXTINF\` strips on the same playlist)
- \`AdSegmentURLPatterns\` / \`AD_SEGMENT_URL_PATTERNS\` (known ad CDN paths)

If matched, blank the line and mark the playlist as stripped.

\`\`\`js
} else if (line.startsWith('#EXT-X-PART:')) {
    const partUriMatch = line.match(/URI="([^"]+)"/);
    const partUri = partUriMatch ? partUriMatch[1] : '';
    if (partUri && (AdSegmentCache.has(partUri) || AdSegmentURLPatterns.some((p) => partUri.includes(p)))) {
        AdSegmentCache.set(partUri, Date.now());
        lines[i] = '';
        hasStrippedAdSegments = true;
    }
}
\`\`\`

## What this is NOT
This is a **minimum viable** port of TTV-AB 6.2.1. The full TTV-AB change also includes:
- Part-level recovery (treating parts as recovery candidates when all segments stripped)
- Shorter recovery cache age for part-only playlists (3s vs 30s)
- Helper functions and counter changes throughout parser

These are not ported because:
1. vaft's recovery uses \`#EXTINF\` format which can't directly inject parts
2. For mixed playlists (the common Twitch case), the existing \`#EXTINF\` recovery is sufficient
3. Adding part-level recovery would be invasive and the user has explicitly asked to avoid large changes

If a future Twitch playlist becomes part-only (no \`#EXTINF\`), recovery would have nothing to inject — but that's the same as today's behavior, so no regression.

## Files
- \`vaft/vaft.user.js\`
- \`vaft/vaft-ublock-origin.js\`
- \`video-swap-new/video-swap-new.user.js\`
- \`video-swap-new/video-swap-new-ublock-origin.js\`

## Test plan
- [ ] Verify normal playback isn't affected (no parts blanked when not in ad break)
- [ ] During an ad break, watch for any \`#EXT-X-PART:\` lines in m3u8 polls and verify ad parts are stripped
- [ ] Verify recovery still works on mixed playlists (\`#EXTINF\` segments still get cached)

## Risk
Low. The change is bounded to the strip loop (only fires during ad blocking), only blanks specific lines whose URI matches known ad URLs, and uses the existing AdSegmentCache for cross-format consistency. No new state, no new globals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)