### PR TITLE
Refactor: unify StreamInfo shape into createStreamInfo factory

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -96,6 +96,51 @@ twitch-videoad.js text/javascript
             }
         }
     }
+    function createStreamInfo(channelName, encodingsM3u8, usherParams) {
+        return {
+            ChannelName: channelName,
+            LastSeenAt: Date.now(),
+            EncodingsM3U8: encodingsM3u8,
+            UsherParams: usherParams,
+            Urls: Object.create(null),
+            ResolutionList: [],
+            RequestedAds: new Set(),
+            ModifiedM3U8: null,
+            IsUsingModifiedM3U8: false,
+            IsShowingAd: false,
+            IsMidroll: false,
+            AdBreakStartedAt: 0,
+            PodLength: 1,
+            HasConfirmedAdAttrs: false,
+            CleanPlaylistCount: 0,
+            ConsecutiveZeroStripBreaks: 0,
+            CsaiOnlyThisBreak: false,
+            IsStrippingAdSegments: false,
+            NumStrippedAdSegments: 0,
+            RecoverySegments: [],
+            RecoveryStartSeq: undefined,
+            FreezeStartedAt: 0,
+            ConsecutiveAllStrippedPolls: 0,
+            TotalAllStrippedPolls: 0,
+            LastCleanNativeM3U8: null,
+            LastCleanNativePlaylistAt: 0,
+            BackupEncodingsM3U8Cache: [],
+            ActiveBackupPlayerType: null,
+            PinnedBackupPlayerType: null,
+            LastCommittedBackupPlayerType: null,
+            FailedBackupPlayerTypes: new Map(),
+            LoggedBackupAdsByType: null,
+            CycleRescuedThisBreak: false,
+            EarlyReloadCount: 0,
+            EarlyReloadAtPoll: 0,
+            EarlyReloadTriggered: false,
+            EarlyReloadAwaitingResult: false,
+            LastPlayerReload: 0,
+            ReloadTimestamps: [],
+            HasCheckedUnknownTags: false,
+            HasLoggedAdAttributes: false,
+        };
+    }
     function maskAsNative(fn, name) {
         fn.toString = () => 'function ' + name + '() { [native code] }';
         return fn;
@@ -216,6 +261,7 @@ twitch-videoad.js text/javascript
                     ${getServerTimeFromM3u8.toString()}
                     ${replaceServerTimeInM3u8.toString()}
                     ${pruneStreamInfos.toString()}
+                    ${createStreamInfo.toString()}
                     const workerString = getWasmWorkerJs('${twitchBlobUrl.replaceAll("'", "%27")}');
                     declareOptions(self);
                     if (!self.__tasPruneInterval) {
@@ -396,36 +442,7 @@ twitch-videoad.js text/javascript
                                     // cooldown calculation, blocking legitimate end-of-break reloads.
                                     HasTriggeredPlayerReload = false;
                                     console.log('[AD DEBUG] New stream session — channel: ' + channelName + ', API: ' + (V2API ? 'v2' : 'v1'));
-                                    StreamInfos[channelName] = streamInfo = {
-                                        ChannelName: channelName,
-                                        LastSeenAt: Date.now(),
-                                        IsShowingAd: false,
-                                        LastPlayerReload: 0,
-                                        EncodingsM3U8: encodingsM3u8,
-                                        ModifiedM3U8: null,
-                                        IsUsingModifiedM3U8: false,
-                                        UsherParams: parsedUrl.search,
-                                        RequestedAds: new Set(),
-                                        Urls: Object.create(null),// xxx.m3u8 -> { Resolution: "284x160", FrameRate: 30.0 }
-                                        ResolutionList: [],
-                                        BackupEncodingsM3U8Cache: [],
-                                        ActiveBackupPlayerType: null,
-                                        PinnedBackupPlayerType: null,
-                                        HasCheckedUnknownTags: false,
-                                        IsMidroll: false,
-                                        IsStrippingAdSegments: false,
-                                        NumStrippedAdSegments: 0,
-                                        RecoverySegments: [],
-                                        FailedBackupPlayerTypes: new Map(),// Map<playerType, timestamp> — failures expire after 15s for retry
-                                        HasLoggedAdAttributes: false,
-                                        LoggedBackupAdsByType: null,
-                                        RecoveryStartSeq: undefined,
-                                        CleanPlaylistCount: 0,
-                                        ReloadTimestamps: [],
-                                        ConsecutiveZeroStripBreaks: 0,
-                                        LastCleanNativeM3U8: null,// Full-playlist snapshot cached during non-ad polls for all-stripped recovery (mirrors TTV-AB LastCleanNativeM3U8)
-                                        LastCleanNativePlaylistAt: 0
-                                    };
+                                    StreamInfos[channelName] = streamInfo = createStreamInfo(channelName, encodingsM3u8, parsedUrl.search);
                                     const lines = encodingsM3u8.split(/\r?\n/);
                                     for (let i = 0; i < lines.length - 1; i++) {
                                         if (lines[i].startsWith('#EXT-X-STREAM-INF') && lines[i + 1].includes('.m3u8')) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -106,6 +106,64 @@
             }
         }
     }
+    // Creates a new StreamInfo with the full field shape declared up-front.
+    // When adding a new streamInfo field, declare it here with an appropriate
+    // zero value so the complete shape is visible in one place.
+    function createStreamInfo(channelName, encodingsM3u8, usherParams) {
+        return {
+            // Identity / lifecycle
+            ChannelName: channelName,
+            LastSeenAt: Date.now(),
+            EncodingsM3U8: encodingsM3u8,
+            UsherParams: usherParams,
+            // Resolutions / URL map
+            Urls: Object.create(null),// xxx.m3u8 -> { Resolution: "284x160", FrameRate: 30.0 }
+            ResolutionList: [],
+            RequestedAds: new Set(),
+            // Modified m3u8 state
+            ModifiedM3U8: null,
+            IsUsingModifiedM3U8: false,
+            // Ad-break state
+            IsShowingAd: false,
+            IsMidroll: false,
+            AdBreakStartedAt: 0,
+            PodLength: 1,
+            HasConfirmedAdAttrs: false,
+            CleanPlaylistCount: 0,
+            ConsecutiveZeroStripBreaks: 0,
+            CsaiOnlyThisBreak: false,
+            // Strip state
+            IsStrippingAdSegments: false,
+            NumStrippedAdSegments: 0,
+            RecoverySegments: [],
+            RecoveryStartSeq: undefined,// LOAD-BEARING: explicitly checked with `!== undefined`
+            FreezeStartedAt: 0,
+            ConsecutiveAllStrippedPolls: 0,
+            TotalAllStrippedPolls: 0,
+            // Clean playlist snapshot for all-stripped recovery (mirrors TTV-AB)
+            LastCleanNativeM3U8: null,
+            LastCleanNativePlaylistAt: 0,
+            // Backup player type cycling
+            BackupEncodingsM3U8Cache: [],
+            ActiveBackupPlayerType: null,
+            PinnedBackupPlayerType: null,
+            LastCommittedBackupPlayerType: null,
+            FailedBackupPlayerTypes: new Map(),// Map<playerType, timestamp> — failures expire after 15s for retry
+            LoggedBackupAdsByType: null,// lazy-init to Set on first "backup has ads" log
+            CycleRescuedThisBreak: false,
+            // Early reload
+            EarlyReloadCount: 0,
+            EarlyReloadAtPoll: 0,
+            EarlyReloadTriggered: false,
+            EarlyReloadAwaitingResult: false,
+            // Reload cooldown
+            LastPlayerReload: 0,
+            ReloadTimestamps: [],
+            // Diagnostic flags (once-per-session)
+            HasCheckedUnknownTags: false,
+            HasLoggedAdAttributes: false,
+        };
+    }
     function maskAsNative(fn, name) {
         fn.toString = () => 'function ' + name + '() { [native code] }';
         return fn;
@@ -226,6 +284,7 @@
                     ${getServerTimeFromM3u8.toString()}
                     ${replaceServerTimeInM3u8.toString()}
                     ${pruneStreamInfos.toString()}
+                    ${createStreamInfo.toString()}
                     const workerString = getWasmWorkerJs('${twitchBlobUrl.replaceAll("'", "%27")}');
                     declareOptions(self);
                     if (!self.__tasPruneInterval) {
@@ -406,36 +465,7 @@
                                     // cooldown calculation, blocking legitimate end-of-break reloads.
                                     HasTriggeredPlayerReload = false;
                                     console.log('[AD DEBUG] New stream session — channel: ' + channelName + ', API: ' + (V2API ? 'v2' : 'v1'));
-                                    StreamInfos[channelName] = streamInfo = {
-                                        ChannelName: channelName,
-                                        LastSeenAt: Date.now(),
-                                        IsShowingAd: false,
-                                        LastPlayerReload: 0,
-                                        EncodingsM3U8: encodingsM3u8,
-                                        ModifiedM3U8: null,
-                                        IsUsingModifiedM3U8: false,
-                                        UsherParams: parsedUrl.search,
-                                        RequestedAds: new Set(),
-                                        Urls: Object.create(null),// xxx.m3u8 -> { Resolution: "284x160", FrameRate: 30.0 }
-                                        ResolutionList: [],
-                                        BackupEncodingsM3U8Cache: [],
-                                        ActiveBackupPlayerType: null,
-                                        PinnedBackupPlayerType: null,
-                                        HasCheckedUnknownTags: false,
-                                        IsMidroll: false,
-                                        IsStrippingAdSegments: false,
-                                        NumStrippedAdSegments: 0,
-                                        RecoverySegments: [],
-                                        FailedBackupPlayerTypes: new Map(),// Map<playerType, timestamp> — failures expire after 15s for retry
-                                        HasLoggedAdAttributes: false,
-                                        LoggedBackupAdsByType: null,
-                                        RecoveryStartSeq: undefined,
-                                        CleanPlaylistCount: 0,
-                                        ReloadTimestamps: [],
-                                        ConsecutiveZeroStripBreaks: 0,
-                                        LastCleanNativeM3U8: null,// Full-playlist snapshot cached during non-ad polls for all-stripped recovery (mirrors TTV-AB LastCleanNativeM3U8)
-                                        LastCleanNativePlaylistAt: 0
-                                    };
+                                    StreamInfos[channelName] = streamInfo = createStreamInfo(channelName, encodingsM3u8, parsedUrl.search);
                                     const lines = encodingsM3u8.split(/\r?\n/);
                                     for (let i = 0; i < lines.length - 1; i++) {
                                         if (lines[i].startsWith('#EXT-X-STREAM-INF') && lines[i + 1].includes('.m3u8')) {

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -55,6 +55,34 @@ twitch-videoad.js text/javascript
         scope.PinBackupPlayerType = false;// If true, remember which backup player type worked and try it first on next ad break
         scope.StreamInfoMaxAgeMs = 30 * 60 * 1000;
     }
+    function createStreamInfo(channelName, usherParams) {
+        return {
+            ChannelName: channelName,
+            LastSeenAt: Date.now(),
+            UsherParams: usherParams,
+            Urls: new Map(),
+            RequestedAds: new Set(),
+            Encodings: null,
+            BackupEncodings: null,
+            BackupEncodingsStatus: new Map(),
+            BackupEncodingsPlayerTypeIndex: -1,
+            PinnedBackupPlayerType: null,
+            HasCheckedUnknownTags: false,
+            HasConfirmedAdAttrs: false,
+            HasLoggedAdAttributes: false,
+            IsMovingOffBackupEncodings: false,
+            IsMidroll: false,
+            IsStrippingAdSegments: false,
+            NumStrippedAdSegments: 0,
+            RecoverySegments: [],
+            RecoveryStartSeq: undefined,
+            CleanPlaylistCount: 0,
+            ConsecutiveZeroStripBreaks: 0,
+            UseFallbackStream: false,
+            LastCleanNativeM3U8: null,
+            LastCleanNativePlaylistAt: 0,
+        };
+    }
     function maskAsNative(fn, name) {
         fn.toString = () => 'function ' + name + '() { [native code] }';
         return fn;
@@ -187,6 +215,7 @@ twitch-videoad.js text/javascript
                     ${getStreamUrlForResolution.toString()}
                     ${updateAdblockBannerForStream.toString()}
                     ${pruneStreamInfos.toString()}
+                    ${createStreamInfo.toString()}
                     const workerString = getWasmWorkerJs('${twitchBlobUrl.replaceAll("'", "%27")}');
                     declareOptions(self);
                     if (!self.__tasPruneInterval) {
@@ -736,29 +765,7 @@ twitch-videoad.js text/javascript
                         }
                         let serverTime = null;
                         if (streamInfo == null || streamInfo.Encodings == null) {
-                            StreamInfos[channelName] = streamInfo = {
-                                LastSeenAt: Date.now(),
-                                RequestedAds: new Set(),
-                                Encodings: null,
-                                BackupEncodings: null,
-                                BackupEncodingsStatus: new Map(),
-                                BackupEncodingsPlayerTypeIndex: -1,
-                                PinnedBackupPlayerType: null,
-                                HasCheckedUnknownTags: false,
-                                IsMovingOffBackupEncodings: false,
-                                IsMidroll: false,
-                                IsStrippingAdSegments: false,
-                                NumStrippedAdSegments: 0,
-                                RecoverySegments: [],
-                                CleanPlaylistCount: 0,
-                                ConsecutiveZeroStripBreaks: 0,
-                                UseFallbackStream: false,
-                                ChannelName: channelName,
-                                UsherParams: (new URL(url)).search,
-                                Urls: new Map(),
-                                LastCleanNativeM3U8: null,// Full-playlist snapshot for all-stripped recovery (mirrors TTV-AB)
-                                LastCleanNativePlaylistAt: 0,
-                            };
+                            StreamInfos[channelName] = streamInfo = createStreamInfo(channelName, (new URL(url)).search);
                             const encodingsM3u8Response = await realFetch(url, options);
                             if (encodingsM3u8Response != null && encodingsM3u8Response.status === 200) {
                                 const encodingsM3u8 = await encodingsM3u8Response.text();

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -66,6 +66,34 @@
         scope.PinBackupPlayerType = false;// If true, remember which backup player type worked and try it first on next ad break
         scope.StreamInfoMaxAgeMs = 30 * 60 * 1000;
     }
+    function createStreamInfo(channelName, usherParams) {
+        return {
+            ChannelName: channelName,
+            LastSeenAt: Date.now(),
+            UsherParams: usherParams,
+            Urls: new Map(),
+            RequestedAds: new Set(),
+            Encodings: null,
+            BackupEncodings: null,
+            BackupEncodingsStatus: new Map(),
+            BackupEncodingsPlayerTypeIndex: -1,
+            PinnedBackupPlayerType: null,
+            HasCheckedUnknownTags: false,
+            HasConfirmedAdAttrs: false,
+            HasLoggedAdAttributes: false,
+            IsMovingOffBackupEncodings: false,
+            IsMidroll: false,
+            IsStrippingAdSegments: false,
+            NumStrippedAdSegments: 0,
+            RecoverySegments: [],
+            RecoveryStartSeq: undefined,
+            CleanPlaylistCount: 0,
+            ConsecutiveZeroStripBreaks: 0,
+            UseFallbackStream: false,
+            LastCleanNativeM3U8: null,
+            LastCleanNativePlaylistAt: 0,
+        };
+    }
     function maskAsNative(fn, name) {
         fn.toString = () => 'function ' + name + '() { [native code] }';
         return fn;
@@ -198,6 +226,7 @@
                     ${getStreamUrlForResolution.toString()}
                     ${updateAdblockBannerForStream.toString()}
                     ${pruneStreamInfos.toString()}
+                    ${createStreamInfo.toString()}
                     const workerString = getWasmWorkerJs('${twitchBlobUrl.replaceAll("'", "%27")}');
                     declareOptions(self);
                     if (!self.__tasPruneInterval) {
@@ -747,29 +776,7 @@
                         }
                         let serverTime = null;
                         if (streamInfo == null || streamInfo.Encodings == null) {
-                            StreamInfos[channelName] = streamInfo = {
-                                LastSeenAt: Date.now(),
-                                RequestedAds: new Set(),
-                                Encodings: null,
-                                BackupEncodings: null,
-                                BackupEncodingsStatus: new Map(),
-                                BackupEncodingsPlayerTypeIndex: -1,
-                                PinnedBackupPlayerType: null,
-                                HasCheckedUnknownTags: false,
-                                IsMovingOffBackupEncodings: false,
-                                IsMidroll: false,
-                                IsStrippingAdSegments: false,
-                                NumStrippedAdSegments: 0,
-                                RecoverySegments: [],
-                                CleanPlaylistCount: 0,
-                                ConsecutiveZeroStripBreaks: 0,
-                                UseFallbackStream: false,
-                                ChannelName: channelName,
-                                UsherParams: (new URL(url)).search,
-                                Urls: new Map(),
-                                LastCleanNativeM3U8: null,// Full-playlist snapshot for all-stripped recovery (mirrors TTV-AB)
-                                LastCleanNativePlaylistAt: 0,
-                            };
+                            StreamInfos[channelName] = streamInfo = createStreamInfo(channelName, (new URL(url)).search);
                             const encodingsM3u8Response = await realFetch(url, options);
                             if (encodingsM3u8Response != null && encodingsM3u8Response.status === 200) {
                                 const encodingsM3u8 = await encodingsM3u8Response.text();


### PR DESCRIPTION
## Summary

Extract the inline `StreamInfos[channelName] = streamInfo = { ... }` initialization block in the worker's usher-intercept path into a top-level `createStreamInfo` factory function that declares the **full** field shape up-front.

Pure refactor. Zero behavior change. The goal is maintainability.

## Motivation — shape drift

The StreamInfo shape was declared inline at two different initialization sites (vaft + video-swap-new). Both declared roughly the fields that were \"known at the time the code was written.\" But every PR that touched `processM3U8` or `stripAdSegments` added more fields lazily, without updating the init block:

**vaft fields declared inline (26)** vs **lazily added later (~12)**:

| Declared at init | Added lazily in code |
|---|---|
| `ChannelName`, `LastSeenAt`, `IsShowingAd`, `LastPlayerReload`, `EncodingsM3U8`, `ModifiedM3U8`, `IsUsingModifiedM3U8`, `UsherParams`, `RequestedAds`, `Urls`, `ResolutionList`, `BackupEncodingsM3U8Cache`, `ActiveBackupPlayerType`, `PinnedBackupPlayerType`, `HasCheckedUnknownTags`, `IsMidroll`, `IsStrippingAdSegments`, `NumStrippedAdSegments`, `RecoverySegments`, `FailedBackupPlayerTypes`, `HasLoggedAdAttributes`, `LoggedBackupAdsByType`, `RecoveryStartSeq`, `CleanPlaylistCount`, `ReloadTimestamps`, `ConsecutiveZeroStripBreaks` | `AdBreakStartedAt`, `PodLength`, `HasConfirmedAdAttrs`, `CycleRescuedThisBreak`, `LastCommittedBackupPlayerType`, `FreezeStartedAt`, `ConsecutiveAllStrippedPolls`, `TotalAllStrippedPolls`, `EarlyReloadCount`, `EarlyReloadAtPoll`, `EarlyReloadTriggered`, `EarlyReloadAwaitingResult` |

You couldn't read the init block to know the complete shape — you had to grep the whole file. Typos in field names went silently uncaught because JS returns `undefined` for missing props. Every recent PR (throughout the v58.0.x line) added at least one new lazily-assigned field.

video-swap-new has the same drift pattern on its own shape (`HasConfirmedAdAttrs`, `RecoveryStartSeq`, `HasLoggedAdAttributes`, `HasLoggedCsaiFastPath` all lazy).

## Change

Introduce `createStreamInfo(...)` as a top-level worker-scope function serialized into the worker blob via `.toString()` (same mechanism as `stripAdSegments`, `processM3U8`, etc.). All ~38 fields (vaft) / ~25 fields (video-swap-new) declared in one place, grouped by concern:

```js
function createStreamInfo(channelName, encodingsM3u8, usherParams) {
    return {
        // Identity / lifecycle
        ChannelName: channelName,
        LastSeenAt: Date.now(),
        EncodingsM3U8: encodingsM3u8,
        UsherParams: usherParams,
        // Resolutions / URL map
        Urls: Object.create(null),
        ResolutionList: [],
        RequestedAds: new Set(),
        // Modified m3u8 state
        ModifiedM3U8: null,
        IsUsingModifiedM3U8: false,
        // Ad-break state
        IsShowingAd: false,
        IsMidroll: false,
        AdBreakStartedAt: 0,
        PodLength: 1,
        HasConfirmedAdAttrs: false,
        CleanPlaylistCount: 0,
        ConsecutiveZeroStripBreaks: 0,
        // Strip state
        IsStrippingAdSegments: false,
        NumStrippedAdSegments: 0,
        RecoverySegments: [],
        RecoveryStartSeq: undefined, // LOAD-BEARING (see below)
        FreezeStartedAt: 0,
        ConsecutiveAllStrippedPolls: 0,
        TotalAllStrippedPolls: 0,
        // Backup player type cycling
        BackupEncodingsM3U8Cache: [],
        ActiveBackupPlayerType: null,
        PinnedBackupPlayerType: null,
        LastCommittedBackupPlayerType: null,
        FailedBackupPlayerTypes: new Map(),
        LoggedBackupAdsByType: null,
        CycleRescuedThisBreak: false,
        // Early reload
        EarlyReloadCount: 0,
        EarlyReloadAtPoll: 0,
        EarlyReloadTriggered: false,
        EarlyReloadAwaitingResult: false,
        // Reload cooldown
        LastPlayerReload: 0,
        ReloadTimestamps: [],
        // Diagnostic flags
        HasCheckedUnknownTags: false,
        HasLoggedAdAttributes: false,
    };
}
```

Init site becomes:

```js
StreamInfos[channelName] = streamInfo = createStreamInfo(channelName, encodingsM3u8, parsedUrl.search);
```

## Safety — every default value verified against existing reads

I walked through every previously-lazy field to confirm that initializing it to a falsy-equivalent default produces identical behavior:

| Field | Old (implicit) | New (explicit) | Read sites | Change? |
|---|---|---|---|---|
| `AdBreakStartedAt` | `undefined` | `0` | `streamInfo.AdBreakStartedAt ? ... : '?'` | No — both falsy |
| `PodLength` | `undefined` | `1` | No reads before first write (`streamInfo.PodLength = podLength`) | No |
| `HasConfirmedAdAttrs` | `undefined` | `false` | `!streamInfo.HasConfirmedAdAttrs` | No |
| `CycleRescuedThisBreak` | `undefined` | `false` | `streamInfo.CycleRescuedThisBreak && ...` | No |
| `LastCommittedBackupPlayerType` | `undefined` | `null` | `if (prevType && prevType !== playerType)` | No |
| `FreezeStartedAt` | `undefined` | `0` | `if (!streamInfo.FreezeStartedAt)` and `? ... : 'unknown'` | No |
| `ConsecutiveAllStrippedPolls` | `undefined` | `0` | `(... \|\| 0) + 1` | No |
| `TotalAllStrippedPolls` | `undefined` | `0` | Same | No |
| `EarlyReloadCount` | `undefined` | `0` | `(... \|\| 0) + 1` | No |
| `EarlyReloadAtPoll` | `undefined` | `0` | `streamInfo.EarlyReloadAtPoll ? ... : ''` | No |
| `EarlyReloadTriggered` | `undefined` | `false` | `!streamInfo.EarlyReloadTriggered` | No |
| `EarlyReloadAwaitingResult` | `undefined` | `false` | Same pattern | No |

### `RecoveryStartSeq: undefined` — LOAD-BEARING

One field stays explicitly `undefined` and is marked with a comment. The recovery injection site uses `if (streamInfo.RecoveryStartSeq !== undefined)` — a strict inequality check. If I'd defaulted this to `0`, the check would incorrectly match on new StreamInfos that never got a real sequence number assigned. Keeping it `undefined` preserves behavior.

### `LoggedBackupAdsByType: null`

Stays `null` (as in the original init block) to preserve the existing lazy-init pattern: `if (!streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType = new Set();`. Both `null` and `undefined` are falsy here, but keeping it explicitly `null` matches the prior code and is more self-documenting.

## Compatibility

- **Worker blob serialization:** `createStreamInfo` is a top-level function in the IIFE, serialized via `${createStreamInfo.toString()}` in the worker blob template — same mechanism as `stripAdSegments`, `processM3U8`, `getAccessToken`, etc. No outer-scope references introduced.
- **.user.js vs uBO scriptlet:** identical code path, factory lives in worker scope under both delivery formats.
- **Userscript manager quirks:** none — the factory uses only plain object literals, `Date.now()`, `new Set()`, `new Map()`, `Object.create(null)`. Everything ES6-baseline.
- **Firefox / iOS / Chromium:** no engine-specific features used.

## Files modified

| File | Factory size | Shape diff |
|---|---|---|
| `vaft/vaft.user.js` | 38 fields | vaft-specific (Early reload, Modified M3U8, URL rewriting) |
| `vaft/vaft-ublock-origin.js` | 38 fields | Same as vaft release |
| `video-swap-new/video-swap-new.user.js` | 25 fields | video-swap-new-specific (BackupEncodings*, IsMovingOffBackupEncodings, UseFallbackStream, HasLoggedCsaiFastPath) |
| `video-swap-new/video-swap-new-ublock-origin.js` | 25 fields | Same as video-swap-new release |

Testing scripts not touched in this PR — will apply via direct-commit to master after this lands (per repo convention).

## Merge conflicts note

This PR will have minor textual conflicts with any open PR that touches the StreamInfo init block (none currently) or that adds new lazy field assignments (PRs #121 and #122 add `LastAdCachePruneAt`, `LoggedAdCacheSize1k`, and regex scope fields — none of which touch the init block itself, so no conflict expected).

Any future PR that adds a new streamInfo field should update the factory as part of that PR — the comment in `createStreamInfo` documents this convention.

## Test plan

- [ ] Acorn validation passes on all four files
- [ ] Start a stream, verify `[AD DEBUG] New stream session` log fires as before
- [ ] Go through an ad break, verify `[AD DEBUG] Ad detected`, `[AD DEBUG] Finished blocking ads`, backup cycling, and all existing logs fire in the same order and with the same values as before the refactor
- [ ] Verify no \"undefined\" or \"NaN\" appears in any log line where a numeric field is interpolated (would indicate a default mismatch)
- [ ] Verify recovery segment injection during a long freeze fires the same way (this is where `RecoveryStartSeq` is checked)
- [ ] Verify `pruneStreamInfos` still clears stale streams on the 5-min interval