### PR TITLE
Cache clean native m3u8 snapshot for all-stripped recovery (ported from TTV-AB)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -422,7 +422,9 @@ twitch-videoad.js text/javascript
                                         RecoveryStartSeq: undefined,
                                         CleanPlaylistCount: 0,
                                         ReloadTimestamps: [],
-                                        ConsecutiveZeroStripBreaks: 0
+                                        ConsecutiveZeroStripBreaks: 0,
+                                        LastCleanNativeM3U8: null,// Full-playlist snapshot cached during non-ad polls for all-stripped recovery (mirrors TTV-AB LastCleanNativeM3U8)
+                                        LastCleanNativePlaylistAt: 0
                                     };
                                     const lines = encodingsM3u8.split(/\r?\n/);
                                     for (let i = 0; i < lines.length - 1; i++) {
@@ -603,23 +605,37 @@ twitch-videoad.js text/javascript
                 streamInfo.RecoveryStartSeq = seq + Math.max(0, liveSegments.length - streamInfo.RecoverySegments.length);
             }
         }
-        // If all segments were stripped, restore cached recovery segments to prevent black screen
-        if (hasStrippedAdSegments && liveSegments.length === 0 && streamInfo.RecoverySegments && streamInfo.RecoverySegments.length > 0) {
+        // If all segments were stripped, try to prevent black screen via recovery content.
+        // Prefer the full-playlist snapshot from a recent non-ad poll (mirrors TTV-AB
+        // LastCleanNativeM3U8 approach) — gives the player 4-6 live segments worth of
+        // content vs the thin per-segment recovery cache. Falls back to the per-segment
+        // cache if the snapshot is stale or missing.
+        if (hasStrippedAdSegments && liveSegments.length === 0) {
             streamInfo.ConsecutiveAllStrippedPolls = (streamInfo.ConsecutiveAllStrippedPolls || 0) + 1;
             streamInfo.TotalAllStrippedPolls = (streamInfo.TotalAllStrippedPolls || 0) + 1;
             if (!streamInfo.FreezeStartedAt) streamInfo.FreezeStartedAt = Date.now();
-            console.log('[AD DEBUG] All segments stripped — restoring ' + streamInfo.RecoverySegments.length + ' recovery segments');
-            if (streamInfo.RecoveryStartSeq !== undefined) {
-                for (let j = 0; j < lines.length; j++) {
-                    if (lines[j].startsWith('#EXT-X-MEDIA-SEQUENCE:')) {
-                        lines[j] = '#EXT-X-MEDIA-SEQUENCE:' + streamInfo.RecoveryStartSeq;
-                        break;
+            // Primary: fresh full-playlist snapshot (< 1.5s old, must not itself contain ad markers)
+            const snapshotAge = streamInfo.LastCleanNativePlaylistAt ? (Date.now() - streamInfo.LastCleanNativePlaylistAt) : Infinity;
+            if (streamInfo.LastCleanNativeM3U8 && snapshotAge <= 1500 && !hasAdTags(streamInfo.LastCleanNativeM3U8)) {
+                console.log('[AD DEBUG] All segments stripped — reusing last clean native playlist (' + snapshotAge + 'ms old)');
+                streamInfo.IsStrippingAdSegments = hasStrippedAdSegments;
+                return streamInfo.LastCleanNativeM3U8;
+            }
+            // Fallback: per-segment recovery cache (existing behavior)
+            if (streamInfo.RecoverySegments && streamInfo.RecoverySegments.length > 0) {
+                console.log('[AD DEBUG] All segments stripped — restoring ' + streamInfo.RecoverySegments.length + ' recovery segments');
+                if (streamInfo.RecoveryStartSeq !== undefined) {
+                    for (let j = 0; j < lines.length; j++) {
+                        if (lines[j].startsWith('#EXT-X-MEDIA-SEQUENCE:')) {
+                            lines[j] = '#EXT-X-MEDIA-SEQUENCE:' + streamInfo.RecoveryStartSeq;
+                            break;
+                        }
                     }
                 }
-            }
-            for (let j = 0; j < streamInfo.RecoverySegments.length; j++) {
-                lines.push(streamInfo.RecoverySegments[j].extinf);
-                lines.push(streamInfo.RecoverySegments[j].url);
+                for (let j = 0; j < streamInfo.RecoverySegments.length; j++) {
+                    lines.push(streamInfo.RecoverySegments[j].extinf);
+                    lines.push(streamInfo.RecoverySegments[j].url);
+                }
             }
         } else if (liveSegments.length > 0) {
             // Reset freeze counter when live segments are available
@@ -688,6 +704,18 @@ twitch-videoad.js text/javascript
             }
         }
         const haveAdTags = hasAdTags(textStr) || SimulatedAdsDepth > 0;
+        // Cache the clean main stream m3u8 for all-stripped recovery fallback.
+        // Updated during non-ad polls (outside of any ad break), so by the time an ad
+        // break starts, streamInfo.LastCleanNativeM3U8 holds a snapshot ~1-2 seconds old
+        // with several live segments. When heavy SSAI breaks leave the main playlist
+        // entirely stripped, stripAdSegments replays this snapshot instead of the thin
+        // RecoverySegments array — typically gives the player 4-6 live segments of
+        // content to chew on vs the 1-2 cached individual segments.
+        // Mirrors TTV-AB src/modules/processor.ts:733-736.
+        if (!haveAdTags && !streamInfo.IsShowingAd && textStr.indexOf('#EXTINF') !== -1) {
+            streamInfo.LastCleanNativeM3U8 = textStr;
+            streamInfo.LastCleanNativePlaylistAt = Date.now();
+        }
         if (haveAdTags) {
             streamInfo.CleanPlaylistCount = 0;
             streamInfo.IsMidroll = textStr.includes('"MIDROLL"') || textStr.includes('"midroll"');

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -432,7 +432,9 @@
                                         RecoveryStartSeq: undefined,
                                         CleanPlaylistCount: 0,
                                         ReloadTimestamps: [],
-                                        ConsecutiveZeroStripBreaks: 0
+                                        ConsecutiveZeroStripBreaks: 0,
+                                        LastCleanNativeM3U8: null,// Full-playlist snapshot cached during non-ad polls for all-stripped recovery (mirrors TTV-AB LastCleanNativeM3U8)
+                                        LastCleanNativePlaylistAt: 0
                                     };
                                     const lines = encodingsM3u8.split(/\r?\n/);
                                     for (let i = 0; i < lines.length - 1; i++) {
@@ -613,23 +615,37 @@
                 streamInfo.RecoveryStartSeq = seq + Math.max(0, liveSegments.length - streamInfo.RecoverySegments.length);
             }
         }
-        // If all segments were stripped, restore cached recovery segments to prevent black screen
-        if (hasStrippedAdSegments && liveSegments.length === 0 && streamInfo.RecoverySegments && streamInfo.RecoverySegments.length > 0) {
+        // If all segments were stripped, try to prevent black screen via recovery content.
+        // Prefer the full-playlist snapshot from a recent non-ad poll (mirrors TTV-AB
+        // LastCleanNativeM3U8 approach) — gives the player 4-6 live segments worth of
+        // content vs the thin per-segment recovery cache. Falls back to the per-segment
+        // cache if the snapshot is stale or missing.
+        if (hasStrippedAdSegments && liveSegments.length === 0) {
             streamInfo.ConsecutiveAllStrippedPolls = (streamInfo.ConsecutiveAllStrippedPolls || 0) + 1;
             streamInfo.TotalAllStrippedPolls = (streamInfo.TotalAllStrippedPolls || 0) + 1;
             if (!streamInfo.FreezeStartedAt) streamInfo.FreezeStartedAt = Date.now();
-            console.log('[AD DEBUG] All segments stripped — restoring ' + streamInfo.RecoverySegments.length + ' recovery segments');
-            if (streamInfo.RecoveryStartSeq !== undefined) {
-                for (let j = 0; j < lines.length; j++) {
-                    if (lines[j].startsWith('#EXT-X-MEDIA-SEQUENCE:')) {
-                        lines[j] = '#EXT-X-MEDIA-SEQUENCE:' + streamInfo.RecoveryStartSeq;
-                        break;
+            // Primary: fresh full-playlist snapshot (< 1.5s old, must not itself contain ad markers)
+            const snapshotAge = streamInfo.LastCleanNativePlaylistAt ? (Date.now() - streamInfo.LastCleanNativePlaylistAt) : Infinity;
+            if (streamInfo.LastCleanNativeM3U8 && snapshotAge <= 1500 && !hasAdTags(streamInfo.LastCleanNativeM3U8)) {
+                console.log('[AD DEBUG] All segments stripped — reusing last clean native playlist (' + snapshotAge + 'ms old)');
+                streamInfo.IsStrippingAdSegments = hasStrippedAdSegments;
+                return streamInfo.LastCleanNativeM3U8;
+            }
+            // Fallback: per-segment recovery cache (existing behavior)
+            if (streamInfo.RecoverySegments && streamInfo.RecoverySegments.length > 0) {
+                console.log('[AD DEBUG] All segments stripped — restoring ' + streamInfo.RecoverySegments.length + ' recovery segments');
+                if (streamInfo.RecoveryStartSeq !== undefined) {
+                    for (let j = 0; j < lines.length; j++) {
+                        if (lines[j].startsWith('#EXT-X-MEDIA-SEQUENCE:')) {
+                            lines[j] = '#EXT-X-MEDIA-SEQUENCE:' + streamInfo.RecoveryStartSeq;
+                            break;
+                        }
                     }
                 }
-            }
-            for (let j = 0; j < streamInfo.RecoverySegments.length; j++) {
-                lines.push(streamInfo.RecoverySegments[j].extinf);
-                lines.push(streamInfo.RecoverySegments[j].url);
+                for (let j = 0; j < streamInfo.RecoverySegments.length; j++) {
+                    lines.push(streamInfo.RecoverySegments[j].extinf);
+                    lines.push(streamInfo.RecoverySegments[j].url);
+                }
             }
         } else if (liveSegments.length > 0) {
             // Reset freeze counter when live segments are available
@@ -698,6 +714,18 @@
             }
         }
         const haveAdTags = hasAdTags(textStr) || SimulatedAdsDepth > 0;
+        // Cache the clean main stream m3u8 for all-stripped recovery fallback.
+        // Updated during non-ad polls (outside of any ad break), so by the time an ad
+        // break starts, streamInfo.LastCleanNativeM3U8 holds a snapshot ~1-2 seconds old
+        // with several live segments. When heavy SSAI breaks leave the main playlist
+        // entirely stripped, stripAdSegments replays this snapshot instead of the thin
+        // RecoverySegments array — typically gives the player 4-6 live segments of
+        // content to chew on vs the 1-2 cached individual segments.
+        // Mirrors TTV-AB src/modules/processor.ts:733-736.
+        if (!haveAdTags && !streamInfo.IsShowingAd && textStr.indexOf('#EXTINF') !== -1) {
+            streamInfo.LastCleanNativeM3U8 = textStr;
+            streamInfo.LastCleanNativePlaylistAt = Date.now();
+        }
         if (haveAdTags) {
             streamInfo.CleanPlaylistCount = 0;
             streamInfo.IsMidroll = textStr.includes('"MIDROLL"') || textStr.includes('"midroll"');

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -523,20 +523,34 @@ twitch-videoad.js text/javascript
                 streamInfo.RecoveryStartSeq = seq + Math.max(0, liveSegments.length - streamInfo.RecoverySegments.length);
             }
         }
-        // If all segments were stripped, restore cached recovery segments to prevent black screen
-        if (hasStrippedAdSegments && liveSegments.length === 0 && streamInfo.RecoverySegments && streamInfo.RecoverySegments.length > 0) {
-            console.log('[AD DEBUG] All segments stripped — restoring ' + streamInfo.RecoverySegments.length + ' recovery segments');
-            if (streamInfo.RecoveryStartSeq !== undefined) {
-                for (let j = 0; j < lines.length; j++) {
-                    if (lines[j].startsWith('#EXT-X-MEDIA-SEQUENCE:')) {
-                        lines[j] = '#EXT-X-MEDIA-SEQUENCE:' + streamInfo.RecoveryStartSeq;
-                        break;
+        // If all segments were stripped, try to prevent black screen via recovery content.
+        // Prefer the full-playlist snapshot from a recent non-ad poll (mirrors TTV-AB
+        // LastCleanNativeM3U8 approach) — gives the player 4-6 live segments worth of
+        // content vs the thin per-segment recovery cache. Falls back to the per-segment
+        // cache if the snapshot is stale or missing.
+        if (hasStrippedAdSegments && liveSegments.length === 0) {
+            // Primary: fresh full-playlist snapshot (< 1.5s old, must not itself contain ad markers)
+            const snapshotAge = streamInfo.LastCleanNativePlaylistAt ? (Date.now() - streamInfo.LastCleanNativePlaylistAt) : Infinity;
+            if (streamInfo.LastCleanNativeM3U8 && snapshotAge <= 1500 && !hasAdTags(streamInfo.LastCleanNativeM3U8)) {
+                console.log('[AD DEBUG] All segments stripped — reusing last clean native playlist (' + snapshotAge + 'ms old)');
+                streamInfo.IsStrippingAdSegments = hasStrippedAdSegments;
+                return streamInfo.LastCleanNativeM3U8;
+            }
+            // Fallback: per-segment recovery cache (existing behavior)
+            if (streamInfo.RecoverySegments && streamInfo.RecoverySegments.length > 0) {
+                console.log('[AD DEBUG] All segments stripped — restoring ' + streamInfo.RecoverySegments.length + ' recovery segments');
+                if (streamInfo.RecoveryStartSeq !== undefined) {
+                    for (let j = 0; j < lines.length; j++) {
+                        if (lines[j].startsWith('#EXT-X-MEDIA-SEQUENCE:')) {
+                            lines[j] = '#EXT-X-MEDIA-SEQUENCE:' + streamInfo.RecoveryStartSeq;
+                            break;
+                        }
                     }
                 }
-            }
-            for (let j = 0; j < streamInfo.RecoverySegments.length; j++) {
-                lines.push(streamInfo.RecoverySegments[j].extinf);
-                lines.push(streamInfo.RecoverySegments[j].url);
+                for (let j = 0; j < streamInfo.RecoverySegments.length; j++) {
+                    lines.push(streamInfo.RecoverySegments[j].extinf);
+                    lines.push(streamInfo.RecoverySegments[j].url);
+                }
             }
         }
         streamInfo.IsStrippingAdSegments = hasStrippedAdSegments;
@@ -568,6 +582,18 @@ twitch-videoad.js text/javascript
             }
         }
         const haveAdTags = hasAdTags(textStr) || (SimulatedAdsDepth > 0 && (!streamInfo.BackupEncodings || !streamInfo.BackupEncodings.includes(url) || SimulatedAdsDepth - 1 > streamInfo.BackupEncodingsPlayerTypeIndex));
+        // Cache the clean main stream m3u8 for all-stripped recovery fallback.
+        // Updated during non-ad polls (outside of any ad break), so by the time an ad
+        // break starts, streamInfo.LastCleanNativeM3U8 holds a snapshot ~1-2 seconds old
+        // with several live segments. When heavy SSAI breaks leave the main playlist
+        // entirely stripped, stripAdSegments replays this snapshot instead of the thin
+        // RecoverySegments array — typically gives the player 4-6 live segments of
+        // content vs the 1-2 cached individual segments.
+        // Mirrors TTV-AB src/modules/processor.ts:733-736.
+        if (!haveAdTags && !streamInfo.BackupEncodings && textStr.indexOf('#EXTINF') !== -1) {
+            streamInfo.LastCleanNativeM3U8 = textStr;
+            streamInfo.LastCleanNativePlaylistAt = Date.now();
+        }
         if (streamInfo.BackupEncodings) {
             const streamM3u8Url = streamInfo.Encodings.match(/^https:.*\.m3u8$/m)?.[0];
             const streamM3u8Response = await realFetch(streamM3u8Url);
@@ -730,6 +756,8 @@ twitch-videoad.js text/javascript
                                 ChannelName: channelName,
                                 UsherParams: (new URL(url)).search,
                                 Urls: new Map(),
+                                LastCleanNativeM3U8: null,// Full-playlist snapshot for all-stripped recovery (mirrors TTV-AB)
+                                LastCleanNativePlaylistAt: 0,
                             };
                             const encodingsM3u8Response = await realFetch(url, options);
                             if (encodingsM3u8Response != null && encodingsM3u8Response.status === 200) {

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -534,20 +534,34 @@
                 streamInfo.RecoveryStartSeq = seq + Math.max(0, liveSegments.length - streamInfo.RecoverySegments.length);
             }
         }
-        // If all segments were stripped, restore cached recovery segments to prevent black screen
-        if (hasStrippedAdSegments && liveSegments.length === 0 && streamInfo.RecoverySegments && streamInfo.RecoverySegments.length > 0) {
-            console.log('[AD DEBUG] All segments stripped — restoring ' + streamInfo.RecoverySegments.length + ' recovery segments');
-            if (streamInfo.RecoveryStartSeq !== undefined) {
-                for (let j = 0; j < lines.length; j++) {
-                    if (lines[j].startsWith('#EXT-X-MEDIA-SEQUENCE:')) {
-                        lines[j] = '#EXT-X-MEDIA-SEQUENCE:' + streamInfo.RecoveryStartSeq;
-                        break;
+        // If all segments were stripped, try to prevent black screen via recovery content.
+        // Prefer the full-playlist snapshot from a recent non-ad poll (mirrors TTV-AB
+        // LastCleanNativeM3U8 approach) — gives the player 4-6 live segments worth of
+        // content vs the thin per-segment recovery cache. Falls back to the per-segment
+        // cache if the snapshot is stale or missing.
+        if (hasStrippedAdSegments && liveSegments.length === 0) {
+            // Primary: fresh full-playlist snapshot (< 1.5s old, must not itself contain ad markers)
+            const snapshotAge = streamInfo.LastCleanNativePlaylistAt ? (Date.now() - streamInfo.LastCleanNativePlaylistAt) : Infinity;
+            if (streamInfo.LastCleanNativeM3U8 && snapshotAge <= 1500 && !hasAdTags(streamInfo.LastCleanNativeM3U8)) {
+                console.log('[AD DEBUG] All segments stripped — reusing last clean native playlist (' + snapshotAge + 'ms old)');
+                streamInfo.IsStrippingAdSegments = hasStrippedAdSegments;
+                return streamInfo.LastCleanNativeM3U8;
+            }
+            // Fallback: per-segment recovery cache (existing behavior)
+            if (streamInfo.RecoverySegments && streamInfo.RecoverySegments.length > 0) {
+                console.log('[AD DEBUG] All segments stripped — restoring ' + streamInfo.RecoverySegments.length + ' recovery segments');
+                if (streamInfo.RecoveryStartSeq !== undefined) {
+                    for (let j = 0; j < lines.length; j++) {
+                        if (lines[j].startsWith('#EXT-X-MEDIA-SEQUENCE:')) {
+                            lines[j] = '#EXT-X-MEDIA-SEQUENCE:' + streamInfo.RecoveryStartSeq;
+                            break;
+                        }
                     }
                 }
-            }
-            for (let j = 0; j < streamInfo.RecoverySegments.length; j++) {
-                lines.push(streamInfo.RecoverySegments[j].extinf);
-                lines.push(streamInfo.RecoverySegments[j].url);
+                for (let j = 0; j < streamInfo.RecoverySegments.length; j++) {
+                    lines.push(streamInfo.RecoverySegments[j].extinf);
+                    lines.push(streamInfo.RecoverySegments[j].url);
+                }
             }
         }
         streamInfo.IsStrippingAdSegments = hasStrippedAdSegments;
@@ -579,6 +593,18 @@
             }
         }
         const haveAdTags = hasAdTags(textStr) || (SimulatedAdsDepth > 0 && (!streamInfo.BackupEncodings || !streamInfo.BackupEncodings.includes(url) || SimulatedAdsDepth - 1 > streamInfo.BackupEncodingsPlayerTypeIndex));
+        // Cache the clean main stream m3u8 for all-stripped recovery fallback.
+        // Updated during non-ad polls (outside of any ad break), so by the time an ad
+        // break starts, streamInfo.LastCleanNativeM3U8 holds a snapshot ~1-2 seconds old
+        // with several live segments. When heavy SSAI breaks leave the main playlist
+        // entirely stripped, stripAdSegments replays this snapshot instead of the thin
+        // RecoverySegments array — typically gives the player 4-6 live segments of
+        // content vs the 1-2 cached individual segments.
+        // Mirrors TTV-AB src/modules/processor.ts:733-736.
+        if (!haveAdTags && !streamInfo.BackupEncodings && textStr.indexOf('#EXTINF') !== -1) {
+            streamInfo.LastCleanNativeM3U8 = textStr;
+            streamInfo.LastCleanNativePlaylistAt = Date.now();
+        }
         if (streamInfo.BackupEncodings) {
             const streamM3u8Url = streamInfo.Encodings.match(/^https:.*\.m3u8$/m)?.[0];
             const streamM3u8Response = await realFetch(streamM3u8Url);
@@ -741,6 +767,8 @@
                                 ChannelName: channelName,
                                 UsherParams: (new URL(url)).search,
                                 Urls: new Map(),
+                                LastCleanNativeM3U8: null,// Full-playlist snapshot for all-stripped recovery (mirrors TTV-AB)
+                                LastCleanNativePlaylistAt: 0,
                             };
                             const encodingsM3u8Response = await realFetch(url, options);
                             if (encodingsM3u8Response != null && encodingsM3u8Response.status === 200) {


### PR DESCRIPTION
## Summary

Ports TTV-AB's `LastCleanNativeM3U8` mechanism to vaft + video-swap-new. Significantly improves recovery behavior on heavy SSAI ad breaks where the main stream's m3u8 ends up entirely stripped.

Independent of PR #124 — both changes address different scenarios and compose cleanly.

## Problem (observed in testing logs)

On heavy SSAI breaks, `stripAdSegments` hits the all-stripped branch (every EXTINF in the current playlist was an ad segment). Current fallback is `streamInfo.RecoverySegments` — up to 6 live segments cached by `stripAdSegments` itself **during ad-break polls**. This has two weaknesses:

1. If the break starts with few live segments visible (e.g. only 1 cached), the fallback is thin
2. The cache is only populated during active strip processing, not before the break

**Observed symptom** from recent testing log:

```
[AD DEBUG] Ad detected — pod: 1 ad(s) (~30s expected)
[AD DEBUG] CSAI fast path — all segments live, skipping backup search
(×2) [AD DEBUG] All segments stripped — restoring 1 recovery segments
Finished blocking ads — stripped 32 ad segments, duration: 65.9s
[AD DEBUG] Ad break stats: 2 all-stripped polls, freeze duration: 33.7s wall-clock
[AD DEBUG] Skipping reload — player healthy (readyState=4, playing)
```

Player survived (thanks to the per-segment recovery cache + PR #96 health check) but experienced a **33.7 second wall-clock freeze** replaying 1 cached segment over and over. A ~50% degraded window during a 65.9s break.

## TTV-AB's approach (`src/modules/processor.ts:733-736` + `parser.ts:608-661`)

Cache the **full m3u8 text** as a snapshot during non-ad polls. When the all-stripped case fires, replay the entire cached playlist instead of individual cached segments.

```ts
// TTV-AB: cache during non-ad polls
if (!hasAds && hasMediaSegments && !info.IsShowingAd) {
    info.LastCleanNativeM3U8 = text;
    info.LastCleanNativePlaylistAt = Date.now();
}
```

```ts
// TTV-AB: use in recovery path
const recoverySource = recoveryCandidates.find(/* freshness + ad-content check */);
if (recoverySource?.m3u8) {
    _log(`[Recovery] Empty playlist - reusing ${recoverySource.label}`, "warning");
    return recoverySource.m3u8;
}
```

A fresh snapshot is typically 1-2 seconds old when a break starts, contains 4-6 live segments (Twitch's typical live window), and is enough content to keep the player fed through most all-stripped windows.

## Implementation

### 1. New `streamInfo` fields

Two fields added to the inline init in all four release files:

```js
LastCleanNativeM3U8: null,       // Full-playlist snapshot
LastCleanNativePlaylistAt: 0,    // Timestamp of last cache update
```

### 2. Cache site in `processM3U8`

```js
const haveAdTags = hasAdTags(textStr) || SimulatedAdsDepth > 0;
// Cache the clean main stream m3u8 for all-stripped recovery fallback.
if (!haveAdTags && !streamInfo.IsShowingAd && textStr.indexOf('#EXTINF') !== -1) {
    streamInfo.LastCleanNativeM3U8 = textStr;
    streamInfo.LastCleanNativePlaylistAt = Date.now();
}
```

- Runs on every poll
- Single string assignment, near-zero cost
- Only caches truly clean playlists (no ad signifiers)
- Only during non-break state (not while IsShowingAd is true)
- Only non-empty playlists (must contain `#EXTINF`)

video-swap-new uses `!streamInfo.BackupEncodings` instead of `!streamInfo.IsShowingAd` since that script doesn't track the latter.

### 3. Recovery site in `stripAdSegments`

```js
if (hasStrippedAdSegments && liveSegments.length === 0) {
    streamInfo.ConsecutiveAllStrippedPolls = (streamInfo.ConsecutiveAllStrippedPolls || 0) + 1;
    streamInfo.TotalAllStrippedPolls = (streamInfo.TotalAllStrippedPolls || 0) + 1;
    if (!streamInfo.FreezeStartedAt) streamInfo.FreezeStartedAt = Date.now();
    // Primary: fresh full-playlist snapshot (< 1.5s old, must not itself contain ad markers)
    const snapshotAge = streamInfo.LastCleanNativePlaylistAt ? (Date.now() - streamInfo.LastCleanNativePlaylistAt) : Infinity;
    if (streamInfo.LastCleanNativeM3U8 && snapshotAge <= 1500 && !hasAdTags(streamInfo.LastCleanNativeM3U8)) {
        console.log('[AD DEBUG] All segments stripped — reusing last clean native playlist (' + snapshotAge + 'ms old)');
        streamInfo.IsStrippingAdSegments = hasStrippedAdSegments;
        return streamInfo.LastCleanNativeM3U8;
    }
    // Fallback: per-segment recovery cache (existing behavior)
    if (streamInfo.RecoverySegments && streamInfo.RecoverySegments.length > 0) {
        // ...existing replay logic unchanged...
    }
}
```

- Primary: if snapshot is ≤ 1.5s old (TTV-AB's threshold) and doesn't itself contain ad markers, return it directly
- Short-circuits the rest of stripAdSegments processing
- Falls back to the existing per-segment `RecoverySegments` cache if snapshot is stale or missing
- Both branches update `ConsecutiveAllStrippedPolls` / `TotalAllStrippedPolls` / `FreezeStartedAt` so the existing freeze-duration reporting still works

## Compatibility

- Runs inside `processM3U8` and `stripAdSegments`, both serialized via `.toString()` into the worker blob. `hasAdTags` is already accessible in worker scope (declared in `declareOptions` and referenced from the strip loop). No new outer-scope dependencies introduced.
- Pure string ops + property reads/writes + integer timestamps. No manager-specific APIs, no DOM, no `window` / `document` access.
- Identical behavior under .user.js (Tampermonkey/Violentmonkey/Greasemonkey) and uBO scriptlet contexts.

## Tradeoffs

**Pros:**
- Directly targets the heavy SSAI freeze case observed in logs
- Pure addition — no sticky flag logic, no counters, no thresholds to tune
- Continuous caching is near-free (one string assignment per non-ad poll)
- Signal is observable (snapshot age, has-segments check, hasAdTags on snapshot) — no heuristics
- TTV-AB has been shipping this mechanism for some time; it's battle-tested upstream

**Cons:**
- One additional string reference per streamInfo (~10-50 KB per active stream). Pruned with streamInfo itself via the existing 5-minute `pruneStreamInfos` interval.
- 1.5s freshness threshold is aggressive — a break's first all-stripped poll must land within 1.5s of the last clean poll to benefit. Subsequent all-stripped polls in the same break (2nd, 3rd, etc.) won't benefit because the snapshot becomes stale. The fallback per-segment cache still handles those.
- Doesn't help on breaks that start with a stale snapshot (e.g. a new session where the first ad break fires before non-ad caching has run).

## What it does NOT do

- Does not modify any existing behavior on non-all-stripped paths
- Does not touch the backup player type cycling logic
- Does not change the sticky CSAI fast path from PR #124
- Does not alter existing `RecoverySegments` cache (kept as fallback)

## Files modified

- `vaft/vaft.user.js` — inline StreamInfo init + `processM3U8` cache site + `stripAdSegments` recovery
- `vaft/vaft-ublock-origin.js` — same
- `video-swap-new/video-swap-new.user.js` — inline StreamInfo init + `processM3U8` cache site (gated on `!streamInfo.BackupEncodings`) + `stripAdSegments` recovery
- `video-swap-new/video-swap-new-ublock-origin.js` — same

Testing scripts will be applied via direct-commit to master after this lands (per repo convention).

## Test plan

- [ ] Acorn validation passes on all four files
- [ ] Normal ad-free streaming: no new log output, no behavior change
- [ ] Light SSAI break: existing strip path handles it, no all-stripped trigger, no change in behavior
- [ ] Heavy SSAI break (all-stripped poll fires): new `All segments stripped — reusing last clean native playlist (Xms old)` log appears, player playback continues smoothly
- [ ] Stale snapshot case: if first all-stripped poll is >1.5s after last cache update, falls back to `restoring N recovery segments` (existing behavior)
- [ ] End of break: normal transition, no lingering state