### PR TITLE
Fix stale backup commit race + sticky CSAI fast path

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -707,7 +707,6 @@ twitch-videoad.js text/javascript
                 streamInfo.LastCommittedBackupPlayerType = null;
                 streamInfo.FreezeStartedAt = 0;
                 streamInfo.CsaiOnlyThisBreak = false;// Reset sticky CSAI flag for new break
-                streamInfo.CsaiPollsWithStrips = 0;// Reset sticky-clear counter for new break
                 console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName + ', pod: ' + podLength + ' ad(s) (~' + (podLength * 30) + 's expected), signifiers: ' + getMatchedAdSignifiers(textStr).join(', '));
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -745,34 +744,16 @@ twitch-videoad.js text/javascript
                 });
             }
             // Sticky CSAI fast path: if a prior poll in THIS break already confirmed the break
-            // is CSAI-only (all segments live + no SSAI strips), stay on the fast path for the
-            // rest of the break even if Twitch starts serving older buffered segments that flip
-            // hasNonLiveSegment to true. Without this, a slow backup search kicked off on poll 2+
-            // can complete tens of seconds after the break already ended and overwrite cleared
-            // streamInfo state with stale backup data, causing buffer reconciliation failures and
-            // stuck loading circles. Clears itself below if any real SSAI segments arrive mid-break.
+            // is CSAI-only (all segments live on poll 1), stay on the fast path for the rest
+            // of the break. stripAdSegments still handles any real EXTINF ad segments that
+            // show up on later polls (they get cached and the fetch hook returns BLANK_MP4),
+            // so ads are blocked even without the backup switch. Skipping backup search for
+            // the whole CSAI break saves ~20 wasted fetches per break — the backup wouldn't
+            // help anyway since every player type has the same CSAI ads. Flag is cleared
+            // only at break end (IsShowingAd=false path).
             if (streamInfo.CsaiOnlyThisBreak && !streamInfo.IsUsingModifiedM3U8) {
-                // Snapshot NumStrippedAdSegments before the strip call so we can detect
-                // whether THIS poll stripped a new EXTINF ad segment (vs just matching a
-                // signifier substring like 'stitched-ad' which is present on every CSAI
-                // break poll). IsStrippingAdSegments is too loose — it's set whenever
-                // hasStrippedAdSegments is true, including via signifier matches, so it
-                // fires on every CSAI break poll and defeats the 2-poll threshold.
-                const numStrippedBefore = streamInfo.NumStrippedAdSegments || 0;
                 if (IsAdStrippingEnabled) {
                     textStr = stripAdSegments(textStr, false, streamInfo);
-                }
-                // Count polls where an actual new EXTINF ad segment was stripped. A single
-                // transient blip (Twitch serving one older buffered non-live segment on
-                // poll 2 of a pure-CSAI break) increments the counter by 1; sustained SSAI
-                // content increments it further on subsequent polls. Require 2+ polls
-                // before accepting as real SSAI and clearing the sticky flag.
-                if ((streamInfo.NumStrippedAdSegments || 0) > numStrippedBefore) {
-                    streamInfo.CsaiPollsWithStrips = (streamInfo.CsaiPollsWithStrips || 0) + 1;
-                }
-                if ((streamInfo.CsaiPollsWithStrips || 0) >= 2) {
-                    streamInfo.CsaiOnlyThisBreak = false;
-                    console.log('[AD DEBUG] Sticky CSAI cleared — sustained SSAI content (' + streamInfo.CsaiPollsWithStrips + ' polls with strips)');
                 }
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -1041,7 +1022,6 @@ twitch-videoad.js text/javascript
                 streamInfo.EarlyReloadAtPoll = 0;
                 streamInfo.TotalAllStrippedPolls = 0;
                 streamInfo.CsaiOnlyThisBreak = false;
-                streamInfo.CsaiPollsWithStrips = 0;
                 // CSAI-only ad break: no segments were stripped — skip reload entirely.
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -752,18 +752,22 @@ twitch-videoad.js text/javascript
             // streamInfo state with stale backup data, causing buffer reconciliation failures and
             // stuck loading circles. Clears itself below if any real SSAI segments arrive mid-break.
             if (streamInfo.CsaiOnlyThisBreak && !streamInfo.IsUsingModifiedM3U8) {
+                // Snapshot NumStrippedAdSegments before the strip call so we can detect
+                // whether THIS poll stripped a new EXTINF ad segment (vs just matching a
+                // signifier substring like 'stitched-ad' which is present on every CSAI
+                // break poll). IsStrippingAdSegments is too loose — it's set whenever
+                // hasStrippedAdSegments is true, including via signifier matches, so it
+                // fires on every CSAI break poll and defeats the 2-poll threshold.
+                const numStrippedBefore = streamInfo.NumStrippedAdSegments || 0;
                 if (IsAdStrippingEnabled) {
                     textStr = stripAdSegments(textStr, false, streamInfo);
                 }
-                // Count polls where stripAdSegments saw actual ad segments, not just
-                // a transient single non-live segment (common on pure-CSAI breaks where
-                // Twitch serves older buffered frames on poll 2). The original single-poll
-                // trigger was flipping the sticky flag on ~100% of CSAI breaks, defeating
-                // the whole-break optimization. Require 2+ polls with strips before
-                // accepting this as real SSAI content. Uses IsStrippingAdSegments (set by
-                // stripAdSegments per-call) rather than NumStrippedAdSegments (cumulative
-                // with mid-break resets) for a cleaner per-poll signal.
-                if (streamInfo.IsStrippingAdSegments) {
+                // Count polls where an actual new EXTINF ad segment was stripped. A single
+                // transient blip (Twitch serving one older buffered non-live segment on
+                // poll 2 of a pure-CSAI break) increments the counter by 1; sustained SSAI
+                // content increments it further on subsequent polls. Require 2+ polls
+                // before accepting as real SSAI and clearing the sticky flag.
+                if ((streamInfo.NumStrippedAdSegments || 0) > numStrippedBefore) {
                     streamInfo.CsaiPollsWithStrips = (streamInfo.CsaiPollsWithStrips || 0) + 1;
                 }
                 if ((streamInfo.CsaiPollsWithStrips || 0) >= 2) {

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -706,6 +706,7 @@ twitch-videoad.js text/javascript
                 streamInfo.CycleRescuedThisBreak = false;
                 streamInfo.LastCommittedBackupPlayerType = null;
                 streamInfo.FreezeStartedAt = 0;
+                streamInfo.CsaiOnlyThisBreak = false;// Reset sticky CSAI flag for new break
                 console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName + ', pod: ' + podLength + ' ad(s) (~' + (podLength * 30) + 's expected), signifiers: ' + getMatchedAdSignifiers(textStr).join(', '));
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -742,6 +743,34 @@ twitch-videoad.js text/javascript
                     key: 'ReloadPlayer'
                 });
             }
