### PR TITLE
Throttle AdSegmentCache prune + diagnostic size log

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -627,11 +627,24 @@ twitch-videoad.js text/javascript
         }
         streamInfo.IsStrippingAdSegments = hasStrippedAdSegments;
         const now = Date.now();
-        AdSegmentCache.forEach((value, key, map) => {
-            if (value < now - 120000) {
-                map.delete(key);
+        // Throttle cache prune to once per 60s. The 120s TTL gives plenty of headroom
+        // and scanning the full cache on every m3u8 poll adds up during heavy ad break
+        // sequences (LL-HLS can poll multiple times per second). Ported from TTV-AB.
+        if (!streamInfo.LastAdCachePruneAt || now - streamInfo.LastAdCachePruneAt > 60000) {
+            streamInfo.LastAdCachePruneAt = now;
+            AdSegmentCache.forEach((value, key, map) => {
+                if (value < now - 120000) {
+                    map.delete(key);
+                }
+            });
+            // Diagnostic: log once per streamInfo when the cache crosses 1000 entries,
+            // so cache bloat from a future TTL/prune bug would surface in user reports
+            // instead of staying invisible.
+            if (AdSegmentCache.size > 1000 && !streamInfo.LoggedAdCacheSize1k) {
+                streamInfo.LoggedAdCacheSize1k = true;
+                console.log('[AD DEBUG] AdSegmentCache crossed 1000 entries (now ' + AdSegmentCache.size + ') — possible cache bloat');
             }
-        });
+        }
         return lines.join('\n');
     }
     // Find the closest matching stream URL for a given resolution from a master m3u8

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -637,11 +637,24 @@
         }
         streamInfo.IsStrippingAdSegments = hasStrippedAdSegments;
         const now = Date.now();
-        AdSegmentCache.forEach((value, key, map) => {
-            if (value < now - 120000) {
-                map.delete(key);
+        // Throttle cache prune to once per 60s. The 120s TTL gives plenty of headroom
+        // and scanning the full cache on every m3u8 poll adds up during heavy ad break
+        // sequences (LL-HLS can poll multiple times per second). Ported from TTV-AB.
+        if (!streamInfo.LastAdCachePruneAt || now - streamInfo.LastAdCachePruneAt > 60000) {
+            streamInfo.LastAdCachePruneAt = now;
+            AdSegmentCache.forEach((value, key, map) => {
+                if (value < now - 120000) {
+                    map.delete(key);
+                }
+            });
+            // Diagnostic: log once per streamInfo when the cache crosses 1000 entries,
+            // so cache bloat from a future TTL/prune bug would surface in user reports
+            // instead of staying invisible.
+            if (AdSegmentCache.size > 1000 && !streamInfo.LoggedAdCacheSize1k) {
+                streamInfo.LoggedAdCacheSize1k = true;
+                console.log('[AD DEBUG] AdSegmentCache crossed 1000 entries (now ' + AdSegmentCache.size + ') — possible cache bloat');
             }
-        });
+        }
         return lines.join('\n');
     }
     // Find the closest matching stream URL for a given resolution from a master m3u8

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -540,11 +540,25 @@ twitch-videoad.js text/javascript
             }
         }
         streamInfo.IsStrippingAdSegments = hasStrippedAdSegments;
-        AdSegmentCache.forEach((value, key, map) => {
-            if (value < Date.now() - 120000) {
-                map.delete(key);
+        const now = Date.now();
+        // Throttle cache prune to once per 60s. The 120s TTL gives plenty of headroom
+        // and scanning the full cache on every m3u8 poll adds up during heavy ad break
+        // sequences (LL-HLS can poll multiple times per second). Ported from TTV-AB.
+        if (!streamInfo.LastAdCachePruneAt || now - streamInfo.LastAdCachePruneAt > 60000) {
+            streamInfo.LastAdCachePruneAt = now;
+            AdSegmentCache.forEach((value, key, map) => {
+                if (value < now - 120000) {
+                    map.delete(key);
+                }
+            });
+            // Diagnostic: log once per streamInfo when the cache crosses 1000 entries,
+            // so cache bloat from a future TTL/prune bug would surface in user reports
+            // instead of staying invisible.
+            if (AdSegmentCache.size > 1000 && !streamInfo.LoggedAdCacheSize1k) {
+                streamInfo.LoggedAdCacheSize1k = true;
+                console.log('[AD DEBUG] AdSegmentCache crossed 1000 entries (now ' + AdSegmentCache.size + ') — possible cache bloat');
             }
-        });
+        }
         return lines.join('\n');
     }
     async function processM3U8(url, textStr, realFetch) {

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -551,11 +551,25 @@
             }
         }
         streamInfo.IsStrippingAdSegments = hasStrippedAdSegments;
