### PR TITLE
Skip 'autoplay' from BackupPlayerTypes — fixes endless loading circle on heavy-ad streams

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -19,7 +19,9 @@ twitch-videoad.js text/javascript
             'site',//Source
             'popout',//Source
             'mobile_web',//Mobile
-            'autoplay',//360p
+            // 'autoplay' (360p) removed: when committed as cycle backup, the player gets stuck
+            // in an endless loading circle after the CSAI-only path releases the backup —
+            // autoplay variants don't transition cleanly back to main stream variants.
             //'picture-by-picture-CACHED'//360p (-CACHED is an internal suffix and is removed)
         ];
         scope.FallbackPlayerType = 'embed';

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -819,6 +819,9 @@ twitch-videoad.js text/javascript
                                         fallbackM3u8 = m3u8Text;
                                     }
                                     if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
+                                        if (hasAdTags(m3u8Text) && !fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1) {
+                                            console.log('[AD DEBUG] All backup player types ad-laden — taking ' + playerType + ' as last-resort fallback (strip+recovery path will engage)');
+                                        }
                                         if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !hasAdTags(m3u8Text)) {
                                             const prevType = streamInfo.LastCommittedBackupPlayerType;
                                             if (prevType && prevType !== playerType) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -830,6 +830,9 @@
                                         fallbackM3u8 = m3u8Text;
                                     }
                                     if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
+                                        if (hasAdTags(m3u8Text) && !fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1) {
+                                            console.log('[AD DEBUG] All backup player types ad-laden — taking ' + playerType + ' as last-resort fallback (strip+recovery path will engage)');
+                                        }
                                         if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !hasAdTags(m3u8Text)) {
                                             const prevType = streamInfo.LastCommittedBackupPlayerType;
                                             if (prevType && prevType !== playerType) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -30,7 +30,9 @@
             'site',//Source
             'popout',//Source
             'mobile_web',//Mobile
-            'autoplay',//360p
+            // 'autoplay' (360p) removed: when committed as cycle backup, the player gets stuck
+            // in an endless loading circle after the CSAI-only path releases the backup —
+            // autoplay variants don't transition cleanly back to main stream variants.
             //'picture-by-picture-CACHED'//360p (-CACHED is an internal suffix and is removed)
         ];
         scope.FallbackPlayerType = 'embed';


### PR DESCRIPTION
## Summary
Removes \`'autoplay'\` from \`BackupPlayerTypes\`. The cycle-during-freeze logic was committing autoplay as a clean backup when all 4 main player types were ad-laden simultaneously, causing the player to lock up in an endless loading circle.

## Reproduced
On both \`teamliquid\` and \`pgl\` (heavy-ad channels), the same exact pattern:
\`\`\`
Ad detected — type: preroll, channel: pgl, pod: 1 ad(s)
Backup stream (embed) also has ads
Backup stream (site) also has ads
Backup stream (popout) also has ads
Backup stream (mobile_web) also has ads
Blocking ads (autoplay) — backup found in 4146ms
... (60s of ad break) ...
Finished blocking ads — stripped 0 ad segments, duration: 60.2s
CSAI-only ad break (stripped 0) — clearing backup without player action
[player permanently stuck — endless loading circle]
\`\`\`

## Why it locks up
\`autoplay\` is a 360p degraded fallback player type. When committed as a primary backup:
1. Player runs on autoplay variants for the duration of the ad break
2. CSAI-only path clears the backup at end-of-break (no reload, just \`IsUsingModifiedM3U8 = false\`)
3. Player tries to transition back from autoplay variants to main stream variants
4. Variant ladders don't match → player gets stuck loading
5. Buffer monitor doesn't catch it (gating conditions don't match the stuck state)

## Fix
\`\`\`diff
  scope.BackupPlayerTypes = [
      'embed',//Source
      'site',//Source
      'popout',//Source
      'mobile_web',//Mobile
-     'autoplay',//360p
  ];
\`\`\`

## Tradeoff
With \`autoplay\` removed, when all 4 main types are ad-laden the cycle falls through to the existing strip+early-reload path (~10s bounded freeze via PR #94). That's slightly worse than \`autoplay\` working correctly, but **far better than indefinite player lockup**. Bounded > unbounded.

video-swap-new is intentionally unaffected — that script uses \`autoplay\` as a primary by design (its whole approach is swapping to a low-quality embed/autoplay player).

## Files
- \`vaft/vaft.user.js\`
- \`vaft/vaft-ublock-origin.js\`

Testing variant (\`vaft/vaft-testing-ublock-origin.js\`) gets the same change applied directly to master in a separate commit.

## Test plan
- [ ] Verify normal CSAI-only breaks still work (cycle isn't needed)
- [ ] Verify the freeze case where all 4 main types ad-laden now falls through to early reload instead of autoplay
- [ ] Verify no player lockup on heavy-ad channels (teamliquid, pgl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)