+            // Sticky CSAI fast path: if a prior poll in THIS break already confirmed the break
+            // is CSAI-only (all segments live + no SSAI strips), stay on the fast path for the
+            // rest of the break even if Twitch starts serving older buffered segments that flip
+            // hasNonLiveSegment to true. Without this, a slow backup search kicked off on poll 2+
+            // can complete tens of seconds after the break already ended and overwrite cleared
+            // streamInfo state with stale backup data, causing buffer reconciliation failures and
+            // stuck loading circles. Clears itself below if any real SSAI segments arrive mid-break.
+            if (streamInfo.CsaiOnlyThisBreak && !streamInfo.IsUsingModifiedM3U8) {
+                if (IsAdStrippingEnabled) {
+                    textStr = stripAdSegments(textStr, false, streamInfo);
+                }
+                // If real SSAI content arrived during this break (NumStrippedAdSegments > 0 after
+                // the strip call), the break is actually mixed CSAI+SSAI — clear the sticky flag
+                // so the next poll can run backup search normally.
+                if (streamInfo.NumStrippedAdSegments > 0) {
+                    streamInfo.CsaiOnlyThisBreak = false;
+                    console.log('[AD DEBUG] Sticky CSAI cleared — SSAI content arrived mid-break');
+                }
+                postMessage({
+                    key: 'UpdateAdBlockBanner',
+                    isMidroll: streamInfo.IsMidroll,
+                    hasAds: streamInfo.IsShowingAd,
+                    isStrippingAdSegments: streamInfo.IsStrippingAdSegments,
+                    numStrippedAdSegments: streamInfo.NumStrippedAdSegments,
+                    activeBackupPlayerType: null
+                });
+                return textStr;
+            }
             // CSAI fast path: if all segments in the main stream are live, skip backup search.
             // CSAI ads are delivered outside the m3u8 — the main stream segments are clean.
             // Just strip tracking URLs and return the main stream directly, avoiding the
