### PR TITLE
Accept v2 API variant URLs without .m3u8 extension

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -643,7 +643,13 @@ twitch-videoad.js text/javascript
         let closestResolutionUrl = null;
         let closestResolutionDifference = Infinity;
         for (let i = 0; i < encodingsLines.length - 1; i++) {
-            if (encodingsLines[i].startsWith('#EXT-X-STREAM-INF') && encodingsLines[i + 1].includes('.m3u8')) {
+            // Accept v2 API variant URLs which are raw CDN URLs without '.m3u8' in the path.
+            // v1 API: next line is '...index-<resolution>.m3u8?...'
+            // v2 API: next line is a raw CDN URL like 'https://video-edge-...net/v1/.../chunked/...'
+            // without '.m3u8'. Matching only on '.m3u8' would skip v2 variants entirely,
+            // causing getStreamUrlForResolution to return null and backup selection to fail.
+            const nextLine = encodingsLines[i + 1]?.trim();
+            if (encodingsLines[i].startsWith('#EXT-X-STREAM-INF') && nextLine && !nextLine.startsWith('#') && (nextLine.includes('.m3u8') || nextLine.includes('://'))) {
                 const attributes = parseAttributes(encodingsLines[i]);
                 const resolution = attributes['RESOLUTION'];
                 const frameRate = attributes['FRAME-RATE'];

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -653,7 +653,13 @@
         let closestResolutionUrl = null;
         let closestResolutionDifference = Infinity;
         for (let i = 0; i < encodingsLines.length - 1; i++) {
-            if (encodingsLines[i].startsWith('#EXT-X-STREAM-INF') && encodingsLines[i + 1].includes('.m3u8')) {
+            // Accept v2 API variant URLs which are raw CDN URLs without '.m3u8' in the path.
+            // v1 API: next line is '...index-<resolution>.m3u8?...'
+            // v2 API: next line is a raw CDN URL like 'https://video-edge-...net/v1/.../chunked/...'
+            // without '.m3u8'. Matching only on '.m3u8' would skip v2 variants entirely,
+            // causing getStreamUrlForResolution to return null and backup selection to fail.
+            const nextLine = encodingsLines[i + 1]?.trim();
+            if (encodingsLines[i].startsWith('#EXT-X-STREAM-INF') && nextLine && !nextLine.startsWith('#') && (nextLine.includes('.m3u8') || nextLine.includes('://'))) {
                 const attributes = parseAttributes(encodingsLines[i]);
                 const resolution = attributes['RESOLUTION'];
                 const frameRate = attributes['FRAME-RATE'];

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -291,10 +291,14 @@ twitch-videoad.js text/javascript
     function setStreamInfoUrls(streamInfo, encodingsM3u8) {
         const lines = encodingsM3u8.split(/\r?\n/);
         for (let i = 0; i < lines.length; i++) {
-            if (!lines[i].startsWith('#') && lines[i].includes('.m3u8')) {
+            // v2 API variant URLs are raw CDN URLs without '.m3u8' in the path.
+            // Accept absolute URLs (containing '://') alongside '.m3u8' URLs.
+            const trimmed = lines[i]?.trim();
+            if (trimmed && !trimmed.startsWith('#') && (trimmed.includes('.m3u8') || trimmed.includes('://'))) {
                 StreamInfosByUrl[lines[i].trimEnd()] = streamInfo;
             }
-            if (lines[i].startsWith('#EXT-X-STREAM-INF') && lines[i + 1].includes('.m3u8')) {
+            const nextLine = lines[i + 1]?.trim();
+            if (lines[i].startsWith('#EXT-X-STREAM-INF') && nextLine && !nextLine.startsWith('#') && (nextLine.includes('.m3u8') || nextLine.includes('://'))) {
                 const attributes = parseAttributes(lines[i]);
                 const resolution = attributes['RESOLUTION'];
                 if (resolution) {
@@ -789,7 +793,9 @@ twitch-videoad.js text/javascript
         let closestResolutionUrl = null;
         let closestResolutionDifference = Infinity;
         for (let i = 0; i < encodingsLines.length - 1; i++) {
-            if (encodingsLines[i].startsWith('#EXT-X-STREAM-INF') && encodingsLines[i + 1].includes('.m3u8')) {
+            // Accept v2 API variant URLs (raw CDN URLs without '.m3u8').
+            const nextLine = encodingsLines[i + 1]?.trim();
+            if (encodingsLines[i].startsWith('#EXT-X-STREAM-INF') && nextLine && !nextLine.startsWith('#') && (nextLine.includes('.m3u8') || nextLine.includes('://'))) {
                 const attributes = parseAttributes(encodingsLines[i]);
                 const resolution = attributes['RESOLUTION'];
                 const frameRate = attributes['FRAME-RATE'];

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -302,10 +302,14 @@
     function setStreamInfoUrls(streamInfo, encodingsM3u8) {
         const lines = encodingsM3u8.split(/\r?\n/);
         for (let i = 0; i < lines.length; i++) {
-            if (!lines[i].startsWith('#') && lines[i].includes('.m3u8')) {
+            // v2 API variant URLs are raw CDN URLs without '.m3u8' in the path.
+            // Accept absolute URLs (containing '://') alongside '.m3u8' URLs.
+            const trimmed = lines[i]?.trim();
+            if (trimmed && !trimmed.startsWith('#') && (trimmed.includes('.m3u8') || trimmed.includes('://'))) {
                 StreamInfosByUrl[lines[i].trimEnd()] = streamInfo;
             }
-            if (lines[i].startsWith('#EXT-X-STREAM-INF') && lines[i + 1].includes('.m3u8')) {
+            const nextLine = lines[i + 1]?.trim();
+            if (lines[i].startsWith('#EXT-X-STREAM-INF') && nextLine && !nextLine.startsWith('#') && (nextLine.includes('.m3u8') || nextLine.includes('://'))) {
                 const attributes = parseAttributes(lines[i]);
                 const resolution = attributes['RESOLUTION'];
                 if (resolution) {
@@ -800,7 +804,9 @@
         let closestResolutionUrl = null;
         let closestResolutionDifference = Infinity;
         for (let i = 0; i < encodingsLines.length - 1; i++) {
-            if (encodingsLines[i].startsWith('#EXT-X-STREAM-INF') && encodingsLines[i + 1].includes('.m3u8')) {
+            // Accept v2 API variant URLs (raw CDN URLs without '.m3u8').
+            const nextLine = encodingsLines[i + 1]?.trim();
+            if (encodingsLines[i].startsWith('#EXT-X-STREAM-INF') && nextLine && !nextLine.startsWith('#') && (nextLine.includes('.m3u8') || nextLine.includes('://'))) {
                 const attributes = parseAttributes(encodingsLines[i]);
                 const resolution = attributes['RESOLUTION'];
                 const frameRate = attributes['FRAME-RATE'];


### PR DESCRIPTION
## Summary

Twitch's v2 API returns raw CDN variant URLs (e.g. `https://video-edge-*.abs.hls.ttvnw.net/v1/.../chunked/...`) that don't contain `.m3u8` in the path. The existing `.includes('.m3u8')` checks in `getStreamUrlForResolution` and `setStreamInfoUrls` skip v2 variants entirely — `getStreamUrlForResolution` returns `null`, backup-stream selection silently fails, and the strip+recovery path engages for the full ad break even when a clean backup was available on another player type.

Ported from TTV-AB [`a10ba47`](https://github.com/GosuDRM/TTV-AB/commit/a10ba47b8858cb5e29be749a104b733b9b2f53ae). Release scripts only (vaft + video-swap-new pairs).

## Fix

Widen the match to accept absolute URLs (containing `://`) alongside `.m3u8` URLs, with a guard against matching comment lines that happen to contain `://`:

```js
const nextLine = encodingsLines[i + 1]?.trim();
if (encodingsLines[i].startsWith('#EXT-X-STREAM-INF') &&
    nextLine && !nextLine.startsWith('#') &&
    (nextLine.includes('.m3u8') || nextLine.includes('://'))) {
```

## Files modified

- `vaft/vaft.user.js` — `getStreamUrlForResolution`
- `vaft/vaft-ublock-origin.js` — same
- `video-swap-new/video-swap-new.user.js` — `setStreamInfoUrls` + `getStreamUrlForResolution`
- `video-swap-new/video-swap-new-ublock-origin.js` — same

Testing pairs not touched (see separate sync PR policy).

## Compatibility

Pure string-matching change inside functions that run in the worker blob (`getStreamUrlForResolution`) or main thread (`setStreamInfoUrls`). No outer-scope references, no userscript-manager-specific APIs. Works identically under Tampermonkey, Violentmonkey, Greasemonkey, and uBO scriptlet contexts.

## Test plan

- [ ] Acorn validation passes on all four files
- [ ] Test on a channel known to serve v2 API responses — verify `[AD DEBUG] Streaming backup m3u8 from <playerType>` fires with a non-null URL during ad breaks
- [ ] Test on a channel serving v1 API — verify existing behavior unchanged
- [ ] No regression in backup stream selection on normal (non-ad) polls