### PR TITLE
Strip LL-HLS prefetch hints on first poll of ad break

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -579,6 +579,28 @@ twitch-videoad.js text/javascript
                     lines[i] = '';
                     hasStrippedAdSegments = true;
                 }
+            } else if (line.startsWith('#EXT-X-TWITCH-PREFETCH:') || line.startsWith('#EXT-X-PRELOAD-HINT:')) {
+                // LL-HLS prefetch/preload hints can point at upcoming ad segments before any
+                // EXTINF line or ad signifier has materialized in the playlist. If we only
+                // strip prefetch hints AFTER hasStrippedAdSegments is set, the first poll of
+                // an ad break can leak a prefetch hint pointing at an ad URL — the player
+                // then pre-fetches ad media via the LL-HLS path before our usual strip catches
+                // up, producing an ad flash. Detect the ad URL here so hasStrippedAdSegments
+                // flips on the first poll and the post-loop unconditional prefetch strip fires.
+                // Ported from TTV-AB 52b41b4.
+                // Format: '#EXT-X-TWITCH-PREFETCH:https://url/here.ts' (raw URL after the colon)
+                //     or: '#EXT-X-PRELOAD-HINT:TYPE=PART,URI="url"' (URI attribute)
+                let hintUrl = '';
+                if (line.startsWith('#EXT-X-TWITCH-PREFETCH:')) {
+                    hintUrl = line.substring('#EXT-X-TWITCH-PREFETCH:'.length).trim();
+                } else {
+                    const hintMatch = line.match(/URI="([^"]+)"/);
+                    hintUrl = hintMatch ? hintMatch[1] : '';
+                }
+                if (hintUrl && (AdSegmentCache.has(hintUrl) || AdSegmentURLPatterns.some((p) => hintUrl.includes(p)))) {
+                    AdSegmentCache.set(hintUrl, Date.now());
+                    hasStrippedAdSegments = true;
+                }
             }
             if (AdSignifiers.some((s) => line.includes(s))) {
                 hasStrippedAdSegments = true;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -589,6 +589,28 @@
                     lines[i] = '';
                     hasStrippedAdSegments = true;
                 }
+            } else if (line.startsWith('#EXT-X-TWITCH-PREFETCH:') || line.startsWith('#EXT-X-PRELOAD-HINT:')) {
+                // LL-HLS prefetch/preload hints can point at upcoming ad segments before any
+                // EXTINF line or ad signifier has materialized in the playlist. If we only
+                // strip prefetch hints AFTER hasStrippedAdSegments is set, the first poll of
+                // an ad break can leak a prefetch hint pointing at an ad URL — the player
+                // then pre-fetches ad media via the LL-HLS path before our usual strip catches
+                // up, producing an ad flash. Detect the ad URL here so hasStrippedAdSegments
+                // flips on the first poll and the post-loop unconditional prefetch strip fires.
+                // Ported from TTV-AB 52b41b4.
+                // Format: '#EXT-X-TWITCH-PREFETCH:https://url/here.ts' (raw URL after the colon)
+                //     or: '#EXT-X-PRELOAD-HINT:TYPE=PART,URI="url"' (URI attribute)
+                let hintUrl = '';
+                if (line.startsWith('#EXT-X-TWITCH-PREFETCH:')) {
+                    hintUrl = line.substring('#EXT-X-TWITCH-PREFETCH:'.length).trim();
+                } else {
+                    const hintMatch = line.match(/URI="([^"]+)"/);
+                    hintUrl = hintMatch ? hintMatch[1] : '';
+                }
+                if (hintUrl && (AdSegmentCache.has(hintUrl) || AdSegmentURLPatterns.some((p) => hintUrl.includes(p)))) {
+                    AdSegmentCache.set(hintUrl, Date.now());
+                    hasStrippedAdSegments = true;
+                }
             }
             if (AdSignifiers.some((s) => line.includes(s))) {
                 hasStrippedAdSegments = true;

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -499,6 +499,26 @@ twitch-videoad.js text/javascript
                     lines[i] = '';
                     hasStrippedAdSegments = true;
                 }
+            } else if (line.startsWith('#EXT-X-TWITCH-PREFETCH:') || line.startsWith('#EXT-X-PRELOAD-HINT:')) {
+                // LL-HLS prefetch/preload hints can point at upcoming ad segments before any
+                // EXTINF line or ad signifier has materialized in the playlist. If we only
+                // strip prefetch hints AFTER hasStrippedAdSegments is set, the first poll of
+                // an ad break can leak a prefetch hint pointing at an ad URL — the player
+                // then pre-fetches ad media via the LL-HLS path before our usual strip catches
+                // up, producing an ad flash. Detect the ad URL here so hasStrippedAdSegments
+                // flips on the first poll and the post-loop unconditional prefetch strip fires.
+                // Ported from TTV-AB 52b41b4.
+                let hintUrl = '';
+                if (line.startsWith('#EXT-X-TWITCH-PREFETCH:')) {
+                    hintUrl = line.substring('#EXT-X-TWITCH-PREFETCH:'.length).trim();
+                } else {
+                    const hintMatch = line.match(/URI="([^"]+)"/);
+                    hintUrl = hintMatch ? hintMatch[1] : '';
+                }
+                if (hintUrl && (AdSegmentCache.has(hintUrl) || AD_SEGMENT_URL_PATTERNS.some((p) => hintUrl.includes(p)))) {
+                    AdSegmentCache.set(hintUrl, Date.now());
+                    hasStrippedAdSegments = true;
+                }
             }
             if (AD_SIGNIFIERS.some((s) => line.includes(s))) {
                 hasStrippedAdSegments = true;

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -510,6 +510,26 @@
                     lines[i] = '';
                     hasStrippedAdSegments = true;
                 }