@@ -755,6 +784,7 @@ twitch-videoad.js text/javascript
                 }
             }
             if (!hasNonLiveSegment && !streamInfo.IsUsingModifiedM3U8) {
+                streamInfo.CsaiOnlyThisBreak = true;// Mark break as confirmed CSAI so subsequent polls stay on the fast path
                 console.log('[AD DEBUG] CSAI fast path — all segments live, skipping backup search');
                 if (IsAdStrippingEnabled) {
                     textStr = stripAdSegments(textStr, false, streamInfo);
@@ -901,7 +931,14 @@ twitch-videoad.js text/javascript
                 backupPlayerType = FallbackPlayerType;
                 backupM3u8 = fallbackM3u8;
             }
-            if (backupM3u8) {
+            // Stale-commit guard: multiple processM3U8 calls can be in flight concurrently for
+            // the same streamInfo (one per m3u8 poll). If this backup search started during the
+            // ad break but completed AFTER a later poll already ran the end-of-break reset
+            // (IsShowingAd = false, ActiveBackupPlayerType = null), committing the backup here
+            // would overwrite the cleared state and feed stale playlist data to the player,
+            // causing buffer reconciliation failures and a forced reload. Check IsShowingAd
+            // here to discard stale results.
+            if (backupM3u8 && streamInfo.IsShowingAd) {
                 textStr = backupM3u8;
                 streamInfo.LastCommittedBackupPlayerType = backupPlayerType;
                 if (streamInfo.ActiveBackupPlayerType != backupPlayerType) {
@@ -912,6 +949,8 @@ twitch-videoad.js text/javascript
                     }
                     console.log(`Blocking${(streamInfo.IsMidroll ? ' midroll ' : ' ')}ads (${backupPlayerType}) — backup found in ${Date.now() - backupSearchStart}ms`);
                 }
+            } else if (backupM3u8 && !streamInfo.IsShowingAd) {
+                console.log('[AD DEBUG] Discarded stale backup commit (' + backupPlayerType + ', ' + (Date.now() - backupSearchStart) + 'ms) — break ended during search');
             } else {
                 console.log('[AD DEBUG] No ad-free backup stream found — ads may leak. Tried: ' + playerTypesToTry.slice(startIndex).join(', '));
             }
@@ -988,6 +1027,7 @@ twitch-videoad.js text/javascript
                 streamInfo.EarlyReloadAwaitingResult = false;
                 streamInfo.EarlyReloadAtPoll = 0;
                 streamInfo.TotalAllStrippedPolls = 0;
+                streamInfo.CsaiOnlyThisBreak = false;
                 // CSAI-only ad break: no segments were stripped — skip reload entirely.
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -707,6 +707,7 @@ twitch-videoad.js text/javascript
                 streamInfo.LastCommittedBackupPlayerType = null;
                 streamInfo.FreezeStartedAt = 0;
                 streamInfo.CsaiOnlyThisBreak = false;// Reset sticky CSAI flag for new break
+                streamInfo.CsaiPollsWithStrips = 0;// Reset sticky-clear counter for new break
                 console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName + ', pod: ' + podLength + ' ad(s) (~' + (podLength * 30) + 's expected), signifiers: ' + getMatchedAdSignifiers(textStr).join(', '));
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -754,12 +755,20 @@ twitch-videoad.js text/javascript
                 if (IsAdStrippingEnabled) {
                     textStr = stripAdSegments(textStr, false, streamInfo);
                 }
