### PR TITLE
Debounce getPlayerAndState 'not found' warnings with 10s grace period

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1429,13 +1429,28 @@ twitch-videoad.js text/javascript
         // Fallback 2: TTV-AB's approach — videoPlayerInstance with playerMode
         const playerStateFallback2 = !playerState && !playerStateFallback ? findReactNode(reactRootNode, node => node.state?.videoPlayerInstance?.playerMode !== undefined)?.state?.videoPlayerInstance : null;
         const finalPlayerState = playerState || playerStateFallback || playerStateFallback2;
-        if (!player && !getPlayerAndState.loggedNoPlayer) {
-            getPlayerAndState.loggedNoPlayer = true;
-            console.log('[AD DEBUG] Player not found — Twitch may have renamed setPlayerActive/mediaPlayerInstance');
+        // Grace period before logging "not found" warnings. The buffer monitor can tick
+        // before React has finished mounting the player, leading to a false-positive
+        // log that fires once on every page load. Only log if the null state persists
+        // for 10+ seconds — by then React is definitely mounted and a persistent null
+        // indicates real API drift (Twitch renamed setPlayerActive/setSrc/etc).
+        if (!player) {
+            if (!getPlayerAndState.firstPlayerNullAt) getPlayerAndState.firstPlayerNullAt = Date.now();
+            if (!getPlayerAndState.loggedNoPlayer && (Date.now() - getPlayerAndState.firstPlayerNullAt) > 10000) {
+                getPlayerAndState.loggedNoPlayer = true;
+                console.log('[AD DEBUG] Player not found for 10s+ — Twitch may have renamed setPlayerActive/mediaPlayerInstance');
+            }
+        } else {
+            getPlayerAndState.firstPlayerNullAt = 0;// reset on successful find
         }
-        if (!finalPlayerState && !getPlayerAndState.loggedNoState) {
-            getPlayerAndState.loggedNoState = true;
-            console.log('[AD DEBUG] Player state not found — Twitch may have renamed setSrc/setInitialPlaybackSettings');
+        if (!finalPlayerState) {
+            if (!getPlayerAndState.firstStateNullAt) getPlayerAndState.firstStateNullAt = Date.now();
+            if (!getPlayerAndState.loggedNoState && (Date.now() - getPlayerAndState.firstStateNullAt) > 10000) {
+                getPlayerAndState.loggedNoState = true;
+                console.log('[AD DEBUG] Player state not found for 10s+ — Twitch may have renamed setSrc/setInitialPlaybackSettings');
+            }
+        } else {
+            getPlayerAndState.firstStateNullAt = 0;// reset on successful find
         }
         return  {
             player: player,

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1439,13 +1439,28 @@
         // Fallback 2: TTV-AB's approach — videoPlayerInstance with playerMode
         const playerStateFallback2 = !playerState && !playerStateFallback ? findReactNode(reactRootNode, node => node.state?.videoPlayerInstance?.playerMode !== undefined)?.state?.videoPlayerInstance : null;
         const finalPlayerState = playerState || playerStateFallback || playerStateFallback2;
-        if (!player && !getPlayerAndState.loggedNoPlayer) {
-            getPlayerAndState.loggedNoPlayer = true;
-            console.log('[AD DEBUG] Player not found — Twitch may have renamed setPlayerActive/mediaPlayerInstance');
+        // Grace period before logging "not found" warnings. The buffer monitor can tick
+        // before React has finished mounting the player, leading to a false-positive
+        // log that fires once on every page load. Only log if the null state persists
+        // for 10+ seconds — by then React is definitely mounted and a persistent null
+        // indicates real API drift (Twitch renamed setPlayerActive/setSrc/etc).
+        if (!player) {
+            if (!getPlayerAndState.firstPlayerNullAt) getPlayerAndState.firstPlayerNullAt = Date.now();
+            if (!getPlayerAndState.loggedNoPlayer && (Date.now() - getPlayerAndState.firstPlayerNullAt) > 10000) {
+                getPlayerAndState.loggedNoPlayer = true;
+                console.log('[AD DEBUG] Player not found for 10s+ — Twitch may have renamed setPlayerActive/mediaPlayerInstance');
+            }
+        } else {
+            getPlayerAndState.firstPlayerNullAt = 0;// reset on successful find
         }
-        if (!finalPlayerState && !getPlayerAndState.loggedNoState) {
-            getPlayerAndState.loggedNoState = true;
-            console.log('[AD DEBUG] Player state not found — Twitch may have renamed setSrc/setInitialPlaybackSettings');
+        if (!finalPlayerState) {
+            if (!getPlayerAndState.firstStateNullAt) getPlayerAndState.firstStateNullAt = Date.now();
+            if (!getPlayerAndState.loggedNoState && (Date.now() - getPlayerAndState.firstStateNullAt) > 10000) {
+                getPlayerAndState.loggedNoState = true;
+                console.log('[AD DEBUG] Player state not found for 10s+ — Twitch may have renamed setSrc/setInitialPlaybackSettings');
+            }
+        } else {
+            getPlayerAndState.firstStateNullAt = 0;// reset on successful find
         }
         return  {
             player: player,


### PR DESCRIPTION
## Summary

Fixes a startup race false positive in vaft's `getPlayerAndState` diagnostic logs. The `Player not found` / `Player state not found` warnings fire once on every page load because the buffer monitor ticks before React finishes mounting the player. Add a 10-second grace period so the warning only fires on persistent failures (real Twitch API drift).

## Problem (observed in user logs)

```
[AD DEBUG] Player not found — Twitch may have renamed setPlayerActive/mediaPlayerInstance
[AD DEBUG] Player state not found — Twitch may have renamed setSrc/setInitialPlaybackSettings
Replaced 'site' player type with 'popout' player type
Amazon IVS Player SDK 1.51.0-rc.3
...
[AD DEBUG] New stream session — channel: august, API: v2
```

Both warnings fire during the startup phase, before the Amazon IVS Player SDK loads and before the first m3u8 request. They then never un-fire (the `loggedNoPlayer` / `loggedNoState` flags are set once and stay set).

**However,** subsequent player operations clearly work in the same session — e.g., `[AD DEBUG] Skipping reload — player healthy (readyState=4, playing)` from the buffer monitor later in the same session proves `doTwitchPlayerTask` successfully finds the player via the same `getPlayerAndState` function. The warnings are startup race false positives, not real API breakage.

## Current code (`vaft/vaft.user.js:1442-1449`)

```js
if (!player && !getPlayerAndState.loggedNoPlayer) {
    getPlayerAndState.loggedNoPlayer = true;
    console.log('[AD DEBUG] Player not found — Twitch may have renamed setPlayerActive/mediaPlayerInstance');
}
if (!finalPlayerState && !getPlayerAndState.loggedNoState) {
    getPlayerAndState.loggedNoState = true;
    console.log('[AD DEBUG] Player state not found — Twitch may have renamed setSrc/setInitialPlaybackSettings');
}
```

The `!getPlayerAndState.loggedNoPlayer` gate is intended to fire the warning once per page load (avoiding spam). But it fires on the **first** null return, which is almost always the startup race.

## Fix

Add a persistent-null timer. Only log when the null state has persisted for 10+ seconds:

```diff
-if (!player && !getPlayerAndState.loggedNoPlayer) {
-    getPlayerAndState.loggedNoPlayer = true;
-    console.log('[AD DEBUG] Player not found — Twitch may have renamed setPlayerActive/mediaPlayerInstance');
-}
+if (!player) {
+    if (!getPlayerAndState.firstPlayerNullAt) getPlayerAndState.firstPlayerNullAt = Date.now();
+    if (!getPlayerAndState.loggedNoPlayer && (Date.now() - getPlayerAndState.firstPlayerNullAt) > 10000) {
+        getPlayerAndState.loggedNoPlayer = true;
+        console.log('[AD DEBUG] Player not found for 10s+ — Twitch may have renamed setPlayerActive/mediaPlayerInstance');
+    }
+} else {
+    getPlayerAndState.firstPlayerNullAt = 0;// reset on successful find
+}
```

Same pattern for `finalPlayerState`.

**How this behaves:**

- **Startup race (common):** first call at t=0.5s returns null → start grace timer. At t=1.5s React mounts → subsequent call finds player → timer resets. No log. ✓
- **Real API drift (rare, important):** every call returns null continuously → grace timer started at first null, no log yet → at t=10s the log fires with updated `"not found for 10s+"` text indicating sustained failure. ✓
- **Intermittent mid-session failures:** any successful find resets the timer. A brief null doesn't stick. No spurious log. ✓

The log text is updated to include `"for 10s+"` so when it does fire, it's clear this is a sustained failure indicating real breakage, not a transient startup race.

## Files modified

- `vaft/vaft.user.js` — `getPlayerAndState` return block
- `vaft/vaft-ublock-origin.js` — same

`video-swap-new` doesn't emit these warnings (they were vaft-specific), so no changes needed there.

Testing scripts will be applied via direct-commit to master after this lands (per repo convention).

## Compatibility

- Runs in the main thread inside `getPlayerAndState` (not inside the worker blob)
- New function-properties on `getPlayerAndState.firstPlayerNullAt` / `firstStateNullAt` — JS function objects accept arbitrary properties, no scope concerns
- No new APIs used — just `Date.now()` and property access
- Works identically under Tampermonkey, Violentmonkey, Greasemonkey, and uBO scriptlet contexts

## Risk

- **Grace period too short:** if React takes >10s to mount the player on a slow connection, the warning would fire as a false positive. Twitch's React tree typically mounts in 1-3s on a cold cache, 100-500ms on warm. 10s has ~3x margin.
- **Grace period too long:** if Twitch actually renamed an API, users would see the warning 10s after the issue starts instead of immediately. Given the warning is diagnostic-only (doesn't affect functionality) and fires once per page load, 10s delay is acceptable.
- **No behavior change:** this only affects log timing. `getPlayerAndState` still returns `{ player, state }` with null values if not found, and downstream code (e.g. `doTwitchPlayerTask`) still handles that case normally.

## Test plan

- [ ] Acorn validation passes on both files
- [ ] Page load on a fresh session: no `Player not found` / `Player state not found` logs (startup race suppressed)
- [ ] Player control still works during ad breaks (existing behavior unchanged)
- [ ] Verify the grace timer resets on successful player find