### PR TITLE
video-swap-new: remove autoplay from backup player types

### DIFF
--- a/video-swap-new/video-swap-new-ublock-origin-testing.js
+++ b/video-swap-new/video-swap-new-ublock-origin-testing.js
@@ -10,7 +10,7 @@ twitch-videoad.js text/javascript
     window.twitchAdSolutionsVersion = ourTwitchAdSolutionsVersion;
     function declareOptions(scope) {
         // Options / globals
-        scope.OPT_BACKUP_PLAYER_TYPES = [ 'autoplay', 'picture-by-picture', /*'autoplay-ALT',*/ 'embed', 'mobile_web' ];
+        scope.OPT_BACKUP_PLAYER_TYPES = [ 'embed', 'popout', 'mobile_web' ];
         scope.OPT_FORCE_ACCESS_TOKEN_PLAYER_TYPE = 'popout';
         scope.AD_SIGNIFIERS = ['stitched-ad', 'X-TV-TWITCH-AD', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-stream-source"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-ad-quartile"', 'SCTE35-OUT'];
         scope.AD_SEGMENT_URL_PATTERNS = ['/adsquared/', '/_404/', '/processing'];
@@ -856,7 +856,7 @@ twitch-videoad.js text/javascript
                 isVod: false,
                 vodID: "",
                 playerType: realPlayerType,
-                platform: realPlayerType == 'autoplay' ? 'android' : 'web'
+                platform: 'web'
             },
             extensions: {
                 persistedQuery: {

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -33,7 +33,7 @@ twitch-videoad.js text/javascript
     window.twitchAdSolutionsVersion = ourTwitchAdSolutionsVersion;
     function declareOptions(scope) {
         // Options / globals
-        scope.OPT_BACKUP_PLAYER_TYPES = [ 'autoplay', 'picture-by-picture', /*'autoplay-ALT',*/ 'embed', 'mobile_web' ];
+        scope.OPT_BACKUP_PLAYER_TYPES = [ 'embed', 'popout', 'mobile_web' ];
         scope.OPT_FORCE_ACCESS_TOKEN_PLAYER_TYPE = 'popout';
         scope.AD_SIGNIFIERS = ['stitched-ad', 'X-TV-TWITCH-AD', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-stream-source"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-ad-quartile"', 'SCTE35-OUT'];
         scope.AD_SEGMENT_URL_PATTERNS = ['/adsquared/', '/_404/', '/processing'];
@@ -906,7 +906,7 @@ twitch-videoad.js text/javascript
                 isVod: false,
                 vodID: "",
                 playerType: realPlayerType,
-                platform: realPlayerType == 'autoplay' ? 'android' : 'web'
+                platform: 'web'
             },
             extensions: {
                 persistedQuery: {

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -44,7 +44,7 @@
     window.twitchAdSolutionsVersion = ourTwitchAdSolutionsVersion;
     function declareOptions(scope) {
         // Options / globals
-        scope.OPT_BACKUP_PLAYER_TYPES = [ 'autoplay', 'picture-by-picture', /*'autoplay-ALT',*/ 'embed', 'mobile_web' ];
+        scope.OPT_BACKUP_PLAYER_TYPES = [ 'embed', 'popout', 'mobile_web' ];
         scope.OPT_FORCE_ACCESS_TOKEN_PLAYER_TYPE = 'popout';
         scope.AD_SIGNIFIERS = ['stitched-ad', 'X-TV-TWITCH-AD', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-stream-source"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-ad-quartile"', 'SCTE35-OUT'];
         scope.AD_SEGMENT_URL_PATTERNS = ['/adsquared/', '/_404/', '/processing'];
@@ -917,7 +917,7 @@
                 isVod: false,
                 vodID: "",
                 playerType: realPlayerType,
-                platform: realPlayerType == 'autoplay' ? 'android' : 'web'
+                platform: 'web'
             },
             extensions: {
                 persistedQuery: {


### PR DESCRIPTION
## Summary
- Remove `autoplay` and `picture-by-picture` from `OPT_BACKUP_PLAYER_TYPES`
- Replace with `embed`, `popout`, `mobile_web` to match vaft's backup type list
- Remove dead `autoplay` platform ternary

## Why
Same issue vaft fixed in PR #110: when the cycle commits `autoplay` as a clean backup, the player gets stuck in an endless loading circle because autoplay's 360p variant ladder is incompatible with main stream variants — the player can't transition back cleanly.

User-reported symptom: `Found ads, switch to backup (autoplay)` followed by unnecessary reload with 0 segments stripped.

## Note on CSAI fast path
video-swap-new already has the CSAI fast path (line 743). In the reported log it didn't fire because the m3u8 had at least one non-live `#EXTINF` segment alongside ad signifiers — a mixed case where the fast path correctly defers to the backup search. This PR doesn't change that logic.

## Test plan
- [ ] Midroll on CSAI-heavy channel → backup uses `embed`/`popout`/`mobile_web`, not `autoplay`
- [ ] No loading circle when transitioning back from backup to main stream