### PR TITLE
Sync vaft_testing.user.js with vaft-testing-ublock-origin.js

### DIFF
--- a/vaft/vaft_testing.user.js
+++ b/vaft/vaft_testing.user.js
@@ -2,15 +2,39 @@
 // @name         TwitchAdSolutions (vaft-testing)
 // @namespace    https://github.com/ryanbr/TwitchAdSolutions
 // @version      604.0.0
-// @description  Multiple solutions for blocking Twitch ads (vaft)
-// @updateURL    https://github.com/ryanbr/TwitchAdSolutions/raw/master/vaft/vaft.user.js
-// @downloadURL  https://github.com/ryanbr/TwitchAdSolutions/raw/master/vaft/vaft.user.js
+// @description  Multiple solutions for blocking Twitch ads (vaft testing variant)
+// @updateURL    https://github.com/ryanbr/TwitchAdSolutions/raw/master/vaft/vaft_testing.user.js
+// @downloadURL  https://github.com/ryanbr/TwitchAdSolutions/raw/master/vaft/vaft_testing.user.js
 // @author       https://github.com/cleanlock/VideoAdBlockForTwitch#credits
 // @match        *://*.twitch.tv/*
 // @run-at       document-start
 // @grant        none
 // ==/UserScript==
 (function() {
+    if ( /(^|\.)twitch\.tv$/.test(document.location.hostname) === false ) { return; }
+    // Skip injection in nested frames that aren't legitimate Twitch embed contexts.
+    // Twitch's main channel page has 5+ hidden cross-origin iframes (auth, analytics,
+    // ad SDK, etc.) and uBO injects into all matching ones. Each becomes a racing vaft
+    // instance that fights for player control. Only the top frame hosts the player on
+    // twitch.tv/CHANNEL; nested auxiliary frames are noise.
+    // Allow-list for nested-frame injection: Twitch's three documented embed contexts
+    // (https://dev.twitch.tv/docs/embed/video-and-clips/) — preserves Twitch streams
+    // embedded on third-party sites where vaft runs in an iframe whose parent is on
+    // a different origin.
+    // Use window.frameElement to detect nested frames — null on top frame, the iframe
+    // element on a same-origin nested frame, throws on a cross-origin nested frame.
+    // More reliable than 'window !== window.top' because Tampermonkey wraps window in a
+    // proxy where the strict comparison can return true even on the top frame.
+    let _isNested = false;
+    try { _isNested = window.frameElement !== null; } catch (_e) { _isNested = true; }
+    if (_isNested) {
+        const _host = document.location.hostname;
+        const _isEmbedContext = _host === 'player.twitch.tv' || _host === 'embed.twitch.tv' || document.location.pathname.startsWith('/embed/');
+        if (!_isEmbedContext) {
+            console.log('[AD DEBUG] vaft-testing skipped — nested frame on ' + _host + document.location.pathname + ' (not a Twitch embed). If you see this on twitch.tv/CHANNEL top frame, please report.');
+            return;
+        }
+    }
     'use strict';
     const ourTwitchAdSolutionsVersion = 604;// Used to prevent conflicts with outdated versions of the scripts
     console.log('[AD DEBUG] TwitchAdSolutions vaft-testing v' + ourTwitchAdSolutionsVersion + ' loading');
@@ -22,22 +46,29 @@
     // Configuration and state shared between window and worker scopes
     function declareOptions(scope) {
         scope.AdSignifiers = ['stitched', 'stitched-ad', 'X-TV-TWITCH-AD', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-stream-source"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-ad-quartile"', 'SCTE35-OUT'];
+        scope.AdSegmentURLPatterns = ['/adsquared/', '/_404/', '/processing'];
         scope.ClientID = 'kimne78kx3ncx6brgo4mv6wki5h1ko';
         scope.BackupPlayerTypes = [
             'embed',//Source
             'site',//Source
             'popout',//Source
-            'autoplay',//360p
+            'mobile_web',//Mobile
+            // 'autoplay' (360p) removed: when committed as cycle backup, the player gets stuck
+            // in an endless loading circle after the CSAI-only path releases the backup —
+            // autoplay variants don't transition cleanly back to main stream variants.
             //'picture-by-picture-CACHED'//360p (-CACHED is an internal suffix and is removed)
         ];
         scope.FallbackPlayerType = 'embed';
         scope.ForceAccessTokenPlayerType = 'popout';
-        var hasInitialToken = false;
         scope.SkipPlayerReloadOnHevc = false;// If true this will skip player reload on streams which have 2k/4k quality (if you enable this and you use the 2k/4k quality setting you'll get error #4000 / #3000 / spinning wheel on chrome based browsers)
         scope.AlwaysReloadPlayerOnAd = false;// Always pause/play when entering/leaving ads
         scope.ReloadPlayerAfterAd = true;// After the ad finishes do a player reload instead of pause/play
         scope.ReloadCooldownSeconds = 30;// Minimum seconds between reloads — breaks CSAI cascades triggered by reload
+        scope.DisableReloadCap = false;// If true, buffer monitor reloads unlimited times (pre-v47 behavior, risk of cascade)
+        scope.DriftCorrectionRate = 1.1;// Playback rate for catching up to live edge after reload (0 = disable drift correction)
+        scope.EarlyReloadPollThreshold = 3;// Number of consecutive all-stripped polls before triggering early reload (each poll ~2s, so 3 = ~6s, 5 = ~10s, 10 = ~20s; 0 = disable)
         scope.DisableAdSpoofing = false;// If true, skip the ad-impression spoofing GQL beacons (notifyAdComplete) — for A/B testing whether spoofing affects ad break duration
+        scope.PinBackupPlayerType = true;// Remember which backup player type worked and try it first on next ad break
         scope.PlayerReloadMinimalRequestsTime = 1500;
         scope.PlayerReloadMinimalRequestsPlayerIndex = 2;//autoplay
         scope.HasTriggeredPlayerReload = false;
@@ -125,8 +156,12 @@
     }
     function isValidWorker(worker) {
         const workerString = worker.toString();
-        return !workerStringConflicts.some((x) => workerString.includes(x))
-            || workerStringReinsert.some((x) => workerString.includes(x));
+        const hasConflict = workerStringConflicts.some((x) => workerString.includes(x));
+        const hasReinsert = workerStringReinsert.some((x) => workerString.includes(x));
+        if (hasConflict && !hasReinsert) {
+            console.log('[AD DEBUG] Worker rejected — conflict string found: ' + workerStringConflicts.filter((x) => workerString.includes(x)).join(', '));
+        }
+        return !hasConflict || hasReinsert;
     }
     // Replace window.Worker to intercept Twitch's video worker and inject ad-blocking logic
     let injectedBlobUrl = null;
@@ -149,6 +184,7 @@
                 } catch {}
                 if (!isTwitchWorker) {
                     super(twitchBlobUrl, options);
+                    console.log('[AD DEBUG] Non-Twitch worker skipped: ' + twitchBlobUrl);
                     return;
                 }
                 // Pre-check: verify we can fetch the worker JS before injecting
@@ -159,10 +195,12 @@
                     console.log('[AD DEBUG] Failed to fetch worker JS — falling back to unmodified worker');
                     return;
                 }
+                console.log('[AD DEBUG] Worker intercepted — injecting ad-block hooks');
                 const newBlobStr = `
                     const pendingFetchRequests = new Map();
                     ${hasAdTags.toString()}
                     ${notifyAdComplete.toString()}
+                    ${getMatchedAdSignifiers.toString()}
                     ${stripAdSegments.toString()}
                     ${getStreamUrlForResolution.toString()}
                     ${processM3U8.toString()}
@@ -176,7 +214,13 @@
                     ${replaceServerTimeInM3u8.toString()}
                     const workerString = getWasmWorkerJs('${twitchBlobUrl.replaceAll("'", "%27")}');
                     declareOptions(self);
+                    ReloadPlayerAfterAd = ${ReloadPlayerAfterAd};
+                    ReloadCooldownSeconds = ${ReloadCooldownSeconds};
+                    DisableReloadCap = ${DisableReloadCap};
+                    PinBackupPlayerType = ${PinBackupPlayerType};
+                    EarlyReloadPollThreshold = ${EarlyReloadPollThreshold};
                     DisableAdSpoofing = ${DisableAdSpoofing};
+                    ForceAccessTokenPlayerType = '${ForceAccessTokenPlayerType}';
                     GQLDeviceID = ${GQLDeviceID ? "'" + GQLDeviceID + "'" : null};
                     AuthorizationHeader = ${AuthorizationHeader ? "'" + AuthorizationHeader + "'" : undefined};
                     ClientIntegrityHeader = ${ClientIntegrityHeader ? "'" + ClientIntegrityHeader + "'" : null};
@@ -214,6 +258,22 @@
                             }
                         } else if (e.data.key == 'TriggeredPlayerReload') {
                             HasTriggeredPlayerReload = true;
+                        } else if (e.data.key == 'ReloadSkipped') {
+                            // Main thread refused the reload (player healthy) — clear the
+                            // early-reload flags so we can re-fire if the player later stalls
+                            let cleared = false;
+                            for (const channel in StreamInfos) {
+                                const si = StreamInfos[channel];
+                                if (si && si.EarlyReloadTriggered) {
+                                    si.EarlyReloadTriggered = false;
+                                    si.EarlyReloadAwaitingResult = false;
+                                    si.EarlyReloadCount = Math.max(0, (si.EarlyReloadCount || 0) - 1);
+                                    cleared = true;
+                                }
+                            }
+                            if (cleared) {
+                                console.log('[AD DEBUG] Reload skipped by main thread (player healthy) — early reload state cleared, can retry');
+                            }
                         } else if (e.data.key == 'SimulateAds') {
                             SimulatedAdsDepth = e.data.value;
                             console.log('SimulatedAdsDepth: ' + SimulatedAdsDepth);
@@ -241,6 +301,12 @@
                             }
                         }
                         playerBufferState.inAdBreak = !!e.data.hasAds;
+                        // Clear drift catch-up when ads start — don't run 1.1x during ad handling
+                        if (e.data.hasAds && (driftCatchUpInterval || driftCatchUpTimeout)) {
+                            if (driftCatchUpInterval) { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; }
+                            if (driftCatchUpTimeout) { clearTimeout(driftCatchUpTimeout); driftCatchUpTimeout = null; }
+                            try { document.querySelector('video').playbackRate = 1.0; } catch {}
+                        }
                     } else if (e.data.key == 'PauseResumePlayer') {
                         doTwitchPlayerTask(true, false);
                     } else if (e.data.key == 'ReloadPlayer') {
@@ -326,6 +392,7 @@
                                     streamInfo = null;
                                 }
                                 if (streamInfo == null || streamInfo.EncodingsM3U8 == null) {
+                                    console.log('[AD DEBUG] New stream session — channel: ' + channelName + ', API: ' + (V2API ? 'v2' : 'v1'));
                                     StreamInfos[channelName] = streamInfo = {
                                         ChannelName: channelName,
                                         IsShowingAd: false,
@@ -339,11 +406,17 @@
                                         ResolutionList: [],
                                         BackupEncodingsM3U8Cache: [],
                                         ActiveBackupPlayerType: null,
+                                        PinnedBackupPlayerType: null,
+                                        HasCheckedUnknownTags: false,
                                         IsMidroll: false,
                                         IsStrippingAdSegments: false,
                                         NumStrippedAdSegments: 0,
-                                        HasCheckedUnknownTags: false,
-                                        HasLoggedAdAttributes: false
+                                        RecoverySegments: [],
+                                        FailedBackupPlayerTypes: new Map(),// Map<playerType, timestamp> — failures expire after 15s for retry
+                                        CleanPlaylistCount: 0,
+                                        HasLoggedAdAttributes: false,
+                                        LoggedBackupAdsByType: null,
+                                        RecoveryStartSeq: undefined
                                     };
                                     const lines = encodingsM3u8.split(/\r?\n/);
                                     for (let i = 0; i < lines.length - 1; i++) {
@@ -362,6 +435,9 @@
                                             }
                                             StreamInfosByUrl[lines[i + 1]] = streamInfo;
                                         }
+                                    }
+                                    if (streamInfo.ResolutionList.length === 0) {
+                                        console.log('[AD DEBUG] No resolutions parsed from encodings m3u8 — Twitch may have changed the format');
                                     }
                                     const nonHevcResolutionList = streamInfo.ResolutionList.filter((element) => element.Codecs.startsWith('avc') || element.Codecs.startsWith('av0'));
                                     if (AlwaysReloadPlayerOnAd || (nonHevcResolutionList.length > 0 && streamInfo.ResolutionList.some((element) => element.Codecs.startsWith('hev') || element.Codecs.startsWith('hvc')) && !SkipPlayerReloadOnHevc)) {
@@ -391,7 +467,11 @@
                                         }
                                     }
                                 }
-                                streamInfo.LastPlayerReload = Date.now();
+                                // Note: do NOT set streamInfo.LastPlayerReload here. It was previously
+                                // set unconditionally on new stream session creation, which caused the
+                                // first end-of-break reload of every new channel to be blocked by
+                                // cooldown — the cooldown check treated the session-creation timestamp
+                                // as a recent reload, even though no reload had actually occurred.
                                 resolve(new Response(replaceServerTimeInM3u8(streamInfo.IsUsingModifiedM3U8 ? streamInfo.ModifiedM3U8 : streamInfo.EncodingsM3U8, serverTime)));
                             } else {
                                 resolve(response);
@@ -477,10 +557,14 @@
             console.log('[AD DEBUG] Ad completion spoof failed: ' + err.message);
         }
     }
+    function getMatchedAdSignifiers(textStr) {
+        return AdSignifiers.filter((s) => textStr.includes(s));
+    }
     // Remove ad segments from an m3u8 playlist and cache their URLs for replacement
     function stripAdSegments(textStr, stripAllSegments, streamInfo) {
         let hasStrippedAdSegments = false;
         let inCueOut = false;
+        const liveSegments = [];
         const lines = textStr.split(/\r?\n/);
         const newAdUrl = 'https://twitch.tv';
         // Log ad tracking attribute names once per stream (helps identify new beacons)
@@ -495,8 +579,14 @@
             let line = lines[i];
             // Track SCTE-35 CUE-OUT/CUE-IN ad boundaries
             if (line.includes('EXT-X-CUE-OUT')) {
+                if (!inCueOut) {
+                    console.log('[AD DEBUG] SCTE-35 CUE-OUT — ad boundary entered');
+                }
                 inCueOut = true;
             } else if (line.includes('EXT-X-CUE-IN')) {
+                if (inCueOut) {
+                    console.log('[AD DEBUG] SCTE-35 CUE-IN — ad boundary exited');
+                }
                 inCueOut = false;
             }
             // Remove tracking urls which appear in the overlay UI
@@ -510,6 +600,24 @@
                 }
                 AdSegmentCache.set(segmentUrl, Date.now());
                 hasStrippedAdSegments = true;
+            } else if (i < lines.length - 1 && line.startsWith('#EXTINF') && AdSegmentURLPatterns.some((p) => lines[i + 1].includes(p))) {
+                console.log('[AD DEBUG] Ad segment detected via URL pattern: ' + lines[i + 1]);
+                AdSegmentCache.set(lines[i + 1], Date.now());
+                hasStrippedAdSegments = true;
+                streamInfo.NumStrippedAdSegments++;
+            } else if (i < lines.length - 1 && line.startsWith('#EXTINF') && isLiveSegment) {
+                liveSegments.push({ extinf: line, url: lines[i + 1] });
+            } else if (line.startsWith('#EXT-X-PART:')) {
+                // LL-HLS part: URI is inline as an attribute. Strip if it matches a known
+                // ad URL (already in cache from a parallel EXTINF strip, or matches a URL pattern).
+                // Without this, the player may use the parts path to fetch ad media via low-latency.
+                const partUriMatch = line.match(/URI="([^"]+)"/);
+                const partUri = partUriMatch ? partUriMatch[1] : '';
+                if (partUri && (AdSegmentCache.has(partUri) || AdSegmentURLPatterns.some((p) => partUri.includes(p)))) {
+                    AdSegmentCache.set(partUri, Date.now());
+                    lines[i] = '';
+                    hasStrippedAdSegments = true;
+                }
             }
             if (AdSignifiers.some((s) => line.includes(s))) {
                 hasStrippedAdSegments = true;
@@ -518,12 +626,43 @@
         if (hasStrippedAdSegments) {
             for (let i = 0; i < lines.length; i++) {
                 // No low latency during ads (otherwise it's possible for the player to prefetch and display ad segments)
-                if (lines[i].startsWith('#EXT-X-TWITCH-PREFETCH:')) {
+                if (lines[i].startsWith('#EXT-X-TWITCH-PREFETCH:') || lines[i].startsWith('#EXT-X-PRELOAD-HINT:')) {
                     lines[i] = '';
                 }
             }
         } else {
             streamInfo.NumStrippedAdSegments = 0;
+        }
+        // Cache live segments for recovery (plus the MEDIA-SEQUENCE of the oldest cached segment,
+        // so the player accepts injected recovery segments as the correct position in the stream)
+        if (liveSegments.length > 0) {
+            streamInfo.RecoverySegments = liveSegments.slice(-6);
+            const seq = parseInt((textStr.match(/#EXT-X-MEDIA-SEQUENCE:(\d+)/) || [])[1]);
+            if (!isNaN(seq)) {
+                streamInfo.RecoveryStartSeq = seq + Math.max(0, liveSegments.length - streamInfo.RecoverySegments.length);
+            }
+        }
+        // If all segments were stripped, restore cached recovery segments to prevent black screen
+        if (hasStrippedAdSegments && liveSegments.length === 0 && streamInfo.RecoverySegments && streamInfo.RecoverySegments.length > 0) {
+            streamInfo.ConsecutiveAllStrippedPolls = (streamInfo.ConsecutiveAllStrippedPolls || 0) + 1;
+            streamInfo.TotalAllStrippedPolls = (streamInfo.TotalAllStrippedPolls || 0) + 1;
+            if (!streamInfo.FreezeStartedAt) streamInfo.FreezeStartedAt = Date.now();
+            console.log('[AD DEBUG] All segments stripped — restoring ' + streamInfo.RecoverySegments.length + ' recovery segments');
+            if (streamInfo.RecoveryStartSeq !== undefined) {
+                for (let j = 0; j < lines.length; j++) {
+                    if (lines[j].startsWith('#EXT-X-MEDIA-SEQUENCE:')) {
+                        lines[j] = '#EXT-X-MEDIA-SEQUENCE:' + streamInfo.RecoveryStartSeq;
+                        break;
+                    }
+                }
+            }
+            for (let j = 0; j < streamInfo.RecoverySegments.length; j++) {
+                lines.push(streamInfo.RecoverySegments[j].extinf);
+                lines.push(streamInfo.RecoverySegments[j].url);
+            }
+        } else if (liveSegments.length > 0) {
+            // Reset freeze counter when live segments are available
+            streamInfo.ConsecutiveAllStrippedPolls = 0;
         }
         streamInfo.IsStrippingAdSegments = hasStrippedAdSegments;
         const now = Date.now();
@@ -576,12 +715,35 @@
             HasTriggeredPlayerReload = false;
             streamInfo.LastPlayerReload = Date.now();
         }
+        if (!streamInfo.HasCheckedUnknownTags) {
+            streamInfo.HasCheckedUnknownTags = true;
+            const unknownAdTags = textStr.match(/#EXT[^:\n]*(?:ad|cue|scte|sponsor)[^:\n]*/gi);
+            if (unknownAdTags) {
+                const unknown = unknownAdTags.filter(t => !AdSignifiers.some(s => t.includes(s)));
+                if (unknown.length > 0) {
+                    console.log('[AD DEBUG] Unknown ad-related tags found: ' + [...new Set(unknown)].join(', '));
+                }
+            }
+        }
         const haveAdTags = hasAdTags(textStr) || SimulatedAdsDepth > 0;
         if (haveAdTags) {
+            streamInfo.CleanPlaylistCount = 0;
             streamInfo.IsMidroll = textStr.includes('"MIDROLL"') || textStr.includes('"midroll"');
             if (!streamInfo.IsShowingAd) {
                 streamInfo.IsShowingAd = true;
-                console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName);
+                streamInfo.AdBreakStartedAt = Date.now();
+                const podLengthMatch = textStr.match(/X-TV-TWITCH-AD-POD-LENGTH="(\d+)"/);
+                const podLength = podLengthMatch ? parseInt(podLengthMatch[1], 10) : 1;
+                // Reset early-reload state for new ad break; allow up to one early reload per ad in pod
+                streamInfo.PodLength = podLength;
+                streamInfo.EarlyReloadTriggered = false;
+                streamInfo.EarlyReloadCount = 0;
+                streamInfo.EarlyReloadAtPoll = 0;
+                streamInfo.SawCSAIFastPath = false;
+                streamInfo.LastCommittedBackupPlayerType = null;
+                streamInfo.FreezeStartedAt = 0;
+                streamInfo.CycleRescuedThisBreak = false;
+                console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName + ', pod: ' + podLength + ' ad(s) (~' + (podLength * 30) + 's expected), signifiers: ' + getMatchedAdSignifiers(textStr).join(', '));
                 if (!DisableAdSpoofing) {
                     notifyAdComplete(textStr);
                 }
@@ -633,6 +795,7 @@
                 }
             }
             if (!hasNonLiveSegment && !streamInfo.IsUsingModifiedM3U8) {
+                streamInfo.SawCSAIFastPath = true;
                 console.log('[AD DEBUG] CSAI fast path — all segments live, skipping backup search');
                 if (IsAdStrippingEnabled) {
                     textStr = stripAdSegments(textStr, false, streamInfo);
@@ -647,6 +810,7 @@
                 });
                 return textStr;
             }
+            const backupSearchStart = Date.now();
             let backupPlayerType = null;
             let backupM3u8 = null;
             let fallbackM3u8 = null;
@@ -657,9 +821,22 @@
                 startIndex = PlayerReloadMinimalRequestsPlayerIndex;
                 isDoingMinimalRequests = true;
             }
-            for (let playerTypeIndex = startIndex; !backupM3u8 && playerTypeIndex < BackupPlayerTypes.length; playerTypeIndex++) {
-                const playerType = BackupPlayerTypes[playerTypeIndex];
+            // Try pinned backup player type first if available
+            const playerTypesToTry = [...BackupPlayerTypes];
+            if (streamInfo.PinnedBackupPlayerType) {
+                const pinnedIndex = playerTypesToTry.indexOf(streamInfo.PinnedBackupPlayerType);
+                if (pinnedIndex > 0) {
+                    playerTypesToTry.splice(pinnedIndex, 1);
+                    playerTypesToTry.unshift(streamInfo.PinnedBackupPlayerType);
+                }
+            }
+            for (let playerTypeIndex = startIndex; !backupM3u8 && playerTypeIndex < playerTypesToTry.length; playerTypeIndex++) {
+                const playerType = playerTypesToTry[playerTypeIndex];
                 const realPlayerType = playerType.replace('-CACHED', '');
+                const failedAt = streamInfo.FailedBackupPlayerTypes.get(realPlayerType);
+                if (failedAt && (Date.now() - failedAt) < 15000) {
+                    continue;
+                }
                 const isFullyCachedPlayerType = playerType != realPlayerType;
                 for (let i = 0; i < 2; i++) {
                     // This caches the m3u8 if it doesn't have ads. If the already existing cache has ads it fetches a new version (second loop)
@@ -671,6 +848,10 @@
                             const accessTokenResponse = await getAccessToken(streamInfo.ChannelName, realPlayerType);
                             if (accessTokenResponse.status === 200) {
                                 const accessToken = await accessTokenResponse.json();
+                                if (!accessToken?.data?.streamPlaybackAccessToken) {
+                                    console.log('[AD DEBUG] GQL response format changed — missing data.streamPlaybackAccessToken for ' + realPlayerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken?.data || accessToken || {})));
+                                    continue;
+                                }
                                 const urlInfo = new URL('https://usher.ttvnw.net/api/' + (V2API ? 'v2/' : '') + 'channel/hls/' + streamInfo.ChannelName + '.m3u8' + streamInfo.UsherParams);
                                 urlInfo.searchParams.set('sig', accessToken.data.streamPlaybackAccessToken.signature);
                                 urlInfo.searchParams.set('token', accessToken.data.streamPlaybackAccessToken.value);
@@ -684,9 +865,11 @@
                                 let errorBody = '';
                                 try { errorBody = ' — ' + (await accessTokenResponse.text()).substring(0, 200); } catch {}
                                 console.log('[AD DEBUG] Access token HTTP ' + accessTokenResponse.status + ' for ' + realPlayerType + (accessTokenResponse.status === 403 ? ' (integrity: ' + (ClientIntegrityHeader ? 'present' : 'missing') + ')' : '') + errorBody);
+                                streamInfo.FailedBackupPlayerTypes.set(realPlayerType, Date.now());
                             }
                         } catch (err) {
                             console.log('[AD DEBUG] Access token failed for ' + realPlayerType + ': ' + err.message);
+                            streamInfo.FailedBackupPlayerTypes.set(realPlayerType, Date.now());
                         }
                     }
                     if (encodingsM3u8) {
@@ -699,7 +882,20 @@
                                     if (playerType == FallbackPlayerType) {
                                         fallbackM3u8 = m3u8Text;
                                     }
-                                    if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= BackupPlayerTypes.length - 1)) {
+                                    if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
+                                        if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 2 && !hasAdTags(m3u8Text)) {
+                                            const prevType = streamInfo.LastCommittedBackupPlayerType;
+                                            if (prevType && prevType !== playerType) {
+                                                console.log('[AD DEBUG] Cycle switched to different clean type (' + playerType + ', was ' + prevType + ') during freeze — recovered without reload');
+                                                // Only mark as cycle-rescued when we ACTUALLY switched player types.
+                                                // Natural recovery (same type became clean) still needs the end-of-break
+                                                // reload to refresh the player buffer — skipping it leaves the player
+                                                // stuck with low buffer and the buffer monitor unable to recover.
+                                                streamInfo.CycleRescuedThisBreak = true;
+                                            } else {
+                                                console.log('[AD DEBUG] Same backup type (' + playerType + ') became clean during freeze — natural recovery');
+                                            }
+                                        }
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;
                                         break;
@@ -711,9 +907,16 @@
                                             console.log('[AD DEBUG] Backup stream (' + playerType + ') also has ads');
                                         }
                                     }
-                                    // If backup also has ads, take it immediately — trying other
-                                    // player types won't help (Twitch serves ads across all types)
-                                    if (hasAdTags(m3u8Text) || isFullyCachedPlayerType || isDoingMinimalRequests) {
+                                    if (isFullyCachedPlayerType) {
+                                        break;
+                                    }
+                                    // Keep iterating other player types in case one is clean.
+                                    // Take ad-laden backup as last resort: minimal-requests window,
+                                    // 3+ ad breaks with 0 strips (false positive), or final type tried.
+                                    if (isDoingMinimalRequests || streamInfo.ConsecutiveZeroStripBreaks >= 3 || playerTypeIndex >= playerTypesToTry.length - 1) {
+                                        if (playerTypeIndex >= playerTypesToTry.length - 1 && !isDoingMinimalRequests && streamInfo.ConsecutiveZeroStripBreaks < 3) {
+                                            console.log('[AD DEBUG] All backup player types ad-laden — taking ' + playerType + ' as last-resort fallback (strip+recovery path will engage)');
+                                        }
                                         backupPlayerType = playerType;
                                         backupM3u8 = m3u8Text;
                                         break;
@@ -738,12 +941,20 @@
             }
             if (backupM3u8) {
                 textStr = backupM3u8;
+                streamInfo.LastCommittedBackupPlayerType = backupPlayerType;
                 if (streamInfo.ActiveBackupPlayerType != backupPlayerType) {
                     streamInfo.ActiveBackupPlayerType = backupPlayerType;
-                    console.log(`Blocking${(streamInfo.IsMidroll ? ' midroll ' : ' ')}ads (${backupPlayerType})`);
+                    // Auto-pin source-quality backup types (embed, site, popout) to skip failed types on next break.
+                    // Never auto-pin low-quality types (autoplay, mobile_web) to avoid quality lock.
+                    const sourceQualityTypes = ['embed', 'site', 'popout'];
+                    if (PinBackupPlayerType || sourceQualityTypes.includes(backupPlayerType)) {
+                        streamInfo.PinnedBackupPlayerType = backupPlayerType;
+                    }
+                    console.log(`Blocking${(streamInfo.IsMidroll ? ' midroll ' : ' ')}ads (${backupPlayerType}) — backup found in ${Date.now() - backupSearchStart}ms`);
+                    streamInfo.LastBackupSwitch = Date.now();
                 }
             } else {
-                console.log('[AD DEBUG] No ad-free backup stream found — ads may leak. Tried: ' + BackupPlayerTypes.slice(startIndex).join(', '));
+                console.log('[AD DEBUG] No ad-free backup stream found — ads may leak. Tried: ' + playerTypesToTry.slice(startIndex).join(', '));
             }
             // TODO: Improve hevc stripping. It should always strip when there is a codec mismatch (both ways)
             const stripHevc = isHevc && streamInfo.ModifiedM3U8;
@@ -752,61 +963,132 @@
             } else if (!backupM3u8) {
                 console.log('[AD DEBUG] Ad stripping disabled and no backup — ads WILL show');
             }
+            // Log reload outcome on the poll after early reload triggered
+            if (streamInfo.EarlyReloadAwaitingResult) {
+                streamInfo.EarlyReloadAwaitingResult = false;
+                if (textStr.includes(',live') && streamInfo.IsStrippingAdSegments) {
+                    console.log('[AD DEBUG] Early reload result: partial — some live segments returned');
+                } else if (!streamInfo.IsStrippingAdSegments) {
+                    console.log('[AD DEBUG] Early reload result: clean — freeze ended');
+                    // Reset trigger flag so subsequent freezes within the same pod can re-fire (bounded by EarlyReloadCount/PodLength)
+                    streamInfo.EarlyReloadTriggered = false;
+                } else {
+                    console.log('[AD DEBUG] Early reload result: still ads — continuing recovery loop');
+                }
+            }
+            // Early reload during prolonged freeze: if we've been looping recovery segments
+            // for N+ polls, trigger a reload to attempt fresh content. Bounded to one reload
+            // per ad in the pod (e.g. 2-ad pod = up to 2 early reloads).
+            const maxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
+            // Thin recovery cache fast path: when fewer than 3 live segments are cached
+            // for fallback, the player will burn through them in seconds. Trigger early
+            // reload immediately on the first all-stripped poll instead of waiting for
+            // the normal threshold — the ~1-2s reload disruption is much shorter than
+            // the strip+buffer-rebuild stall that would otherwise occur (~10-15s).
+            const recoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
+            const effectiveThreshold = recoveryThin ? 1 : EarlyReloadPollThreshold;
+            if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= effectiveThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < maxEarlyReloads) {
+                streamInfo.EarlyReloadTriggered = true;
+                streamInfo.EarlyReloadAwaitingResult = true;
+                streamInfo.EarlyReloadCount = (streamInfo.EarlyReloadCount || 0) + 1;
+                streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
+                const reason = recoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
+                console.log('[AD DEBUG] Early reload triggered — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + reason + ' [' + streamInfo.EarlyReloadCount + '/' + maxEarlyReloads + ']');
+                postMessage({ key: 'ReloadPlayer' });
+            }
         } else if (streamInfo.IsShowingAd) {
-            console.log('Finished blocking ads — stripped ' + streamInfo.NumStrippedAdSegments + ' ad segments');
-            const hadStrippedSegments = streamInfo.NumStrippedAdSegments > 0;
-            if (!hadStrippedSegments) {
-                if (!streamInfo.ConsecutiveZeroStripBreaks) streamInfo.ConsecutiveZeroStripBreaks = 0;
-                streamInfo.ConsecutiveZeroStripBreaks++;
-                if (streamInfo.ConsecutiveZeroStripBreaks >= 3) {
-                    console.log('[AD DEBUG] Warning: ' + streamInfo.ConsecutiveZeroStripBreaks + ' consecutive ad breaks with 0 segments stripped — possible false positive from ad signifiers');
+            streamInfo.CleanPlaylistCount++;
+            // Check if the current playlist has live segments — if not, backup stream is dead
+            const hasLiveSegments = textStr.includes(',live');
+            if (streamInfo.CleanPlaylistCount >= 2 || !hasLiveSegments) {
+                if (!hasLiveSegments) {
+                    console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
                 }
-            } else {
-                streamInfo.ConsecutiveZeroStripBreaks = 0;
-            }
-            streamInfo.IsShowingAd = false;
-            streamInfo.IsStrippingAdSegments = false;
-            streamInfo.NumStrippedAdSegments = 0;
-            streamInfo.ActiveBackupPlayerType = null;
-            streamInfo.RequestedAds.clear();
-            if (streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType.clear();
-            // Auto-escalate cooldown: if 3+ reloads in last 2 min, triple the cooldown to reduce cascade pressure
-            if (!streamInfo.ReloadTimestamps) streamInfo.ReloadTimestamps = [];
-            streamInfo.ReloadTimestamps = streamInfo.ReloadTimestamps.filter(t => Date.now() - t < 300000);
-            const recentReloads = streamInfo.ReloadTimestamps.filter(t => Date.now() - t < 300000).length;
-            const effectiveCooldown = recentReloads >= 3 ? ReloadCooldownSeconds * 3 : ReloadCooldownSeconds;
-            const tooSoonSinceLastReload = streamInfo.LastPlayerReload && (Date.now() - streamInfo.LastPlayerReload) < (effectiveCooldown * 1000);
-            // CSAI-only ad break: backup was used but no segments were stripped.
-            // Skip reload entirely — avoids CSAI cascade on ad-heavy channels.
-            if (!hadStrippedSegments) {
-                console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');
-                streamInfo.IsUsingModifiedM3U8 = false;
-            } else {
-            // Reload if backup was used AND segments were stripped (need clean state). Otherwise, respect ReloadPlayerAfterAd + cooldown.
-            const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments && !tooSoonSinceLastReload);
-            if (shouldReload) {
-                streamInfo.ReloadTimestamps.push(Date.now());// Only track actual reloads, not skipped ones
-                streamInfo.IsUsingModifiedM3U8 = false;
-                streamInfo.LastPlayerReload = Date.now();
-                postMessage({
-                    key: 'ReloadPlayer'
-                });
-            } else {
-                if (tooSoonSinceLastReload) {
-                    console.log('[AD DEBUG] Skipping reload — last reload was ' + ((Date.now() - streamInfo.LastPlayerReload) / 1000).toFixed(0) + 's ago (cooldown: ' + effectiveCooldown + 's' + (recentReloads >= 3 ? ', auto-escalated from ' + recentReloads + ' reloads in 5min' : '') + ')');
+                const adBreakDurationSec = streamInfo.AdBreakStartedAt ? ((Date.now() - streamInfo.AdBreakStartedAt) / 1000).toFixed(1) : '?';
+                console.log('Finished blocking ads — stripped ' + streamInfo.NumStrippedAdSegments + ' ad segments, duration: ' + adBreakDurationSec + 's (IsUsingModifiedM3U8: ' + streamInfo.IsUsingModifiedM3U8 + ')');
+                if (streamInfo.TotalAllStrippedPolls > 0) {
+                    const reloadInfo = streamInfo.EarlyReloadAtPoll ? ', early reload at poll ' + streamInfo.EarlyReloadAtPoll : '';
+                    const wallClockFreeze = streamInfo.FreezeStartedAt ? ((Date.now() - streamInfo.FreezeStartedAt) / 1000).toFixed(1) + 's wall-clock' : 'unknown';
+                    console.log('[AD DEBUG] Ad break stats: ' + streamInfo.TotalAllStrippedPolls + ' all-stripped polls, freeze duration: ' + wallClockFreeze + reloadInfo);
                 }
-                postMessage({
-                    key: 'PauseResumePlayer'
-                });
+                const hadStrippedSegments = streamInfo.NumStrippedAdSegments > 0;
+                // Only count toward false-positive guard if it was NOT a CSAI-only break.
+                // CSAI breaks are real ads delivered outside the m3u8 — they legitimately
+                // produce 0 stripped segments and should not be flagged as false positives.
+                if (!hadStrippedSegments && !streamInfo.SawCSAIFastPath) {
+                    if (!streamInfo.ConsecutiveZeroStripBreaks) streamInfo.ConsecutiveZeroStripBreaks = 0;
+                    streamInfo.ConsecutiveZeroStripBreaks++;
+                    if (streamInfo.ConsecutiveZeroStripBreaks >= 3) {
+                        console.log('[AD DEBUG] Warning: ' + streamInfo.ConsecutiveZeroStripBreaks + ' consecutive non-CSAI ad breaks with 0 segments stripped — possible false positive from ad signifiers');
+                    }
+                } else if (hadStrippedSegments) {
+                    streamInfo.ConsecutiveZeroStripBreaks = 0;
+                }
+                streamInfo.IsShowingAd = false;
+                streamInfo.IsStrippingAdSegments = false;
+                streamInfo.NumStrippedAdSegments = 0;
+                streamInfo.ActiveBackupPlayerType = null;
+                streamInfo.RequestedAds.clear();
+                streamInfo.FailedBackupPlayerTypes.clear();
+                if (streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType.clear();
+                streamInfo.CleanPlaylistCount = 0;
+                streamInfo.ConsecutiveAllStrippedPolls = 0;
+                streamInfo.EarlyReloadTriggered = false;
+                streamInfo.EarlyReloadAwaitingResult = false;
+                streamInfo.EarlyReloadAtPoll = 0;
+                streamInfo.TotalAllStrippedPolls = 0;
+                // Auto-escalate cooldown: if 3+ reloads in last 2 min, triple the cooldown to reduce cascade pressure
+                if (!streamInfo.ReloadTimestamps) streamInfo.ReloadTimestamps = [];
+                streamInfo.ReloadTimestamps = streamInfo.ReloadTimestamps.filter(t => Date.now() - t < 300000);
+                const recentReloads = streamInfo.ReloadTimestamps.filter(t => Date.now() - t < 300000).length;
+                const effectiveCooldown = recentReloads >= 3 ? ReloadCooldownSeconds * 3 : ReloadCooldownSeconds;
+                const tooSoonSinceLastReload = streamInfo.LastPlayerReload && (Date.now() - streamInfo.LastPlayerReload) < (effectiveCooldown * 1000);
+                // CSAI-only ad break: backup was used but no segments were stripped.
+                // Skip reload entirely — avoids CSAI cascade on ad-heavy channels.
+                // Clearing the flag makes next m3u8 poll serve main stream seamlessly.
+                if (!hadStrippedSegments) {
+                    console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');
+                    streamInfo.IsUsingModifiedM3U8 = false;
+                } else {
+                // Skip end-of-break reload when cycle rescue handled the break cleanly:
+                // a freeze of ≤2 polls (~4s) was resolved by switching to a clean backup,
+                // and no early reload was needed. The player is on a healthy backup stream
+                // — reloading just to return to the canonical player type causes an unnecessary
+                // ~1-2s loading circle.
+                const cycleRescuedCleanly = streamInfo.CycleRescuedThisBreak &&
+                    (streamInfo.TotalAllStrippedPolls || 0) <= 2 &&
+                    (streamInfo.EarlyReloadCount || 0) === 0;
+                if (cycleRescuedCleanly) {
+                    console.log('[AD DEBUG] Cycle rescue handled the break cleanly — skipping end-of-break reload');
+                }
+                // Reload if backup was used AND segments were stripped (need clean state). Otherwise, respect ReloadPlayerAfterAd + cooldown.
+                const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments && !tooSoonSinceLastReload && !cycleRescuedCleanly);
+                console.log('[AD DEBUG] Reload decision: shouldReload=' + shouldReload + ' IsUsingModifiedM3U8=' + streamInfo.IsUsingModifiedM3U8 + ' hadStripped=' + hadStrippedSegments + ' tooSoon=' + tooSoonSinceLastReload + ' cooldown=' + effectiveCooldown + 's');
+                if (shouldReload) {
+                    streamInfo.ReloadTimestamps.push(Date.now());// Only track actual reloads, not skipped ones
+                    streamInfo.IsUsingModifiedM3U8 = false;
+                    streamInfo.LastPlayerReload = Date.now();
+                    postMessage({
+                        key: 'ReloadPlayer'
+                    });
+                } else {
+                    if (tooSoonSinceLastReload) {
+                        console.log('[AD DEBUG] Skipping reload — last reload was ' + ((Date.now() - streamInfo.LastPlayerReload) / 1000).toFixed(0) + 's ago (cooldown: ' + effectiveCooldown + 's' + (recentReloads >= 3 ? ', auto-escalated from ' + recentReloads + ' reloads in 5min' : '') + ')');
+                    }
+                    postMessage({
+                        key: 'PauseResumePlayer'
+                    });
+                }
+                }// end else (non-CSAI path)
             }
-            }// end else (non-CSAI path)
         }
         postMessage({
             key: 'UpdateAdBlockBanner',
             isMidroll: streamInfo.IsMidroll,
             hasAds: streamInfo.IsShowingAd,
             isStrippingAdSegments: streamInfo.IsStrippingAdSegments,
-            numStrippedAdSegments: streamInfo.NumStrippedAdSegments
+            numStrippedAdSegments: streamInfo.NumStrippedAdSegments,
+            activeBackupPlayerType: streamInfo.ActiveBackupPlayerType
         });
         return textStr;
     }
@@ -883,6 +1165,33 @@
         });
     }
     let playerForMonitoringBuffering = null;
+    let driftCatchUpInterval = null;
+    let driftCatchUpTimeout = null;
+    function startDriftCorrection(videoElement) {
+        if (DriftCorrectionRate <= 1) return;
+        if (driftCatchUpInterval) { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; }
+        if (driftCatchUpTimeout) { clearTimeout(driftCatchUpTimeout); driftCatchUpTimeout = null; }
+        videoElement.playbackRate = DriftCorrectionRate;
+        console.log('[AD DEBUG] Drift correction: catching up at ' + DriftCorrectionRate + 'x');
+        driftCatchUpInterval = setInterval(() => {
+            try {
+                const vid = document.querySelector('video');
+                if (vid && vid.buffered.length > 0) {
+                    if (vid.buffered.end(vid.buffered.length - 1) - vid.currentTime <= 1) {
+                        vid.playbackRate = 1.0;
+                        console.log('[AD DEBUG] Drift correction complete — resumed normal playback speed');
+                        clearInterval(driftCatchUpInterval); driftCatchUpInterval = null;
+                        if (driftCatchUpTimeout) { clearTimeout(driftCatchUpTimeout); driftCatchUpTimeout = null; }
+                    }
+                }
+            } catch { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; }
+        }, 500);
+        driftCatchUpTimeout = setTimeout(() => {
+            try { videoElement.playbackRate = 1.0; } catch {}
+            if (driftCatchUpInterval) { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; }
+            driftCatchUpTimeout = null;
+        }, 30000);
+    }
     const playerBufferState = {
         channelName: null,
         hasStreamStarted: false,
@@ -890,6 +1199,7 @@
         bufferedPosition: 0,
         bufferDuration: 0,
         numSame: 0,
+        fixAttempts: 0,
         lastFixTime: 0,
         isLive: true
     };
@@ -904,6 +1214,7 @@
                     player: playerAndState.player,
                     state: playerAndState.state
                 };
+                // Track user pause intent on the video element (once per element)
                 const video = playerAndState.player.getHTMLVideoElement?.();
                 if (video && !video.__tasIntentHooked) {
                     video.__tasIntentHooked = true;
@@ -937,6 +1248,10 @@
                               playerBufferState.channelName = channelName;
                               playerBufferState.hasStreamStarted = false;
                               playerBufferState.numSame = 0;
+                              playerBufferState.fixAttempts = 0;
+                              playerBufferState.recoveryReloadUsed = false;
+                              playerBufferState.userPauseIntent = false;
+                        playerBufferState.loggedPauseIntent = false;
                               //console.log('Channel changed to ' + channelName);
                           }
                       }
@@ -959,7 +1274,13 @@
                         ) {
                             playerBufferState.numSame++;
                             if (playerBufferState.numSame == PlayerBufferingSameStateCount) {
-                                console.log('Attempt to fix buffering position:' + playerBufferState.position + ' bufferedPosition:' + playerBufferState.bufferedPosition + ' bufferDuration:' + playerBufferState.bufferDuration);
+                                playerBufferState.fixAttempts++;
+                                // Cap: at most ONE reload per recovery window. After reloading once,
+                                // stay on pause/play until playback recovers. Prevents reload cascades.
+                                const wouldEscalate = playerBufferState.fixAttempts >= 3;
+                                const escalateToReload = wouldEscalate && (DisableReloadCap || !playerBufferState.recoveryReloadUsed);
+                                const reloadCapNote = wouldEscalate && !escalateToReload ? ' (reload cap reached, pause/play only — set twitchAdSolutions_disableReloadCap=true to bypass)' : (escalateToReload ? ' (escalating to reload)' : '');
+                                console.log('Attempt to fix buffering position:' + playerBufferState.position + ' bufferedPosition:' + playerBufferState.bufferedPosition + ' bufferDuration:' + playerBufferState.bufferDuration + reloadCapNote);
                                 // Seek past buffer gap instead of stalling
                                 const video = player.getHTMLVideoElement?.();
                                 if (video && video.buffered.length > 1) {
@@ -967,6 +1288,7 @@
                                         if (video.buffered.start(bi) > video.currentTime + 0.5) {
                                             console.log('[AD DEBUG] Seeking past ' + (video.buffered.start(bi) - video.currentTime).toFixed(1) + 's buffer gap');
                                             video.currentTime = video.buffered.start(bi);
+                                            startDriftCorrection(video);
                                             break;
                                         }
                                     }
@@ -974,14 +1296,26 @@
                                 if (video) {
                                     console.log('[AD DEBUG] Video state: readyState=' + video.readyState + ' networkState=' + video.networkState + ' buffered=' + (video.buffered.length > 0 ? video.buffered.end(video.buffered.length - 1).toFixed(1) : 0) + ' currentTime=' + video.currentTime.toFixed(1) + ' paused=' + video.paused);
                                 }
-                                const isPausePlay = !PlayerBufferingDoPlayerReload;
-                                const isReload = PlayerBufferingDoPlayerReload;
+                                const isPausePlay = escalateToReload ? false : !PlayerBufferingDoPlayerReload;
+                                const isReload = escalateToReload ? true : PlayerBufferingDoPlayerReload;
                                 doTwitchPlayerTask(isPausePlay, isReload);
                                 playerBufferState.lastFixTime = Date.now();
                                 playerBufferState.numSame = 0;
+                                if (escalateToReload) {
+                                    playerBufferState.fixAttempts = 0;
+                                    playerBufferState.recoveryReloadUsed = true;
+                                }
                             }
                         } else {
                             playerBufferState.numSame = 0;
+                            playerBufferState.fixAttempts = 0;
+                            playerBufferState.recoveryReloadUsed = false;
+                        }
+                        // Detect position jump (native gap recovery) — drift to catch up
+                        // Skip during ad breaks and 10s after: backup stream switching causes buffer gaps that trigger false jumps
+                        if (playerBufferState.position > 0 && position - playerBufferState.position > 5 && !playerBufferState.inAdBreak && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000)) {
+                            console.log('[AD DEBUG] Position jumped ' + (position - playerBufferState.position).toFixed(1) + 's — starting drift correction');
+                            startDriftCorrection(player.getHTMLVideoElement?.());
                         }
                         playerBufferState.position = position;
                         playerBufferState.bufferedPosition = bufferedPosition;
@@ -994,6 +1328,42 @@
                 console.error('error when monitoring player for buffering: ' + err);
                 playerForMonitoringBuffering = null;
             }
+        }
+        // Loading-circle health check: during an ad strip+recovery loop the normal buffer monitor
+        // is gated off (isActivelyStrippingAds), so a visibly stalled player would otherwise wait
+        // for the worker's poll-based early reload (~10s). This catches the visible stall ~3s after
+        // it starts and triggers a reload directly, eliminating most of the loading-circle window.
+        if (isActivelyStrippingAds && playerForMonitoringBuffering) {
+            try {
+                const player = playerForMonitoringBuffering.player;
+                const video = player?.getHTMLVideoElement?.();
+                if (video && !video.ended && !playerBufferState.userPauseIntent) {
+                    // Track whether the player has ever had data — distinguishes a real stall
+                    // (had data, lost data) from initial player init (never had data yet).
+                    // Without this, fresh page load + preroll causes PR #96 to misfire repeatedly
+                    // because readyState=0 is normal during init.
+                    if (video.readyState >= 3) {
+                        playerBufferState.hasHadData = true;
+                    }
+                    const isStalled = video.readyState < 3 && (video.paused || video.networkState === 2);
+                    const stallReloadCooldown = 15000;
+                    const cooldownExpired = !playerBufferState.lastAdStallReloadAt || (Date.now() - playerBufferState.lastAdStallReloadAt) > stallReloadCooldown;
+                    if (isStalled && cooldownExpired && playerBufferState.hasHadData) {
+                        if (!playerBufferState.adStallStartAt) {
+                            playerBufferState.adStallStartAt = Date.now();
+                        } else if ((Date.now() - playerBufferState.adStallStartAt) > 3000) {
+                            console.log('[AD DEBUG] Loading circle detected during ad break (' + ((Date.now() - playerBufferState.adStallStartAt) / 1000).toFixed(1) + 's stall, readyState=' + video.readyState + ') — early reload');
+                            playerBufferState.lastAdStallReloadAt = Date.now();
+                            playerBufferState.adStallStartAt = 0;
+                            doTwitchPlayerTask(false, true);
+                        }
+                    } else if (!isStalled) {
+                        playerBufferState.adStallStartAt = 0;
+                    }
+                }
+            } catch {}
+        } else if (!isActivelyStrippingAds && playerBufferState.adStallStartAt) {
+            playerBufferState.adStallStartAt = 0;
         }
         const isLive = playerForMonitoringBuffering?.state?.props?.content?.type === 'live';
         if (playerBufferState.isLive && !isLive) {
@@ -1016,46 +1386,6 @@
         const shouldThrottle = typeof document !== 'undefined' && document.hidden && !document.pictureInPictureElement;
         const nextDelay = shouldThrottle ? PlayerBufferingDelay * 3 : PlayerBufferingDelay;
         setTimeout(monitorPlayerBuffering, nextDelay);
-    }
-    // Auto-recover from player errors (#2000, #3000, #4000) by reloading the page
-    const PLAYER_ERROR_MAX_RETRIES = 3;
-    const PLAYER_ERROR_COOLDOWN = 5000;// 5s cooldown between recovery attempts
-    function getPlayerErrorRetries() {
-        return parseInt(sessionStorage.getItem('twitchAdSolutions_errorRetries') || '0', 10);
-    }
-    function setPlayerErrorRetries(count) {
-        sessionStorage.setItem('twitchAdSolutions_errorRetries', String(count));
-    }
-    function clearPlayerErrorRetries() {
-        sessionStorage.removeItem('twitchAdSolutions_errorRetries');
-    }
-    let lastPlayerErrorTime = 0;
-    function monitorPlayerErrors() {
-        const contentGate = document.querySelector('[data-a-target="player-overlay-content-gate"]');
-        if (contentGate) {
-            const text = contentGate.textContent;
-            if (text.includes('#2000') || text.includes('#3000') || text.includes('#4000')) {
-                const now = Date.now();
-                if (now - lastPlayerErrorTime > PLAYER_ERROR_COOLDOWN) {
-                    const retries = getPlayerErrorRetries() + 1;
-                    setPlayerErrorRetries(retries);
-                    lastPlayerErrorTime = now;
-                    if (retries <= PLAYER_ERROR_MAX_RETRIES) {
-                        console.log('[AD DEBUG] Player error detected, reloading page (attempt ' + retries + '/' + PLAYER_ERROR_MAX_RETRIES + ')');
-                        window.location.reload();
-                        return;
-                    } else {
-                        console.log('[AD DEBUG] Player error persists after ' + PLAYER_ERROR_MAX_RETRIES + ' retries, giving up');
-                    }
-                }
-            }
-        } else {
-            // Player is working, clear retry counter
-            if (getPlayerErrorRetries() > 0) {
-                clearPlayerErrorRetries();
-            }
-        }
-        setTimeout(monitorPlayerErrors, 3000);
     }
     // Hide Twitch's ad break / Turbo promo overlay when we're already blocking ads
     function hideTwitchAdOverlays() {
@@ -1090,7 +1420,7 @@
             }
             if (adBlockDiv != null) {
                 isActivelyStrippingAds = data.isStrippingAdSegments;
-                adBlockDiv.P.textContent = 'Blocking' + (data.isMidroll ? ' midroll' : '') + ' ads' + (data.isStrippingAdSegments ? ' (stripping)' : '');// + (data.numStrippedAdSegments > 0 ? ` (${data.numStrippedAdSegments})` : '');
+                adBlockDiv.P.textContent = 'Blocking' + (data.isMidroll ? ' midroll' : '') + ' ads' + (data.isStrippingAdSegments ? ' (stripping)' : '') + (data.activeBackupPlayerType ? ' (' + data.activeBackupPlayerType + ')' : '');
                 adBlockDiv.style.display = data.hasAds && playerBufferState.isLive ? 'block' : 'none';
             }
             if (data.hasAds) {
@@ -1141,6 +1471,14 @@
             player = player.playerInstance;
         }
         const playerState = findReactNode(reactRootNode, node => node.setSrc && node.setInitialPlaybackSettings);
+        if (!player && !getPlayerAndState.loggedNoPlayer) {
+            getPlayerAndState.loggedNoPlayer = true;
+            console.log('[AD DEBUG] Player not found — Twitch may have renamed setPlayerActive/mediaPlayerInstance');
+        }
+        if (!playerState && !getPlayerAndState.loggedNoState) {
+            getPlayerAndState.loggedNoState = true;
+            console.log('[AD DEBUG] Player state not found — Twitch may have renamed setSrc/setInitialPlaybackSettings');
+        }
         return  {
             player: player,
             state: playerState
@@ -1150,7 +1488,6 @@
     function doTwitchPlayerTask(isPausePlay, isReload) {
         const playerAndState = getPlayerAndState();
         if (!playerAndState) {
-            console.log('Could not find react root');
             return;
         }
         const player = playerAndState.player;
@@ -1163,14 +1500,26 @@
             console.log('Could not find player state');
             return;
         }
-        if (player.isPaused() || player.core?.paused) {
+        const wasPaused = player.isPaused() || player.core?.paused;
+        // Only block pause/play toggle if already paused — still allow reloads
+        if (isPausePlay && wasPaused) {
+            // User deliberately paused — respect their intent, don't auto-resume
+            if (playerBufferState.userPauseIntent) {
+                if (!playerBufferState.loggedPauseIntent) {
+                    playerBufferState.loggedPauseIntent = true;
+                    console.log('[AD DEBUG] Respecting user pause intent — skipping auto-resume');
+                }
+                return;
+            }
             // If WE recently called pause/play and player is still paused, retry play (stuck from autoplay policy or ad-state interference)
             if (playerBufferState.weJustPaused && (Date.now() - playerBufferState.weJustPaused) < 10000) {
                 try { player.play()?.catch?.(() => {}); } catch {}
             }
             return;
         }
-        playerBufferState.weJustPaused = 0;
+        if (!wasPaused) {
+            playerBufferState.weJustPaused = 0;
+        }
         playerBufferState.lastFixTime = Date.now();
         playerBufferState.numSame = 0;
         if (isPausePlay) {
@@ -1184,6 +1533,7 @@
             const video = player.getHTMLVideoElement?.();
             if (video && video.readyState >= 3 && !video.paused && !video.ended) {
                 console.log('[AD DEBUG] Skipping reload — player healthy (readyState=' + video.readyState + ', playing)');
+                postTwitchWorkerMessage('ReloadSkipped');
                 return;
             }
         }
@@ -1207,11 +1557,24 @@
                 }
             } catch {}
             playerBufferState.lastReloadAt = Date.now();
-            playerForMonitoringBuffering = null;// Force re-acquire player ref after reload — old ref reads stale buffer state
+            playerBufferState.userPauseIntent = false;
+            playerBufferState.loggedPauseIntent = false;
+            // playerForMonitoringBuffering re-acquired fresh every tick — no manual invalidation needed
             console.log('Reloading Twitch player');
             playerState.setSrc({ isNewMediaPlayerInstance: true, refreshAccessToken: true });
             postTwitchWorkerMessage('TriggeredPlayerReload');
-            player.play()?.catch?.(() => {});
+            // Resume playback with retry — only if user hadn't manually paused
+            if (!wasPaused) {
+                player.play()?.catch?.(() => {});
+                // Retry resume if play() didn't take effect
+                setTimeout(() => {
+                    try {
+                        if (player.isPaused() && !player.core?.paused) {
+                            player.play()?.catch?.(() => {});
+                        }
+                    } catch {}
+                }, 1500);
+            }
             // Always restore muted/volume state after reload — Chrome autoplay policy can force muted
             if (currentQualityLS || currentMutedLS || currentVolumeLS) {
                 setTimeout(() => {
@@ -1224,6 +1587,19 @@
                         }
                         if (currentVolumeLS) {
                             localStorage.setItem(lsKeyVolume, currentVolumeLS);
+                        }
+                        const videos = document.getElementsByTagName('video');
+                        if (videos.length > 0 && videos[0].muted) {
+                            videos[0].muted = false;
+                        }
+                        // Correct live drift after reload
+                        if (videos.length > 0 && videos[0].buffered.length > 0 && videos[0].readyState >= 3) {
+                            const liveEdge = videos[0].buffered.end(videos[0].buffered.length - 1);
+                            const drift = liveEdge - videos[0].currentTime;
+                            if (drift > 2) {
+                                console.log('[AD DEBUG] Post-reload live drift correction: ' + drift.toFixed(1) + 's behind');
+                                startDriftCorrection(videos[0]);
+                            }
                         }
                     } catch {}
                 }, 3000);
@@ -1260,6 +1636,8 @@
     }
     // Hook fetch() in the window scope to capture auth headers and modify player type requests
     function hookFetch() {
+        console.log('[AD DEBUG] Window fetch hook installed');
+        let hasLoggedHeaders = false;
         const realFetch = window.fetch;
         window.realFetch = realFetch;
         window.fetch = maskAsNative(function(url, init, ...args) {
@@ -1285,34 +1663,33 @@
                     if (typeof init.headers['Authorization'] === 'string' && init.headers['Authorization'] !== AuthorizationHeader) {
                         postTwitchWorkerMessage('UpdateAuthorizationHeader', AuthorizationHeader = init.headers['Authorization']);
                     }
+                    if (!hasLoggedHeaders && GQLDeviceID && AuthorizationHeader) {
+                        hasLoggedHeaders = true;
+                        console.log('[AD DEBUG] GQL headers captured — DeviceId: ' + (GQLDeviceID ? 'yes' : 'no') + ', Auth: ' + (AuthorizationHeader ? 'yes' : 'no') + ', Integrity: ' + (ClientIntegrityHeader ? 'yes' : 'no'));
+                    }
                     // Get rid of mini player above chat - TODO: Reject this locally instead of having server reject it
                     if (init && typeof init.body === 'string' && init.body.includes('PlaybackAccessToken') && init.body.includes('picture-by-picture')) {
                         init.body = '';
                     }
                     if (ForceAccessTokenPlayerType && typeof init.body === 'string' && init.body.includes('PlaybackAccessToken')) {
-                        if (!hasInitialToken) {
-                            hasInitialToken = true;
-                            console.log('[AD DEBUG] Skipping player type force on initial request');
+                        let replacedPlayerType = '';
+                        const newBody = JSON.parse(init.body);
+                        if (Array.isArray(newBody)) {
+                            for (let i = 0; i < newBody.length; i++) {
+                                if (newBody[i]?.variables?.playerType && newBody[i]?.variables?.playerType !== ForceAccessTokenPlayerType) {
+                                    replacedPlayerType = newBody[i].variables.playerType;
+                                    newBody[i].variables.playerType = ForceAccessTokenPlayerType;
+                                }
+                            }
                         } else {
-                            let replacedPlayerType = '';
-                            const newBody = JSON.parse(init.body);
-                            if (Array.isArray(newBody)) {
-                                for (let i = 0; i < newBody.length; i++) {
-                                    if (newBody[i]?.variables?.playerType && newBody[i]?.variables?.playerType !== ForceAccessTokenPlayerType) {
-                                        replacedPlayerType = newBody[i].variables.playerType;
-                                        newBody[i].variables.playerType = ForceAccessTokenPlayerType;
-                                    }
-                                }
-                            } else {
-                                if (newBody?.variables?.playerType && newBody?.variables?.playerType !== ForceAccessTokenPlayerType) {
-                                    replacedPlayerType = newBody.variables.playerType;
-                                    newBody.variables.playerType = ForceAccessTokenPlayerType;
-                                }
+                            if (newBody?.variables?.playerType && newBody?.variables?.playerType !== ForceAccessTokenPlayerType) {
+                                replacedPlayerType = newBody.variables.playerType;
+                                newBody.variables.playerType = ForceAccessTokenPlayerType;
                             }
-                            if (replacedPlayerType) {
-                                console.log(`Replaced '${replacedPlayerType}' player type with '${ForceAccessTokenPlayerType}' player type`);
-                                init.body = JSON.stringify(newBody);
-                            }
+                        }
+                        if (replacedPlayerType) {
+                            console.log(`Replaced '${replacedPlayerType}' player type with '${ForceAccessTokenPlayerType}' player type`);
+                            init.body = JSON.stringify(newBody);
                         }
                     }
                 }
@@ -1406,17 +1783,51 @@
     }
     declareOptions(window);
     try {
+        const lsReloadAfterAd = localStorage.getItem('twitchAdSolutions_reloadPlayerAfterAd');
+        if (lsReloadAfterAd !== null) {
+            ReloadPlayerAfterAd = lsReloadAfterAd === 'true';
+        }
+        const lsReloadCooldown = parseInt(localStorage.getItem('twitchAdSolutions_reloadCooldownSeconds'));
+        if (!isNaN(lsReloadCooldown) && lsReloadCooldown >= 0) {
+            ReloadCooldownSeconds = lsReloadCooldown;
+        }
+        const lsDisableReloadCap = localStorage.getItem('twitchAdSolutions_disableReloadCap');
+        if (lsDisableReloadCap !== null) {
+            DisableReloadCap = lsDisableReloadCap === 'true';
+        }
+        const lsDriftRate = parseFloat(localStorage.getItem('twitchAdSolutions_driftCorrectionRate'));
+        if (!isNaN(lsDriftRate) && lsDriftRate >= 0) {
+            DriftCorrectionRate = lsDriftRate;
+        }
+        const lsEarlyReload = parseInt(localStorage.getItem('twitchAdSolutions_earlyReloadPollThreshold'));
+        if (!isNaN(lsEarlyReload) && lsEarlyReload >= 0) {
+            EarlyReloadPollThreshold = lsEarlyReload;
+        }
         const lsDisableAdSpoofing = localStorage.getItem('twitchAdSolutions_disableAdSpoofing');
         if (lsDisableAdSpoofing !== null) {
             DisableAdSpoofing = lsDisableAdSpoofing === 'true';
         }
+        const lsPlayerType = localStorage.getItem('twitchAdSolutions_playerType');
+        if (lsPlayerType !== null) {
+            ForceAccessTokenPlayerType = lsPlayerType;
+        }
+        const lsPinBackup = localStorage.getItem('twitchAdSolutions_pinBackupPlayerType');
+        if (lsPinBackup !== null) {
+            PinBackupPlayerType = lsPinBackup === 'true';
+        }
+        const lsHideAdOverlay = localStorage.getItem('twitchAdSolutions_hideAdOverlay');
+        if (lsHideAdOverlay === 'true') {
+            const style = document.createElement('style');
+            style.textContent = '.tas-adblock-overlay { display: none !important; }';
+            (document.head || document.documentElement).appendChild(style);
+        }
     } catch {}
+    console.log('[AD DEBUG] Config: ReloadPlayerAfterAd = ' + ReloadPlayerAfterAd + ', ForceAccessTokenPlayerType = ' + ForceAccessTokenPlayerType + ', PinBackupPlayerType = ' + PinBackupPlayerType);
     hookWindowWorker();
     hookFetch();
     if (PlayerBufferingFix) {
         monitorPlayerBuffering();
     }
-    monitorPlayerErrors();
     if (document.readyState === "complete" || document.readyState === "interactive") {
         onContentLoaded();
     } else {


### PR DESCRIPTION
## Summary
Brings \`vaft_testing.user.js\` (the userscript variant of testing) in line with \`vaft-testing-ublock-origin.js\` (the uBO variant). The userscript variant was severely out of sync — missing nearly all of the freeze-recovery and frame-handling work from the past several weeks.

## Why
The two testing files are supposed to be a sync pair (different packaging, same logic) per CLAUDE.md, but throughout recent work the sync was only applied to the uBO variant. Userscript testing users were running a substantially older codebase.

## What was missing from the userscript variant
- frameElement-based nested frame check (#109, #113)
- Loading circle detected health check (#96)
- EarlyReloadPollThreshold + early reload (#94)
- ConsecutiveAllStrippedPolls / freeze tracking infrastructure
- EXT-X-PART: ad strip (#105)
- EXT-X-PRELOAD-HINT strip (#104)
- CycleRescuedThisBreak skip-reload logic (#98 + #101)
- All backup player types ad-laden log (#108)
- 'autoplay' removed from BackupPlayerTypes (#107)
- And several more smaller corrections

## Approach
Rather than cherry-picking each missing feature individually, regenerate \`vaft_testing.user.js\` by:
1. Taking the body of \`vaft-testing-ublock-origin.js\` (line 2 onwards — skipping the uBO resource header)
2. Prepending the userscript metadata header

The two files are now functionally identical with only the packaging difference (userscript header vs uBO resource header).

## Stats
- Before: 1437 lines
- After: 1848 lines (+546, -135)

## Test plan
- [ ] Install vaft_testing.user.js via Tampermonkey/Violentmonkey
- [ ] Verify it loads on twitch.tv/CHANNEL with the same logs as the uBO variant
- [ ] Verify all recent fixes (frame check, PR #96 init grace, etc.) work the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)