+            } else if (line.startsWith('#EXT-X-TWITCH-PREFETCH:') || line.startsWith('#EXT-X-PRELOAD-HINT:')) {
+                // LL-HLS prefetch/preload hints can point at upcoming ad segments before any
+                // EXTINF line or ad signifier has materialized in the playlist. If we only
+                // strip prefetch hints AFTER hasStrippedAdSegments is set, the first poll of
+                // an ad break can leak a prefetch hint pointing at an ad URL — the player
+                // then pre-fetches ad media via the LL-HLS path before our usual strip catches
+                // up, producing an ad flash. Detect the ad URL here so hasStrippedAdSegments
+                // flips on the first poll and the post-loop unconditional prefetch strip fires.
+                // Ported from TTV-AB 52b41b4.
+                let hintUrl = '';
+                if (line.startsWith('#EXT-X-TWITCH-PREFETCH:')) {
+                    hintUrl = line.substring('#EXT-X-TWITCH-PREFETCH:'.length).trim();
+                } else {
+                    const hintMatch = line.match(/URI="([^"]+)"/);
+                    hintUrl = hintMatch ? hintMatch[1] : '';
+                }
+                if (hintUrl && (AdSegmentCache.has(hintUrl) || AD_SEGMENT_URL_PATTERNS.some((p) => hintUrl.includes(p)))) {
+                    AdSegmentCache.set(hintUrl, Date.now());
+                    hasStrippedAdSegments = true;
+                }
             }
             if (AD_SIGNIFIERS.some((s) => line.includes(s))) {
                 hasStrippedAdSegments = true;


### PR DESCRIPTION
## Summary

The existing unconditional prefetch-hint strip is gated on `hasStrippedAdSegments`, which is only true after a matching `#EXTINF` line or an `AdSignifier` has been seen in the playlist. On the **first poll** of an ad break, Twitch's LL-HLS `#EXT-X-TWITCH-PREFETCH:` / `#EXT-X-PRELOAD-HINT:` line can point at a yet-to-materialize ad segment before any of those conditions are met. The player then pre-fetches the ad media via the low-latency path before the next poll's strip catches up, producing a brief ad flash.

Ported from TTV-AB [`52b41b4`](https://github.com/GosuDRM/TTV-AB/commit/52b41b402ae2f120f863ca76fb7f5dc1757e4a55). Release scripts only (vaft + video-swap-new pairs).

## Fix

Adapted for vaft's architecture. TTV-AB strips ALL prefetch hints unconditionally during ads; vaft's existing post-loop already does that once `hasStrippedAdSegments` is set. This change only needs to flip that flag **earlier** — in the main line loop, detect when a prefetch hint's URL matches `AdSegmentCache` or `AdSegmentURLPatterns` and set `hasStrippedAdSegments = true`. The existing post-loop then strips all hints on the same poll.

```js
} else if (line.startsWith('#EXT-X-TWITCH-PREFETCH:') || line.startsWith('#EXT-X-PRELOAD-HINT:')) {
    let hintUrl = '';
    if (line.startsWith('#EXT-X-TWITCH-PREFETCH:')) {
        hintUrl = line.substring('#EXT-X-TWITCH-PREFETCH:'.length).trim();
    } else {
        const hintMatch = line.match(/URI=\"([^\"]+)\"/);
        hintUrl = hintMatch ? hintMatch[1] : '';
    }
    if (hintUrl && (AdSegmentCache.has(hintUrl) || AdSegmentURLPatterns.some((p) => hintUrl.includes(p)))) {
        AdSegmentCache.set(hintUrl, Date.now());
        hasStrippedAdSegments = true;
    }
}
```

Handles both LL-HLS prefetch formats:
- `#EXT-X-TWITCH-PREFETCH:https://url/here.ts` (Twitch-specific, raw URL after colon)
- `#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"url\"` (standard LL-HLS, quoted attribute)

## Files modified

- `vaft/vaft.user.js` — `stripAdSegments`
- `vaft/vaft-ublock-origin.js` — same
- `video-swap-new/video-swap-new.user.js` — `stripAdSegments`
- `video-swap-new/video-swap-new-ublock-origin.js` — same

## Compatibility

- Runs inside `stripAdSegments`, which is serialized via `.toString()` into the worker blob. No outer-scope references introduced (`AdSegmentCache` and `AdSegmentURLPatterns` are already in worker scope).
- Pure string/regex matching, no userscript-manager-specific APIs, no window/document access.
- Works identically under Tampermonkey, Violentmonkey, Greasemonkey, and uBO scriptlet contexts.

## Risk

- **False positives:** only matches URLs already in `AdSegmentCache` (from prior strips, 2min TTL) or matching `AdSegmentURLPatterns` (static known-ad patterns). Won't false-flag legitimate live segments because `AdSegmentCache` is populated only by confirmed ad strips.
- **Blast radius:** if the hint doesn't match, behavior is unchanged (falls through to the existing line processing). If it does match, we set `hasStrippedAdSegments = true`, which is strictly the intended state for that poll.
- Testing scripts not touched.

## Test plan

- [ ] Acorn validation passes on all four files
- [ ] Test on a channel known to serve LL-HLS prefetch hints — verify `[AD DEBUG] Ad detected` fires on the first poll when prefetch points at an ad URL, not the second
- [ ] Verify no regression on ad-free streams (prefetch hints for live segments should pass through untouched)
- [ ] Verify ad-break detection timing (first strip should happen one poll sooner in the prefetch-leading case)