### PR TITLE
Frame check: use window.frameElement for Tampermonkey compatibility (fixes #112)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -10,7 +10,13 @@ twitch-videoad.js text/javascript
     // (https://dev.twitch.tv/docs/embed/video-and-clips/) — preserves Twitch streams
     // embedded on third-party sites where vaft runs in an iframe whose parent is on
     // a different origin.
-    if (window !== window.top) {
+    // Use window.frameElement to detect nested frames — null on top frame, the iframe
+    // element on a same-origin nested frame, throws on a cross-origin nested frame.
+    // More reliable than 'window !== window.top' because Tampermonkey wraps window in a
+    // proxy where the strict comparison can return true even on the top frame.
+    let _isNested = false;
+    try { _isNested = window.frameElement !== null; } catch (_e) { _isNested = true; }
+    if (_isNested) {
         const _host = document.location.hostname;
         const _isEmbedContext = _host === 'player.twitch.tv' || _host === 'embed.twitch.tv' || document.location.pathname.startsWith('/embed/');
         if (!_isEmbedContext) { return; }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -21,7 +21,13 @@
     // (https://dev.twitch.tv/docs/embed/video-and-clips/) — preserves Twitch streams
     // embedded on third-party sites where vaft runs in an iframe whose parent is on
     // a different origin.
-    if (window !== window.top) {
+    // Use window.frameElement to detect nested frames — null on top frame, the iframe
+    // element on a same-origin nested frame, throws on a cross-origin nested frame.
+    // More reliable than 'window !== window.top' because Tampermonkey wraps window in a
+    // proxy where the strict comparison can return true even on the top frame.
+    let _isNested = false;
+    try { _isNested = window.frameElement !== null; } catch (_e) { _isNested = true; }
+    if (_isNested) {
         const _host = document.location.hostname;
         const _isEmbedContext = _host === 'player.twitch.tv' || _host === 'embed.twitch.tv' || document.location.pathname.startsWith('/embed/');
         if (!_isEmbedContext) { return; }

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -10,7 +10,13 @@ twitch-videoad.js text/javascript
     // (https://dev.twitch.tv/docs/embed/video-and-clips/) — preserves Twitch streams
     // embedded on third-party sites where the script runs in an iframe whose parent
     // is on a different origin.
-    if (window !== window.top) {
+    // Use window.frameElement to detect nested frames — null on top frame, the iframe
+    // element on a same-origin nested frame, throws on a cross-origin nested frame.
+    // More reliable than 'window !== window.top' because Tampermonkey wraps window in a
+    // proxy where the strict comparison can return true even on the top frame.
+    let _isNested = false;
+    try { _isNested = window.frameElement !== null; } catch (_e) { _isNested = true; }
+    if (_isNested) {
         const _host = document.location.hostname;
         const _isEmbedContext = _host === 'player.twitch.tv' || _host === 'embed.twitch.tv' || document.location.pathname.startsWith('/embed/');
         if (!_isEmbedContext) { return; }

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -21,7 +21,13 @@
     // (https://dev.twitch.tv/docs/embed/video-and-clips/) — preserves Twitch streams
     // embedded on third-party sites where the script runs in an iframe whose parent
     // is on a different origin.
-    if (window !== window.top) {
+    // Use window.frameElement to detect nested frames — null on top frame, the iframe
+    // element on a same-origin nested frame, throws on a cross-origin nested frame.
+    // More reliable than 'window !== window.top' because Tampermonkey wraps window in a
+    // proxy where the strict comparison can return true even on the top frame.
+    let _isNested = false;
+    try { _isNested = window.frameElement !== null; } catch (_e) { _isNested = true; }
+    if (_isNested) {
         const _host = document.location.hostname;
         const _isEmbedContext = _host === 'player.twitch.tv' || _host === 'embed.twitch.tv' || document.location.pathname.startsWith('/embed/');
         if (!_isEmbedContext) { return; }


### PR DESCRIPTION
## Summary
Fixes vaft completely failing to load on Tampermonkey after PR #109's frame check was added. Reported by issue #112 and reproduced independently.

## Root cause
PR #109 added \`if (window !== window.top) return;\` to skip nested-frame injection. This works in uBlock Origin's resource override context but **fails on Tampermonkey** because Tampermonkey wraps \`window\` in a proxy/sandbox where \`window\` and \`window.top\` are different proxy instances of the same underlying object. Strict equality (\`!==\`) returns \`true\` even on the top frame, so the check incorrectly treats every page as a nested frame and returns early. Result: vaft never logs anything, never hooks fetch, never blocks ads.

## Reproduction
- Install vaft.user.js via Tampermonkey (Edge or Chrome)
- Visit twitch.tv/CHANNEL
- Console shows ZERO \`[AD DEBUG]\` lines (vaft hasn't run)
- Compare to uBO install: \`[AD DEBUG] TwitchAdSolutions vaft v45 loading\` appears

## Fix
Replace the strict equality check with \`window.frameElement\` — the canonical "am I in a nested iframe" check:

```js
let _isNested = false;
try { _isNested = window.frameElement !== null; } catch (_e) { _isNested = true; }
if (_isNested) {
    const _host = document.location.hostname;
    const _isEmbedContext = _host === 'player.twitch.tv' || _host === 'embed.twitch.tv' || document.location.pathname.startsWith('/embed/');
    if (!_isEmbedContext) { return; }
}
```

\`frameElement\` returns:
- \`null\` on the top frame (any environment, including Tampermonkey proxies)
- the iframe element on a same-origin nested iframe
- throws \`SecurityError\` on a cross-origin nested iframe

The catch defaults to \`_isNested = true\` so the embed allowlist still applies for cross-origin nested cases.

## Behavior matrix
| Scenario | frameElement | _isNested | Behavior |
|---|---|---|---|
| twitch.tv/CHANNEL top frame (uBO) | null | false | ✓ run |
| twitch.tv/CHANNEL top frame (Tampermonkey) | null | false | ✓ run (THE FIX) |
| Hidden cross-origin iframe on twitch.tv | throws | true | embed check → skip |
| twitch.tv/embed/CHANNEL nested in 3rd-party | iframe element | true | embed check → run |
| twitch.tv same-origin nested iframe | iframe element | true | embed check → skip unless embed |

## Files
- \`vaft/vaft.user.js\`
- \`vaft/vaft-ublock-origin.js\`
- \`video-swap-new/video-swap-new.user.js\`
- \`video-swap-new/video-swap-new-ublock-origin.js\`

Testing variant gets the same change applied to master in a separate commit.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)