### PR TITLE
vaft: reload anyway if player is >10s behind live edge

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1496,13 +1496,24 @@ twitch-videoad.js text/javascript
             const video = player.getHTMLVideoElement?.();
             if (video && video.readyState >= 3 && !video.paused && !video.ended) {
                 let latencySec = 0;
+                let latencyKnown = false;
                 try {
                     if (video.seekable && video.seekable.length > 0) {
                         const seekableEnd = video.seekable.end(video.seekable.length - 1);
-                        latencySec = Math.max(0, seekableEnd - video.currentTime);
+                        if (Number.isFinite(seekableEnd)) {
+                            const calc = Math.max(0, seekableEnd - video.currentTime);
+                            // Sanity cap: values >1h indicate garbage from the Media Source API
+                            // (seen right after a reload while the seekable range is in a transient state).
+                            if (calc < 3600) {
+                                latencySec = calc;
+                                latencyKnown = true;
+                            }
+                        }
                     }
                 } catch (e) {}
-                if (latencySec > 10) {
+                if (!latencyKnown) {
+                    console.log('[AD DEBUG] Latency unknown (seekable unavailable) — proceeding with reload');
+                } else if (latencySec > 7) {
                     console.log('[AD DEBUG] Player playing but ' + latencySec.toFixed(1) + 's behind live — proceeding with reload to reset latency');
                 } else {
                     console.log('[AD DEBUG] Skipping reload — player healthy (readyState=' + video.readyState + ', playing, latency=' + latencySec.toFixed(1) + 's)');

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1491,11 +1491,23 @@ twitch-videoad.js text/javascript
             return;
         }
         if (isReload) {
-            // Skip reload if the player is already healthy — avoids disrupting smooth playback
+            // Skip reload if the player is already healthy — avoids disrupting smooth playback.
+            // But if we're way behind live edge (e.g. after a long ad break), proceed with reload to reset latency.
             const video = player.getHTMLVideoElement?.();
             if (video && video.readyState >= 3 && !video.paused && !video.ended) {
-                console.log('[AD DEBUG] Skipping reload — player healthy (readyState=' + video.readyState + ', playing)');
-                return;
+                let latencySec = 0;
+                try {
+                    if (video.seekable && video.seekable.length > 0) {
+                        const seekableEnd = video.seekable.end(video.seekable.length - 1);
+                        latencySec = Math.max(0, seekableEnd - video.currentTime);
+                    }
+                } catch (e) {}
+                if (latencySec > 10) {
+                    console.log('[AD DEBUG] Player playing but ' + latencySec.toFixed(1) + 's behind live — proceeding with reload to reset latency');
+                } else {
+                    console.log('[AD DEBUG] Skipping reload — player healthy (readyState=' + video.readyState + ', playing, latency=' + latencySec.toFixed(1) + 's)');
+                    return;
+                }
             }
         }
         if (isReload) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1506,13 +1506,24 @@
             const video = player.getHTMLVideoElement?.();
             if (video && video.readyState >= 3 && !video.paused && !video.ended) {
                 let latencySec = 0;
+                let latencyKnown = false;
                 try {
                     if (video.seekable && video.seekable.length > 0) {
                         const seekableEnd = video.seekable.end(video.seekable.length - 1);
-                        latencySec = Math.max(0, seekableEnd - video.currentTime);
+                        if (Number.isFinite(seekableEnd)) {
+                            const calc = Math.max(0, seekableEnd - video.currentTime);
+                            // Sanity cap: values >1h indicate garbage from the Media Source API
+                            // (seen right after a reload while the seekable range is in a transient state).
+                            if (calc < 3600) {
+                                latencySec = calc;
+                                latencyKnown = true;
+                            }
+                        }
                     }
                 } catch (e) {}
-                if (latencySec > 10) {
+                if (!latencyKnown) {
+                    console.log('[AD DEBUG] Latency unknown (seekable unavailable) — proceeding with reload');
+                } else if (latencySec > 7) {
                     console.log('[AD DEBUG] Player playing but ' + latencySec.toFixed(1) + 's behind live — proceeding with reload to reset latency');
                 } else {
                     console.log('[AD DEBUG] Skipping reload — player healthy (readyState=' + video.readyState + ', playing, latency=' + latencySec.toFixed(1) + 's)');

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1501,11 +1501,23 @@
             return;
         }
         if (isReload) {
-            // Skip reload if the player is already healthy — avoids disrupting smooth playback
+            // Skip reload if the player is already healthy — avoids disrupting smooth playback.
+            // But if we're way behind live edge (e.g. after a long ad break), proceed with reload to reset latency.
             const video = player.getHTMLVideoElement?.();
             if (video && video.readyState >= 3 && !video.paused && !video.ended) {
-                console.log('[AD DEBUG] Skipping reload — player healthy (readyState=' + video.readyState + ', playing)');
-                return;
+                let latencySec = 0;
+                try {
+                    if (video.seekable && video.seekable.length > 0) {
+                        const seekableEnd = video.seekable.end(video.seekable.length - 1);
+                        latencySec = Math.max(0, seekableEnd - video.currentTime);
+                    }
+                } catch (e) {}
+                if (latencySec > 10) {
+                    console.log('[AD DEBUG] Player playing but ' + latencySec.toFixed(1) + 's behind live — proceeding with reload to reset latency');
+                } else {
+                    console.log('[AD DEBUG] Skipping reload — player healthy (readyState=' + video.readyState + ', playing, latency=' + latencySec.toFixed(1) + 's)');
+                    return;
+                }
             }
         }
         if (isReload) {


### PR DESCRIPTION
## Summary
- Post-ad reload skip check was treating any playing `readyState>=3` video as healthy
- A player can be playing smoothly while sitting 30s behind live edge after a long strip-only break (issue #127)
- Measure latency via `video.seekable.end - video.currentTime` and proceed with the reload when it exceeds 10s

## Why
Issue #127: preroll strip of 28 segments (~43s) left the player playing but ~30s behind live. The existing early-return in `doTwitchPlayerTask` prevented the post-ad reload from running, so latency never recovered until the user manually reloaded.

## Change
`vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js` — in the `isReload` healthy-skip branch, compute `latencySec` from `seekable.end - currentTime`. If >10s, log and fall through to the normal reload path. Otherwise log with the latency included and return as before.

`try { ... } catch (e) {}` guards the seekable access (some players throw on empty ranges).

## Scope
- No behavior change for post-ad reloads where latency is <10s (vast majority of ad breaks)
- No impact on CSAI-only breaks (they don't call the reload path at all)
- No impact on non-reload `doTwitchPlayerTask` calls
- Testing builds already carry the equivalent change on master

Fixes #127.

## Test plan
- [ ] Preroll with 20+ stripped segments → reload fires, latency drops to ~3s
- [ ] Midroll with <5 stripped segments and player still near live → reload still skipped (log shows latency=~2s)
- [ ] Playback pause/play unaffected outside reload path