-                // If real SSAI content arrived during this break (NumStrippedAdSegments > 0 after
-                // the strip call), the break is actually mixed CSAI+SSAI — clear the sticky flag
-                // so the next poll can run backup search normally.
-                if (streamInfo.NumStrippedAdSegments > 0) {
+                // Count polls where stripAdSegments saw actual ad segments, not just
+                // a transient single non-live segment (common on pure-CSAI breaks where
+                // Twitch serves older buffered frames on poll 2). The original single-poll
+                // trigger was flipping the sticky flag on ~100% of CSAI breaks, defeating
+                // the whole-break optimization. Require 2+ polls with strips before
+                // accepting this as real SSAI content. Uses IsStrippingAdSegments (set by
+                // stripAdSegments per-call) rather than NumStrippedAdSegments (cumulative
+                // with mid-break resets) for a cleaner per-poll signal.
+                if (streamInfo.IsStrippingAdSegments) {
+                    streamInfo.CsaiPollsWithStrips = (streamInfo.CsaiPollsWithStrips || 0) + 1;
+                }
+                if ((streamInfo.CsaiPollsWithStrips || 0) >= 2) {
                     streamInfo.CsaiOnlyThisBreak = false;
-                    console.log('[AD DEBUG] Sticky CSAI cleared — SSAI content arrived mid-break');
+                    console.log('[AD DEBUG] Sticky CSAI cleared — sustained SSAI content (' + streamInfo.CsaiPollsWithStrips + ' polls with strips)');
                 }
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -1028,6 +1037,7 @@ twitch-videoad.js text/javascript
                 streamInfo.EarlyReloadAtPoll = 0;
                 streamInfo.TotalAllStrippedPolls = 0;
                 streamInfo.CsaiOnlyThisBreak = false;
+                streamInfo.CsaiPollsWithStrips = 0;
                 // CSAI-only ad break: no segments were stripped — skip reload entirely.
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -755,6 +755,22 @@ twitch-videoad.js text/javascript
                 if (IsAdStrippingEnabled) {
                     textStr = stripAdSegments(textStr, false, streamInfo);
                 }
+                // Early reload during prolonged freeze — mirrors the check in the normal
+                // backup-search path which we'd otherwise skip entirely by returning early
+                // from the sticky path. Without this, heavy SSAI breaks on CSAI-confirmed
+                // streams leave the player replaying the thin recovery cache for the full
+                // break duration (observed: 35.9s freeze on pod-1 break, 3 all-stripped
+                // polls, 1-segment recovery cache).
+                // Bounded to maxEarlyReloads per ad in pod so reload loops are impossible.
+                const stickyMaxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
+                if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= EarlyReloadPollThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < stickyMaxEarlyReloads) {
+                    streamInfo.EarlyReloadTriggered = true;
+                    streamInfo.EarlyReloadAwaitingResult = true;
+                    streamInfo.EarlyReloadCount = (streamInfo.EarlyReloadCount || 0) + 1;
+                    streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
+                    console.log('[AD DEBUG] Early reload triggered (sticky path) — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls (~' + (streamInfo.ConsecutiveAllStrippedPolls * 2) + 's freeze) [' + streamInfo.EarlyReloadCount + '/' + stickyMaxEarlyReloads + ']');
+                    postMessage({ key: 'ReloadPlayer' });
+                }
                 postMessage({
                     key: 'UpdateAdBlockBanner',
                     isMidroll: streamInfo.IsMidroll,

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -765,6 +765,22 @@
                 if (IsAdStrippingEnabled) {
                     textStr = stripAdSegments(textStr, false, streamInfo);
                 }
+                // Early reload during prolonged freeze — mirrors the check in the normal
+                // backup-search path (line ~952) which we'd otherwise skip entirely by
+                // returning early from the sticky path. Without this, heavy SSAI breaks
+                // on CSAI-confirmed streams leave the player replaying the thin recovery
+                // cache for the full break duration (observed: 35.9s freeze on pod-1
+                // break, 3 all-stripped polls, 1-segment recovery cache).
+                // Bounded to maxEarlyReloads per ad in pod so reload loops are impossible.
+                const stickyMaxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
+                if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= EarlyReloadPollThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < stickyMaxEarlyReloads) {
+                    streamInfo.EarlyReloadTriggered = true;
+                    streamInfo.EarlyReloadAwaitingResult = true;
+                    streamInfo.EarlyReloadCount = (streamInfo.EarlyReloadCount || 0) + 1;
+                    streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
+                    console.log('[AD DEBUG] Early reload triggered (sticky path) — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls (~' + (streamInfo.ConsecutiveAllStrippedPolls * 2) + 's freeze) [' + streamInfo.EarlyReloadCount + '/' + stickyMaxEarlyReloads + ']');
+                    postMessage({ key: 'ReloadPlayer' });
+                }
                 postMessage({
                     key: 'UpdateAdBlockBanner',
                     isMidroll: streamInfo.IsMidroll,

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -717,7 +717,6 @@
                 streamInfo.LastCommittedBackupPlayerType = null;
                 streamInfo.FreezeStartedAt = 0;
                 streamInfo.CsaiOnlyThisBreak = false;// Reset sticky CSAI flag for new break
-                streamInfo.CsaiPollsWithStrips = 0;// Reset sticky-clear counter for new break
                 console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName + ', pod: ' + podLength + ' ad(s) (~' + (podLength * 30) + 's expected), signifiers: ' + getMatchedAdSignifiers(textStr).join(', '));
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -755,34 +754,16 @@
                 });
             }
             // Sticky CSAI fast path: if a prior poll in THIS break already confirmed the break
