### PR TITLE
vaft: fire early reload immediately when recovery cache is thin

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -868,12 +868,15 @@ twitch-videoad.js text/javascript
                 // polls, 1-segment recovery cache).
                 // Bounded to maxEarlyReloads per ad in pod so reload loops are impossible.
                 const stickyMaxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
-                if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= EarlyReloadPollThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < stickyMaxEarlyReloads) {
+                const stickyRecoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
+                const stickyEffectiveThreshold = stickyRecoveryThin ? 1 : EarlyReloadPollThreshold;
+                if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= stickyEffectiveThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < stickyMaxEarlyReloads) {
                     streamInfo.EarlyReloadTriggered = true;
                     streamInfo.EarlyReloadAwaitingResult = true;
                     streamInfo.EarlyReloadCount = (streamInfo.EarlyReloadCount || 0) + 1;
                     streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
-                    console.log('[AD DEBUG] Early reload triggered (sticky path) — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls (~' + (streamInfo.ConsecutiveAllStrippedPolls * 2) + 's freeze) [' + streamInfo.EarlyReloadCount + '/' + stickyMaxEarlyReloads + ']');
+                    const stickyReason = stickyRecoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
+                    console.log('[AD DEBUG] Early reload triggered (sticky path) — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + stickyReason + ' [' + streamInfo.EarlyReloadCount + '/' + stickyMaxEarlyReloads + ']');
                     postMessage({ key: 'ReloadPlayer' });
                 }
                 postMessage({
@@ -1093,12 +1096,15 @@ twitch-videoad.js text/javascript
             // for N+ polls (~Nx2s), trigger a reload to attempt fresh content. Bounded to one
             // reload per ad in the pod (e.g. 2-ad pod = up to 2 early reloads).
             const maxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
-            if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= EarlyReloadPollThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < maxEarlyReloads) {
+            const recoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
+            const effectiveThreshold = recoveryThin ? 1 : EarlyReloadPollThreshold;
+            if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= effectiveThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < maxEarlyReloads) {
                 streamInfo.EarlyReloadTriggered = true;
                 streamInfo.EarlyReloadAwaitingResult = true;
                 streamInfo.EarlyReloadCount = (streamInfo.EarlyReloadCount || 0) + 1;
                 streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
-                console.log('[AD DEBUG] Early reload triggered — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls (~' + (streamInfo.ConsecutiveAllStrippedPolls * 2) + 's freeze) [' + streamInfo.EarlyReloadCount + '/' + maxEarlyReloads + ']');
+                const reason = recoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
+                console.log('[AD DEBUG] Early reload triggered — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + reason + ' [' + streamInfo.EarlyReloadCount + '/' + maxEarlyReloads + ']');
                 postMessage({ key: 'ReloadPlayer' });
             }
         } else if (streamInfo.IsShowingAd) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -891,12 +891,15 @@
                 // break, 3 all-stripped polls, 1-segment recovery cache).
                 // Bounded to maxEarlyReloads per ad in pod so reload loops are impossible.
                 const stickyMaxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
-                if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= EarlyReloadPollThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < stickyMaxEarlyReloads) {
+                const stickyRecoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
+                const stickyEffectiveThreshold = stickyRecoveryThin ? 1 : EarlyReloadPollThreshold;
+                if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= stickyEffectiveThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < stickyMaxEarlyReloads) {
                     streamInfo.EarlyReloadTriggered = true;
                     streamInfo.EarlyReloadAwaitingResult = true;
                     streamInfo.EarlyReloadCount = (streamInfo.EarlyReloadCount || 0) + 1;
                     streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
-                    console.log('[AD DEBUG] Early reload triggered (sticky path) — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls (~' + (streamInfo.ConsecutiveAllStrippedPolls * 2) + 's freeze) [' + streamInfo.EarlyReloadCount + '/' + stickyMaxEarlyReloads + ']');
+                    const stickyReason = stickyRecoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
+                    console.log('[AD DEBUG] Early reload triggered (sticky path) — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + stickyReason + ' [' + streamInfo.EarlyReloadCount + '/' + stickyMaxEarlyReloads + ']');
                     postMessage({ key: 'ReloadPlayer' });
                 }
                 postMessage({
@@ -1116,12 +1119,15 @@
             // for N+ polls (~Nx2s), trigger a reload to attempt fresh content. Bounded to one
             // reload per ad in the pod (e.g. 2-ad pod = up to 2 early reloads).
             const maxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
-            if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= EarlyReloadPollThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < maxEarlyReloads) {
+            const recoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
+            const effectiveThreshold = recoveryThin ? 1 : EarlyReloadPollThreshold;
+            if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= effectiveThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < maxEarlyReloads) {
                 streamInfo.EarlyReloadTriggered = true;
                 streamInfo.EarlyReloadAwaitingResult = true;
                 streamInfo.EarlyReloadCount = (streamInfo.EarlyReloadCount || 0) + 1;
                 streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
-                console.log('[AD DEBUG] Early reload triggered — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls (~' + (streamInfo.ConsecutiveAllStrippedPolls * 2) + 's freeze) [' + streamInfo.EarlyReloadCount + '/' + maxEarlyReloads + ']');
+                const reason = recoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
+                console.log('[AD DEBUG] Early reload triggered — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + reason + ' [' + streamInfo.EarlyReloadCount + '/' + maxEarlyReloads + ']');
                 postMessage({ key: 'ReloadPlayer' });
             }
         } else if (streamInfo.IsShowingAd) {


### PR DESCRIPTION
## Summary
- When recovery cache has <3 segments, lower the early reload threshold from 5 polls (~10s) to 1 poll (~2s)
- Applied to both the sticky CSAI fast path and the normal backup-search path
- Adds diagnostic log showing cache depth when thin-cache trigger fires

## Why
Prerolls and SSAI-heavy breaks often start with an empty or near-empty recovery cache (no prior clean content). With only 1 recovery segment, the player loops decode errors (`AVC finishFrame called without active frame`) for ~10s before the early reload fires. Reloading immediately saves ~8s of useless freeze time.

Reported in #129 — users see "video rolls back to the same point repeatedly" during ad blocking.

## Change
Both early reload check sites (`sticky path` and `normal path`) now compute:
```js
const recoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
const effectiveThreshold = recoveryThin ? 1 : EarlyReloadPollThreshold;
```

When thin: fire on poll 1. When normal (≥3 segments): use the default threshold (5 polls).

## Test plan
- [ ] Preroll with thin cache (≤1 recovery segment) → reload fires at poll 1 with `(thin recovery cache: N segments)` in log
- [ ] Midroll with healthy cache (≥3 segments) → reload fires at poll 5 as before
- [ ] Early reload budget still bounded to 1 per ad in pod