-        AdSegmentCache.forEach((value, key, map) => {
-            if (value < Date.now() - 120000) {
-                map.delete(key);
+        const now = Date.now();
+        // Throttle cache prune to once per 60s. The 120s TTL gives plenty of headroom
+        // and scanning the full cache on every m3u8 poll adds up during heavy ad break
+        // sequences (LL-HLS can poll multiple times per second). Ported from TTV-AB.
+        if (!streamInfo.LastAdCachePruneAt || now - streamInfo.LastAdCachePruneAt > 60000) {
+            streamInfo.LastAdCachePruneAt = now;
+            AdSegmentCache.forEach((value, key, map) => {
+                if (value < now - 120000) {
+                    map.delete(key);
+                }
+            });
+            // Diagnostic: log once per streamInfo when the cache crosses 1000 entries,
+            // so cache bloat from a future TTL/prune bug would surface in user reports
+            // instead of staying invisible.
+            if (AdSegmentCache.size > 1000 && !streamInfo.LoggedAdCacheSize1k) {
+                streamInfo.LoggedAdCacheSize1k = true;
+                console.log('[AD DEBUG] AdSegmentCache crossed 1000 entries (now ' + AdSegmentCache.size + ') — possible cache bloat');
             }
-        });
+        }
         return lines.join('\n');
     }
     async function processM3U8(url, textStr, realFetch) {


### PR DESCRIPTION
## Summary

Two small additions to `stripAdSegments` in the vaft + video-swap-new release pairs.

### 1. Throttle cache prune to once per 60s

The AdSegmentCache TTL scan currently runs on every call to `stripAdSegments` — which fires on every m3u8 poll (~2s normally, faster under LL-HLS). With a populated cache (hundreds of entries after a few ad breaks), the full-forEach walk adds up during heavy ad sequences. Throttling the prune to run at most once per 60s drops the hot-path cost by ~30x.

Uses a per-`streamInfo` timestamp (`LastAdCachePruneAt`) so the throttle state travels with the stream and doesn't need a new worker-scope variable. The 120s TTL gives plenty of headroom — entries now expire anywhere in [120s, 180s] instead of exactly at 120s, but the cache size stays bounded.

### 2. One-shot diagnostic log at 1000 cache entries

Adds a single `[AD DEBUG]` log when `AdSegmentCache.size` crosses 1000, gated on a per-`streamInfo` flag so it fires at most once. The motivation: if a future TTL/prune bug causes cache bloat, we currently have no visibility. This surfaces the symptom in user console output instead of leaving it invisible.

Ported from the TTV-AB prune-throttle pattern ([parser.ts prune logic](https://github.com/GosuDRM/TTV-AB/blob/main/src/modules/parser.ts)).

## Diff

```diff
 streamInfo.IsStrippingAdSegments = hasStrippedAdSegments;
 const now = Date.now();
-AdSegmentCache.forEach((value, key, map) => {
-    if (value < now - 120000) {
-        map.delete(key);
-    }
-});
+if (!streamInfo.LastAdCachePruneAt || now - streamInfo.LastAdCachePruneAt > 60000) {
+    streamInfo.LastAdCachePruneAt = now;
+    AdSegmentCache.forEach((value, key, map) => {
+        if (value < now - 120000) {
+            map.delete(key);
+        }
+    });
+    if (AdSegmentCache.size > 1000 && !streamInfo.LoggedAdCacheSize1k) {
+        streamInfo.LoggedAdCacheSize1k = true;
+        console.log('[AD DEBUG] AdSegmentCache crossed 1000 entries (now ' + AdSegmentCache.size + ') — possible cache bloat');
+    }
+}
 return lines.join('\n');
```

## Files modified

- `vaft/vaft.user.js` — `stripAdSegments`
- `vaft/vaft-ublock-origin.js` — same
- `video-swap-new/video-swap-new.user.js` — `stripAdSegments`
- `video-swap-new/video-swap-new-ublock-origin.js` — same

## Compatibility

- Runs inside `stripAdSegments`, which is serialized via `.toString()` into the worker blob. No outer-scope references introduced (`streamInfo` is already in scope, `AdSegmentCache` is already in worker scope via `declareOptions`).
- New `streamInfo` fields (`LastAdCachePruneAt`, `LoggedAdCacheSize1k`) are implicitly initialized to `undefined` on first access — no changes to StreamInfo construction needed.
- No manager-specific APIs. Works identically under Tampermonkey, Violentmonkey, Greasemonkey, and uBO scriptlet contexts.

## Risk

- **Cache TTL shifted from exactly 120s to [120s, 180s]**: worst-case an entry lives 60s longer than before. Far below any realistic memory pressure — `AdSegmentCache` typically holds <500 entries even during heavy ad activity.
- **Diagnostic log**: strictly additive, zero perf impact (one integer compare), one-shot gated so no spam.

## Test plan

- [ ] Acorn validation passes on all four files
- [ ] Normal playback unchanged — no new log lines during clean streaming
- [ ] During an ad break, verify the first poll runs the prune and subsequent polls within the same minute skip it (can be inspected via a temporary debug log if needed)
- [ ] No `[AD DEBUG] AdSegmentCache crossed 1000 entries` log under normal operation