-            // is CSAI-only (all segments live + no SSAI strips), stay on the fast path for the
-            // rest of the break even if Twitch starts serving older buffered segments that flip
-            // hasNonLiveSegment to true. Without this, a slow backup search kicked off on poll 2+
-            // can complete tens of seconds after the break already ended and overwrite cleared
-            // streamInfo state with stale backup data, causing buffer reconciliation failures and
-            // stuck loading circles. Clears itself below if any real SSAI segments arrive mid-break.
+            // is CSAI-only (all segments live on poll 1), stay on the fast path for the rest
+            // of the break. stripAdSegments still handles any real EXTINF ad segments that
+            // show up on later polls (they get cached and the fetch hook returns BLANK_MP4),
+            // so ads are blocked even without the backup switch. Skipping backup search for
+            // the whole CSAI break saves ~20 wasted fetches per break — the backup wouldn't
+            // help anyway since every player type has the same CSAI ads. Flag is cleared
+            // only at break end (IsShowingAd=false path).
             if (streamInfo.CsaiOnlyThisBreak && !streamInfo.IsUsingModifiedM3U8) {
-                // Snapshot NumStrippedAdSegments before the strip call so we can detect
-                // whether THIS poll stripped a new EXTINF ad segment (vs just matching a
-                // signifier substring like 'stitched-ad' which is present on every CSAI
-                // break poll). IsStrippingAdSegments is too loose — it's set whenever
-                // hasStrippedAdSegments is true, including via signifier matches, so it
-                // fires on every CSAI break poll and defeats the 2-poll threshold.
-                const numStrippedBefore = streamInfo.NumStrippedAdSegments || 0;
                 if (IsAdStrippingEnabled) {
                     textStr = stripAdSegments(textStr, false, streamInfo);
-                }
-                // Count polls where an actual new EXTINF ad segment was stripped. A single
-                // transient blip (Twitch serving one older buffered non-live segment on
-                // poll 2 of a pure-CSAI break) increments the counter by 1; sustained SSAI
-                // content increments it further on subsequent polls. Require 2+ polls
-                // before accepting as real SSAI and clearing the sticky flag.
-                if ((streamInfo.NumStrippedAdSegments || 0) > numStrippedBefore) {
-                    streamInfo.CsaiPollsWithStrips = (streamInfo.CsaiPollsWithStrips || 0) + 1;
-                }
-                if ((streamInfo.CsaiPollsWithStrips || 0) >= 2) {
-                    streamInfo.CsaiOnlyThisBreak = false;
-                    console.log('[AD DEBUG] Sticky CSAI cleared — sustained SSAI content (' + streamInfo.CsaiPollsWithStrips + ' polls with strips)');
                 }
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -1051,7 +1032,6 @@
                 streamInfo.EarlyReloadAtPoll = 0;
                 streamInfo.TotalAllStrippedPolls = 0;
                 streamInfo.CsaiOnlyThisBreak = false;
-                streamInfo.CsaiPollsWithStrips = 0;
                 // CSAI-only ad break: no segments were stripped — skip reload entirely.
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -716,6 +716,7 @@
                 streamInfo.CycleRescuedThisBreak = false;
                 streamInfo.LastCommittedBackupPlayerType = null;
                 streamInfo.FreezeStartedAt = 0;
+                streamInfo.CsaiOnlyThisBreak = false;// Reset sticky CSAI flag for new break
                 console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName + ', pod: ' + podLength + ' ad(s) (~' + (podLength * 30) + 's expected), signifiers: ' + getMatchedAdSignifiers(textStr).join(', '));
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -752,6 +753,34 @@
                     key: 'ReloadPlayer'
                 });
             }
+            // Sticky CSAI fast path: if a prior poll in THIS break already confirmed the break
+            // is CSAI-only (all segments live + no SSAI strips), stay on the fast path for the
+            // rest of the break even if Twitch starts serving older buffered segments that flip
+            // hasNonLiveSegment to true. Without this, a slow backup search kicked off on poll 2+
+            // can complete tens of seconds after the break already ended and overwrite cleared
+            // streamInfo state with stale backup data, causing buffer reconciliation failures and
+            // stuck loading circles. Clears itself below if any real SSAI segments arrive mid-break.
+            if (streamInfo.CsaiOnlyThisBreak && !streamInfo.IsUsingModifiedM3U8) {
+                if (IsAdStrippingEnabled) {
+                    textStr = stripAdSegments(textStr, false, streamInfo);
+                }
+                // If real SSAI content arrived during this break (NumStrippedAdSegments > 0 after
+                // the strip call), the break is actually mixed CSAI+SSAI — clear the sticky flag
+                // so the next poll can run backup search normally.
+                if (streamInfo.NumStrippedAdSegments > 0) {
+                    streamInfo.CsaiOnlyThisBreak = false;
+                    console.log('[AD DEBUG] Sticky CSAI cleared — SSAI content arrived mid-break');
+                }
+                postMessage({
+                    key: 'UpdateAdBlockBanner',
+                    isMidroll: streamInfo.IsMidroll,
+                    hasAds: streamInfo.IsShowingAd,
+                    isStrippingAdSegments: streamInfo.IsStrippingAdSegments,
+                    numStrippedAdSegments: streamInfo.NumStrippedAdSegments,
+                    activeBackupPlayerType: null
+                });
+                return textStr;
+            }
             // CSAI fast path: if all segments in the main stream are live, skip backup search.
             // CSAI ads are delivered outside the m3u8 — the main stream segments are clean.
             // Just strip tracking URLs and return the main stream directly, avoiding the
