### PR TITLE
PR #96: skip loading-circle health check during initial player init

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1282,10 +1282,17 @@ twitch-videoad.js text/javascript
                 const player = playerForMonitoringBuffering.player;
                 const video = player?.getHTMLVideoElement?.();
                 if (video && !video.ended && !playerBufferState.userPauseIntent) {
+                    // Track whether the player has ever had data — distinguishes a real stall
+                    // (had data, lost data) from initial player init (never had data yet).
+                    // Without this, fresh page load + preroll causes PR #96 to misfire repeatedly
+                    // because readyState=0 is normal during init.
+                    if (video.readyState >= 3) {
+                        playerBufferState.hasHadData = true;
+                    }
                     const isStalled = video.readyState < 3 && (video.paused || video.networkState === 2);
                     const stallReloadCooldown = 15000;
                     const cooldownExpired = !playerBufferState.lastAdStallReloadAt || (Date.now() - playerBufferState.lastAdStallReloadAt) > stallReloadCooldown;
-                    if (isStalled && cooldownExpired) {
+                    if (isStalled && cooldownExpired && playerBufferState.hasHadData) {
                         if (!playerBufferState.adStallStartAt) {
                             playerBufferState.adStallStartAt = Date.now();
                         } else if ((Date.now() - playerBufferState.adStallStartAt) > 3000) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1293,10 +1293,17 @@
                 const player = playerForMonitoringBuffering.player;
                 const video = player?.getHTMLVideoElement?.();
                 if (video && !video.ended && !playerBufferState.userPauseIntent) {
+                    // Track whether the player has ever had data — distinguishes a real stall
+                    // (had data, lost data) from initial player init (never had data yet).
+                    // Without this, fresh page load + preroll causes PR #96 to misfire repeatedly
+                    // because readyState=0 is normal during init.
+                    if (video.readyState >= 3) {
+                        playerBufferState.hasHadData = true;
+                    }
                     const isStalled = video.readyState < 3 && (video.paused || video.networkState === 2);
                     const stallReloadCooldown = 15000;
                     const cooldownExpired = !playerBufferState.lastAdStallReloadAt || (Date.now() - playerBufferState.lastAdStallReloadAt) > stallReloadCooldown;
-                    if (isStalled && cooldownExpired) {
+                    if (isStalled && cooldownExpired && playerBufferState.hasHadData) {
                         if (!playerBufferState.adStallStartAt) {
                             playerBufferState.adStallStartAt = Date.now();
                         } else if ((Date.now() - playerBufferState.adStallStartAt) > 3000) {


### PR DESCRIPTION
## Summary
Fixes PR #96 misfiring on fresh page load + preroll, which was causing 4+ cascading reloads in the first ~60s of viewing.

## Reproduced
User refreshed twitch.tv/pgl with the script installed. During the preroll ad break:
\`\`\`
[AD DEBUG] Loading circle detected during ad break (3.0s stall, readyState=0) — early reload
Reloading Twitch player
... (5 cycling 'Blocking ads (X)' commits) ...
[AD DEBUG] Loading circle detected during ad break (3.0s stall, readyState=0) — early reload
Reloading Twitch player
... (5 more cycling commits) ...
[AD DEBUG] Loading circle detected during ad break (3.0s stall, readyState=0) — early reload
Reloading Twitch player
... (continues) ...
\`\`\`

Confirmed single-instance after PR #109 merged (only ONE \`v603 loading\` line). The cascade was internal to PR #96 misfiring.

## Root cause
\`readyState=0\` is **normal** during initial player init — the player hasn't loaded any data yet. PR #96 treated it as a stall and fired a reload, which caused another player reinit (back to readyState=0), which triggered PR #96 again, etc.

## Fix
Track \`playerBufferState.hasHadData\` flag that flips \`true\` once \`video.readyState >= 3\` is ever observed. PR #96 only fires when this flag is true.

\`\`\`js
if (video.readyState >= 3) {
    playerBufferState.hasHadData = true;
}
const isStalled = video.readyState < 3 && (video.paused || video.networkState === 2);
const cooldownExpired = ...;
if (isStalled && cooldownExpired && playerBufferState.hasHadData) {
    // ... existing fire logic
}
\`\`\`

This naturally distinguishes:
- **Initial load** (never had data) → PR #96 doesn't fire, player init proceeds normally
- **Mid-stream stall** (had data, lost data) → PR #96 fires as designed

No arbitrary time threshold. Adapts to slow/fast networks.

## Test plan
- [ ] Refresh twitch.tv/CHANNEL with the script installed during a preroll
- [ ] Verify NO \`Loading circle detected\` log fires until the player has actually had data
- [ ] Verify mid-stream freezes still trigger PR #96 normally (after the player has had data)

## Files
- \`vaft/vaft.user.js\`
- \`vaft/vaft-ublock-origin.js\`

Testing variant gets the same change applied to master in a separate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)