### PR TITLE
vaft: restart drift correction on re-entry + guard pause intent reset

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1284,7 +1284,8 @@ twitch-videoad.js text/javascript
     let driftCatchUpTimeout = null;
     function startDriftCorrection(videoElement) {
         if (DriftCorrectionRate <= 1) return;
-        if (driftCatchUpInterval) return; // already correcting — let it finish or timeout
+        if (driftCatchUpInterval) { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; }
+        if (driftCatchUpTimeout) { clearTimeout(driftCatchUpTimeout); driftCatchUpTimeout = null; }
         videoElement.playbackRate = DriftCorrectionRate;
         console.log('[AD DEBUG] Drift correction: catching up at ' + DriftCorrectionRate + 'x');
         driftCatchUpInterval = setInterval(() => {
@@ -1696,7 +1697,8 @@ twitch-videoad.js text/javascript
             console.log('Could not find player state');
             return;
         }
-        if (player.isPaused() || player.core?.paused) {
+        const wasPaused = player.isPaused() || player.core?.paused;
+        if (wasPaused) {
             // User deliberately paused — respect their intent, don't auto-resume
             if (playerBufferState.userPauseIntent) {
                 if (!playerBufferState.loggedPauseIntent) {
@@ -1711,7 +1713,9 @@ twitch-videoad.js text/javascript
             }
             return;
         }
-        playerBufferState.weJustPaused = 0;
+        if (!wasPaused) {
+            playerBufferState.weJustPaused = 0;
+        }
         playerBufferState.lastFixTime = Date.now();
         playerBufferState.numSame = 0;
         if (isPausePlay) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1307,7 +1307,8 @@
     let driftCatchUpTimeout = null;
     function startDriftCorrection(videoElement) {
         if (DriftCorrectionRate <= 1) return;
-        if (driftCatchUpInterval) return; // already correcting — let it finish or timeout
+        if (driftCatchUpInterval) { clearInterval(driftCatchUpInterval); driftCatchUpInterval = null; }
+        if (driftCatchUpTimeout) { clearTimeout(driftCatchUpTimeout); driftCatchUpTimeout = null; }
         videoElement.playbackRate = DriftCorrectionRate;
         console.log('[AD DEBUG] Drift correction: catching up at ' + DriftCorrectionRate + 'x');
         driftCatchUpInterval = setInterval(() => {
@@ -1723,7 +1724,8 @@
             console.log('Could not find player state');
             return;
         }
-        if (player.isPaused() || player.core?.paused) {
+        const wasPaused = player.isPaused() || player.core?.paused;
+        if (wasPaused) {
             // User deliberately paused — respect their intent, don't auto-resume
             if (playerBufferState.userPauseIntent) {
                 if (!playerBufferState.loggedPauseIntent) {
@@ -1738,7 +1740,9 @@
             }
             return;
         }
-        playerBufferState.weJustPaused = 0;
+        if (!wasPaused) {
+            playerBufferState.weJustPaused = 0;
+        }
         playerBufferState.lastFixTime = Date.now();
         playerBufferState.numSame = 0;
         if (isPausePlay) {


### PR DESCRIPTION
## Summary
Two bug fixes ported from the testing build:

1. **Drift correction restart** — `startDriftCorrection` now clears stale interval/timeout on re-entry instead of silently returning. If called while already running (e.g. position jump during post-reload drift), the old code ignored the new request, leaving the player at 1.1x with a partially elapsed 30s safety timeout.

2. **Pause intent guard** — `doTwitchPlayerTask` only resets `weJustPaused` when the player wasn't already paused. The unconditional reset could clear pause tracking too early when a user pauses during a stall recovery window, allowing the `play()` retry to fire against their intent.

## Test plan
- [ ] Trigger two drift corrections in quick succession (position jump during post-reload drift) → second one restarts fresh instead of being ignored
- [ ] Pause player during buffer monitor stall recovery → player stays paused, no auto-resume