@@ -765,6 +794,7 @@
                 }
             }
             if (!hasNonLiveSegment && !streamInfo.IsUsingModifiedM3U8) {
+                streamInfo.CsaiOnlyThisBreak = true;// Mark break as confirmed CSAI so subsequent polls stay on the fast path
                 console.log('[AD DEBUG] CSAI fast path — all segments live, skipping backup search');
                 if (IsAdStrippingEnabled) {
                     textStr = stripAdSegments(textStr, false, streamInfo);
@@ -911,7 +941,14 @@
                 backupPlayerType = FallbackPlayerType;
                 backupM3u8 = fallbackM3u8;
             }
-            if (backupM3u8) {
+            // Stale-commit guard: multiple processM3U8 calls can be in flight concurrently for
+            // the same streamInfo (one per m3u8 poll). If this backup search started during the
+            // ad break but completed AFTER a later poll already ran the end-of-break reset
+            // (IsShowingAd = false, ActiveBackupPlayerType = null), committing the backup here
+            // would overwrite the cleared state and feed stale playlist data to the player,
+            // causing buffer reconciliation failures and a forced reload. Check IsShowingAd
+            // here to discard stale results.
+            if (backupM3u8 && streamInfo.IsShowingAd) {
                 textStr = backupM3u8;
                 streamInfo.LastCommittedBackupPlayerType = backupPlayerType;
                 if (streamInfo.ActiveBackupPlayerType != backupPlayerType) {
@@ -922,6 +959,8 @@
                     }
                     console.log(`Blocking${(streamInfo.IsMidroll ? ' midroll ' : ' ')}ads (${backupPlayerType}) — backup found in ${Date.now() - backupSearchStart}ms`);
                 }
+            } else if (backupM3u8 && !streamInfo.IsShowingAd) {
+                console.log('[AD DEBUG] Discarded stale backup commit (' + backupPlayerType + ', ' + (Date.now() - backupSearchStart) + 'ms) — break ended during search');
             } else {
                 console.log('[AD DEBUG] No ad-free backup stream found — ads may leak. Tried: ' + playerTypesToTry.slice(startIndex).join(', '));
             }
@@ -998,6 +1037,7 @@
                 streamInfo.EarlyReloadAwaitingResult = false;
                 streamInfo.EarlyReloadAtPoll = 0;
                 streamInfo.TotalAllStrippedPolls = 0;
+                streamInfo.CsaiOnlyThisBreak = false;
                 // CSAI-only ad break: no segments were stripped — skip reload entirely.
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -762,18 +762,22 @@
             // streamInfo state with stale backup data, causing buffer reconciliation failures and
             // stuck loading circles. Clears itself below if any real SSAI segments arrive mid-break.
             if (streamInfo.CsaiOnlyThisBreak && !streamInfo.IsUsingModifiedM3U8) {
+                // Snapshot NumStrippedAdSegments before the strip call so we can detect
+                // whether THIS poll stripped a new EXTINF ad segment (vs just matching a
+                // signifier substring like 'stitched-ad' which is present on every CSAI
+                // break poll). IsStrippingAdSegments is too loose — it's set whenever
+                // hasStrippedAdSegments is true, including via signifier matches, so it
+                // fires on every CSAI break poll and defeats the 2-poll threshold.
+                const numStrippedBefore = streamInfo.NumStrippedAdSegments || 0;
                 if (IsAdStrippingEnabled) {
                     textStr = stripAdSegments(textStr, false, streamInfo);
                 }
-                // Count polls where stripAdSegments saw actual ad segments, not just
-                // a transient single non-live segment (common on pure-CSAI breaks where
-                // Twitch serves older buffered frames on poll 2). The original single-poll
-                // trigger was flipping the sticky flag on ~100% of CSAI breaks, defeating
-                // the whole-break optimization. Require 2+ polls with strips before
-                // accepting this as real SSAI content. Uses IsStrippingAdSegments (set by
-                // stripAdSegments per-call) rather than NumStrippedAdSegments (cumulative
-                // with mid-break resets) for a cleaner per-poll signal.
-                if (streamInfo.IsStrippingAdSegments) {
+                // Count polls where an actual new EXTINF ad segment was stripped. A single
+                // transient blip (Twitch serving one older buffered non-live segment on
+                // poll 2 of a pure-CSAI break) increments the counter by 1; sustained SSAI
+                // content increments it further on subsequent polls. Require 2+ polls
+                // before accepting as real SSAI and clearing the sticky flag.
+                if ((streamInfo.NumStrippedAdSegments || 0) > numStrippedBefore) {
                     streamInfo.CsaiPollsWithStrips = (streamInfo.CsaiPollsWithStrips || 0) + 1;
                 }
                 if ((streamInfo.CsaiPollsWithStrips || 0) >= 2) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -717,6 +717,7 @@
                 streamInfo.LastCommittedBackupPlayerType = null;
                 streamInfo.FreezeStartedAt = 0;
                 streamInfo.CsaiOnlyThisBreak = false;// Reset sticky CSAI flag for new break
+                streamInfo.CsaiPollsWithStrips = 0;// Reset sticky-clear counter for new break
                 console.log('[AD DEBUG] Ad detected — type: ' + (streamInfo.IsMidroll ? 'midroll' : 'preroll') + ', channel: ' + streamInfo.ChannelName + ', pod: ' + podLength + ' ad(s) (~' + (podLength * 30) + 's expected), signifiers: ' + getMatchedAdSignifiers(textStr).join(', '));
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -764,12 +765,20 @@
                 if (IsAdStrippingEnabled) {
                     textStr = stripAdSegments(textStr, false, streamInfo);
                 }
-                // If real SSAI content arrived during this break (NumStrippedAdSegments > 0 after
-                // the strip call), the break is actually mixed CSAI+SSAI — clear the sticky flag
-                // so the next poll can run backup search normally.
-                if (streamInfo.NumStrippedAdSegments > 0) {
+                // Count polls where stripAdSegments saw actual ad segments, not just
+                // a transient single non-live segment (common on pure-CSAI breaks where
+                // Twitch serves older buffered frames on poll 2). The original single-poll
+                // trigger was flipping the sticky flag on ~100% of CSAI breaks, defeating
+                // the whole-break optimization. Require 2+ polls with strips before
+                // accepting this as real SSAI content. Uses IsStrippingAdSegments (set by
+                // stripAdSegments per-call) rather than NumStrippedAdSegments (cumulative
+                // with mid-break resets) for a cleaner per-poll signal.
+                if (streamInfo.IsStrippingAdSegments) {
+                    streamInfo.CsaiPollsWithStrips = (streamInfo.CsaiPollsWithStrips || 0) + 1;
+                }
+                if ((streamInfo.CsaiPollsWithStrips || 0) >= 2) {
                     streamInfo.CsaiOnlyThisBreak = false;
-                    console.log('[AD DEBUG] Sticky CSAI cleared — SSAI content arrived mid-break');
+                    console.log('[AD DEBUG] Sticky CSAI cleared — sustained SSAI content (' + streamInfo.CsaiPollsWithStrips + ' polls with strips)');
                 }
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -1038,6 +1047,7 @@
                 streamInfo.EarlyReloadAtPoll = 0;
                 streamInfo.TotalAllStrippedPolls = 0;
                 streamInfo.CsaiOnlyThisBreak = false;
+                streamInfo.CsaiPollsWithStrips = 0;
                 // CSAI-only ad break: no segments were stripped — skip reload entirely.
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');


### PR DESCRIPTION
## Summary

Two complementary fixes for a concurrent-poll race observed in testing logs where a slow backup search completed after its ad break had already ended, overwriting cleared `streamInfo` state with stale backup data and causing a forced player reload + ~20s visible loading circle.

## Symptom (from user log)

```
[AD DEBUG] New stream session — channel: august, API: v2
[AD DEBUG] Ad detected — type: midroll, channel: august, pod: 1 ad(s) (~30s expected)
[AD DEBUG] Spoofed ad completion for 1 ad(s) — roll: midroll
[AD DEBUG] CSAI fast path — all segments live, skipping backup search   ← poll 1 correct
[AD DEBUG] Ad tracking attributes seen: ... (22 keys)
Finished blocking ads — stripped 0 ad segments, duration: 68.0s         ← break ended normally
[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action
(8 minutes of normal playback)
Blocking midroll ads (embed) — backup found in 43851ms                  ← STALE: poll 2's slow backup search
Attempt to fix buffering position:557.11 bufferedPosition:587.24        ← player buffer stuck
[AD DEBUG] Seeking past 2.1s buffer gap
[AD DEBUG] Drift correction: catching up at 1.1x
(buffer drains to 0, player pauses, forced reload to position 0)
```

## Root cause

`processM3U8` is async and runs independently per m3u8 fetch. Twitch polls ~every 2s. Multiple `processM3U8` calls can be in flight concurrently against the same `streamInfo`.

During the ad break above:

1. **Poll 1** enters ad break → CSAI fast path → early return ✅
2. **Poll 2** (~2s later) sees `hasNonLiveSegment = true` (Twitch started serving older buffered segments in the playlist) → runs the full backup player type cycling loop
3. That loop is slow because **every backup type has the same CSAI ad signifiers** (CSAI ads are delivered at the player level, not in the m3u8, so every stream view shows them). So it cycles through all 4 types × 2 retries × 2+ fetches = 16+ network round trips. **Total 43.8 seconds.**
4. **Polls 3–N** fire normally at 2s intervals. They detect break end at ~68s, run the end-of-break reset (`IsShowingAd = false`, `ActiveBackupPlayerType = null`), log `Finished blocking ads`.
5. **Poll 2 finally returns**, 43.8s after starting. At the commit site (`vaft.user.js:914-924`):

```js
if (backupM3u8) {
    textStr = backupM3u8;
    streamInfo.LastCommittedBackupPlayerType = backupPlayerType;
    if (streamInfo.ActiveBackupPlayerType != backupPlayerType) {
        streamInfo.ActiveBackupPlayerType = backupPlayerType;  // STALE WRITE
        ...
    }
}
```

No awareness that the break already ended. Poll 2 unconditionally writes the stale backup commit back into `streamInfo` and returns the backup m3u8 as the HTTP response body. The Twitch player, which was happily playing the main stream, receives a playlist with different segment timestamps. MSE can't reconcile, buffer drains to 0, forced reload.

## Fix 1 — Stale-commit guard

Check `streamInfo.IsShowingAd` at the backup commit site. If the break ended while the search was running, log a diagnostic and discard the result instead of writing stale state.

```diff
-if (backupM3u8) {
+if (backupM3u8 && streamInfo.IsShowingAd) {
     textStr = backupM3u8;
     streamInfo.LastCommittedBackupPlayerType = backupPlayerType;
     // ... existing commit logic ...
+} else if (backupM3u8 && !streamInfo.IsShowingAd) {
+    console.log('[AD DEBUG] Discarded stale backup commit (' + backupPlayerType + ', ' + (Date.now() - backupSearchStart) + 'ms) — break ended during search');
 } else {
     console.log('[AD DEBUG] No ad-free backup stream found ...');
 }
```

This fixes the symptom but not the waste — we'd still spend 43.8s grinding through backup player types during every pure-CSAI break, just without the stale commit at the end.

## Fix 2 — Sticky CSAI fast path

Once a poll confirms the break is CSAI-only (all segments live + in an ad break), mark the break as such and stay on the fast path for subsequent polls even if Twitch starts serving older buffered segments mid-break. Clears itself if:

- Break ends (`IsShowingAd = false`)
- Real SSAI content arrives mid-break (`NumStrippedAdSegments > 0` after the strip — handles mixed CSAI+SSAI breaks)

```js
// New: sticky fast path runs BEFORE the existing hasNonLiveSegment scan
if (streamInfo.CsaiOnlyThisBreak && !streamInfo.IsUsingModifiedM3U8) {
    if (IsAdStrippingEnabled) {
        textStr = stripAdSegments(textStr, false, streamInfo);
    }
    if (streamInfo.NumStrippedAdSegments > 0) {
        streamInfo.CsaiOnlyThisBreak = false;
        console.log('[AD DEBUG] Sticky CSAI cleared — SSAI content arrived mid-break');
    }
    // banner + return
    return textStr;
}

// Existing CSAI fast path now also sets the flag:
if (!hasNonLiveSegment && !streamInfo.IsUsingModifiedM3U8) {
    streamInfo.CsaiOnlyThisBreak = true;  // new line
    console.log('[AD DEBUG] CSAI fast path — all segments live, skipping backup search');
    // ... existing strip + return
}
```

New field `CsaiOnlyThisBreak` initialized to `false` at break entry and cleared alongside other break-end state (`IsShowingAd = false` block).

## Why both fixes

- **Stale-commit guard alone:** fixes the user-visible bug (stuck buffer / forced reload after slow backup search lands post-break). But we still waste 43.8s of worker CPU + ~16 network round trips per CSAI break, the search just completes silently and gets discarded.
- **Sticky CSAI alone:** prevents the 43.8s backup grind on pure-CSAI breaks. But we're still vulnerable to the race on any break where the backup search runs legitimately and takes longer than expected (mixed CSAI+SSAI, slow network during real SSAI recovery).

Shipping both means: CSAI-only breaks never run a backup search past poll 1, and any legitimately slow backup search that does run has its result discarded if it lands after the break ends.

## Files modified

- `vaft/vaft.user.js` — new-break-entry init, sticky fast path, existing fast path, commit-site guard, end-of-break cleanup
- `vaft/vaft-ublock-origin.js` — same

Testing scripts will be applied via direct-commit after this PR lands (per repo convention).

**video-swap-new not touched.** It has a different backup commit architecture (`onFoundAd` writes `BackupEncodings`, subsequent polls check `if (streamInfo.BackupEncodings && haveAdTags)`). The same class of race may or may not exist there — needs separate investigation. Left for a follow-up PR if confirmed.

## Risk

- **Sticky flag stuck on forever:** only possible if break-end cleanup doesn't fire. The flag is cleared in the same block as `IsShowingAd = false` / `ActiveBackupPlayerType = null` / all other break-end state, so if that block fails to run, many other things are broken first.
- **Mixed CSAI+SSAI breaks:** the `NumStrippedAdSegments > 0` check clears the sticky flag when real SSAI content arrives, so the next poll runs the normal backup search. Worst case: one poll of missed backup search on the transition from CSAI to SSAI — recovered on the next poll.
- **Stale-commit guard false-negatives:** if the check accidentally discards a legitimate backup commit, the player would miss the backup. Only possible if `IsShowingAd` becomes false while the break is actually still active — which would be a different bug in the break-end detection, not this fix. The guard is a safety net, not a new code path.

## Test plan

- [ ] Acorn validation passes on both vaft files
- [ ] CSAI-only midroll break: first poll logs CSAI fast path, subsequent polls take the same path silently (no log spam), no `Blocking midroll ads` log
- [ ] Mixed CSAI+SSAI break: if SSAI segments appear, sticky flag clears and backup search runs normally (`Sticky CSAI cleared — SSAI content arrived mid-break` diagnostic)
- [ ] Slow network SSAI break where backup search takes >10s and break ends before it completes: `Discarded stale backup commit` log fires, player doesn't get stale backup data
- [ ] Normal SSAI break with fast backup search: unchanged behavior
- [ ] Break-end reset still fires; next break enters cleanly with fresh state