### PR TITLE
Fix all-backups-ad-laden log placement (follow-up to #107)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -819,9 +819,6 @@ twitch-videoad.js text/javascript
                                         fallbackM3u8 = m3u8Text;
                                     }
                                     if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
-                                        if (hasAdTags(m3u8Text) && !fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1) {
-                                            console.log('[AD DEBUG] All backup player types ad-laden — taking ' + playerType + ' as last-resort fallback (strip+recovery path will engage)');
-                                        }
                                         if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !hasAdTags(m3u8Text)) {
                                             const prevType = streamInfo.LastCommittedBackupPlayerType;
                                             if (prevType && prevType !== playerType) {
@@ -858,6 +855,9 @@ twitch-videoad.js text/javascript
                                     // Final type is taken as last resort either way.
                                     const inFreeze = (streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1;
                                     if (hasAdTags(m3u8Text) && (!inFreeze || playerTypeIndex >= playerTypesToTry.length - 1)) {
+                                        if (inFreeze && playerTypeIndex >= playerTypesToTry.length - 1) {
+                                            console.log('[AD DEBUG] All backup player types ad-laden during freeze — taking ' + playerType + ' as last-resort fallback (strip+recovery path will engage)');
+                                        }
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;
                                         break;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -830,9 +830,6 @@
                                         fallbackM3u8 = m3u8Text;
                                     }
                                     if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
-                                        if (hasAdTags(m3u8Text) && !fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1) {
-                                            console.log('[AD DEBUG] All backup player types ad-laden — taking ' + playerType + ' as last-resort fallback (strip+recovery path will engage)');
-                                        }
                                         if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !hasAdTags(m3u8Text)) {
                                             const prevType = streamInfo.LastCommittedBackupPlayerType;
                                             if (prevType && prevType !== playerType) {
@@ -869,6 +866,9 @@
                                     // Final type is taken as last resort either way.
                                     const inFreeze = (streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1;
                                     if (hasAdTags(m3u8Text) && (!inFreeze || playerTypeIndex >= playerTypesToTry.length - 1)) {
+                                        if (inFreeze && playerTypeIndex >= playerTypesToTry.length - 1) {
+                                            console.log('[AD DEBUG] All backup player types ad-laden during freeze — taking ' + playerType + ' as last-resort fallback (strip+recovery path will engage)');
+                                        }
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;
                                         break;


### PR DESCRIPTION
## Summary
Fixes the placement of the \`[AD DEBUG] All backup player types ad-laden\` log added in PR #107. The log was in a code block that required \`fallbackM3u8\` to be null, which never happens in practice because \`embed\` (the FallbackPlayerType) is tried first and sets \`fallbackM3u8\` even when ad-laden.

## Why
After PR #107 merged, real test data on \`pgl\` showed all 4 backup types ad-laden cycling through, then committing \`mobile_web\` as fallback — but the new debug log never fired. Investigation showed the log was inside the \`(!fallbackM3u8 && playerTypeIndex >= last)\` block, which can't be reached when embed has already been processed.

## Fix
Move the log to the actual hybrid-block last-resort commit site (where \`hasAdTags(m3u8Text) && (!inFreeze || playerTypeIndex >= last)\` triggers commit). Gate it on \`inFreeze && playerTypeIndex >= last\` so it only fires when cycling exhausted all options during a recovery freeze.

\`\`\`js
const inFreeze = (streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1;
if (hasAdTags(m3u8Text) && (!inFreeze || playerTypeIndex >= playerTypesToTry.length - 1)) {
    if (inFreeze && playerTypeIndex >= playerTypesToTry.length - 1) {
        console.log('[AD DEBUG] All backup player types ad-laden during freeze — taking ' + playerType + ' as last-resort fallback (strip+recovery path will engage)');
    }
    backupPlayerType = playerType;
    backupM3u8 = m3u8Text;
    break;
}
\`\`\`

Also removes the dead log code from the previous (wrong) location.

## Files
- \`vaft/vaft.user.js\`
- \`vaft/vaft-ublock-origin.js\`

Testing variant (\`vaft/vaft-testing-ublock-origin.js\`) was already fixed via direct master commit \`1a9ebd5\` since it has different commit logic structure.

## Test plan
- [ ] On a heavy-ad channel during a recovery freeze, when all 4 backup types are ad-laden, verify the log fires before \`Blocking ads (X)\` commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)