### PR TITLE
video-swap-new: add early reload on freeze + reload cooldown

### DIFF
--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -57,6 +57,8 @@ twitch-videoad.js text/javascript
         scope.AdSegmentCache = new Map();
         scope.AllSegmentsAreAdSegments = false;
         scope.ReloadPlayerAfterAd = true;// After the ad finishes do a player reload instead of pause/play
+        scope.ReloadCooldownSeconds = 30;// Minimum seconds between reloads — breaks CSAI cascades triggered by reload
+        scope.EarlyReloadPollThreshold = 5;// All-stripped polls before early reload (~2s each, so 5 = ~10s; 0 = disable)
         scope.PinBackupPlayerType = false;// If true, remember which backup player type worked and try it first on next ad break
         scope.StreamInfoMaxAgeMs = 30 * 60 * 1000;
     }
@@ -86,6 +88,10 @@ twitch-videoad.js text/javascript
             UseFallbackStream: false,
             LastCleanNativeM3U8: null,
             LastCleanNativePlaylistAt: 0,
+            ConsecutiveAllStrippedPolls: 0,
+            EarlyReloadTriggered: false,
+            LastPlayerReload: 0,
+            ReloadTimestamps: [],
         };
     }
     function maskAsNative(fn, name) {
@@ -107,6 +113,8 @@ twitch-videoad.js text/javascript
     const loggedCsaiTypes = new Set();
     let twitchPlayerAndState = null;
     let localStorageHookFailed = false;
+    let lastReloadTimestamp = 0;
+    let reloadTimestamps = [];
     const twitchWorkers = [];
     const workerStringConflicts = [
         'twitch',
@@ -227,6 +235,8 @@ twitch-videoad.js text/javascript
                         self.__tasPruneInterval = setInterval(pruneStreamInfos, 5 * 60 * 1000);
                     }
                     ReloadPlayerAfterAd = ${ReloadPlayerAfterAd};
+                    ReloadCooldownSeconds = ${ReloadCooldownSeconds};
+                    EarlyReloadPollThreshold = ${EarlyReloadPollThreshold};
                     PinBackupPlayerType = ${PinBackupPlayerType};
                     OPT_FORCE_ACCESS_TOKEN_PLAYER_TYPE = '${OPT_FORCE_ACCESS_TOKEN_PLAYER_TYPE}';
                     gql_device_id = ${gql_device_id ? "'" + gql_device_id + "'" : null};
@@ -591,6 +601,15 @@ twitch-videoad.js text/javascript
         // content vs the thin per-segment recovery cache. Falls back to the per-segment
         // cache if the snapshot is stale or missing.
         if (hasStrippedAdSegments && liveSegments.length === 0) {
+            streamInfo.ConsecutiveAllStrippedPolls = (streamInfo.ConsecutiveAllStrippedPolls || 0) + 1;
+            const recoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
+            const effectiveThreshold = recoveryThin ? 1 : EarlyReloadPollThreshold;
+            if (EarlyReloadPollThreshold > 0 && streamInfo.ConsecutiveAllStrippedPolls >= effectiveThreshold && !streamInfo.EarlyReloadTriggered) {
+                streamInfo.EarlyReloadTriggered = true;
+                const reason = recoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
+                console.log('[AD DEBUG] Early reload triggered — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + reason);
+                postMessage({ key: 'UboReloadPlayer' });
+            }
             // Primary: fresh full-playlist snapshot (< 1.5s old, must not itself contain ad markers)
             const snapshotAge = streamInfo.LastCleanNativePlaylistAt ? (Date.now() - streamInfo.LastCleanNativePlaylistAt) : Infinity;
             if (streamInfo.LastCleanNativeM3U8 && snapshotAge <= 1500 && !hasAdTags(streamInfo.LastCleanNativeM3U8)) {
@@ -698,6 +717,8 @@ twitch-videoad.js text/javascript
                             }
                             streamInfo.HasConfirmedAdAttrs = false;
                             streamInfo.HasLoggedCsaiFastPath = false;
+                            streamInfo.ConsecutiveAllStrippedPolls = 0;
+                            streamInfo.EarlyReloadTriggered = false;
                             streamInfo.IsMovingOffBackupEncodings = true;
                             streamInfo.BackupEncodings = null;
                             streamInfo.BackupEncodingsStatus.clear();
@@ -1179,6 +1200,22 @@ twitch-videoad.js text/javascript
         if (player.isPaused() || player.core?.paused) {
             return;
         }
+        if (!isPausePlay && ReloadCooldownSeconds > 0) {
+            const now = Date.now();
+            const cooldownMs = ReloadCooldownSeconds * 1000;
+            if (lastReloadTimestamp && now - lastReloadTimestamp < cooldownMs) {
+                console.log('[AD DEBUG] Skipping reload — cooldown active (' + Math.round((cooldownMs - (now - lastReloadTimestamp)) / 1000) + 's remaining)');
+                return;
+            }
+            reloadTimestamps.push(now);
+            const fiveMinAgo = now - 300000;
+            while (reloadTimestamps.length > 0 && reloadTimestamps[0] < fiveMinAgo) { reloadTimestamps.shift(); }
+            if (reloadTimestamps.length >= 3 && ReloadCooldownSeconds < 90) {
+                ReloadCooldownSeconds = 90;
+                console.log('[AD DEBUG] Auto-escalated reload cooldown to 90s (3+ reloads in 5 minutes)');
+            }
+            lastReloadTimestamp = now;
+        }
         if (isPausePlay) {
             player.pause();
             player.play()?.catch?.(() => {});
@@ -1343,6 +1380,14 @@ twitch-videoad.js text/javascript
         const lsPinBackup = localStorage.getItem('twitchAdSolutions_pinBackupPlayerType');
         if (lsPinBackup !== null) {
             PinBackupPlayerType = lsPinBackup === 'true';
+        }
+        const lsCooldown = parseInt(localStorage.getItem('twitchAdSolutions_reloadCooldownSeconds'));
+        if (!isNaN(lsCooldown) && lsCooldown >= 0) {
+            ReloadCooldownSeconds = lsCooldown;
+        }
+        const lsEarlyReload = parseInt(localStorage.getItem('twitchAdSolutions_earlyReloadPollThreshold'));
+        if (!isNaN(lsEarlyReload) && lsEarlyReload >= 0) {
+            EarlyReloadPollThreshold = lsEarlyReload;
         }
         const lsHideAdOverlay = localStorage.getItem('twitchAdSolutions_hideAdOverlay');
         if (lsHideAdOverlay === 'true') {

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -68,6 +68,8 @@
         scope.AdSegmentCache = new Map();
         scope.AllSegmentsAreAdSegments = false;
         scope.ReloadPlayerAfterAd = true;// After the ad finishes do a player reload instead of pause/play
+        scope.ReloadCooldownSeconds = 30;// Minimum seconds between reloads — breaks CSAI cascades triggered by reload
+        scope.EarlyReloadPollThreshold = 5;// All-stripped polls before early reload (~2s each, so 5 = ~10s; 0 = disable)
         scope.PinBackupPlayerType = false;// If true, remember which backup player type worked and try it first on next ad break
         scope.StreamInfoMaxAgeMs = 30 * 60 * 1000;
     }
@@ -97,6 +99,11 @@
             UseFallbackStream: false,
             LastCleanNativeM3U8: null,
             LastCleanNativePlaylistAt: 0,
+            // Early reload + cooldown
+            ConsecutiveAllStrippedPolls: 0,
+            EarlyReloadTriggered: false,
+            LastPlayerReload: 0,
+            ReloadTimestamps: [],
         };
     }
     function maskAsNative(fn, name) {
@@ -118,6 +125,8 @@
     const loggedCsaiTypes = new Set();
     let twitchPlayerAndState = null;
     let localStorageHookFailed = false;
+    let lastReloadTimestamp = 0;
+    let reloadTimestamps = [];
     const twitchWorkers = [];
     const workerStringConflicts = [
         'twitch',
@@ -238,6 +247,8 @@
                         self.__tasPruneInterval = setInterval(pruneStreamInfos, 5 * 60 * 1000);
                     }
                     ReloadPlayerAfterAd = ${ReloadPlayerAfterAd};
+                    ReloadCooldownSeconds = ${ReloadCooldownSeconds};
+                    EarlyReloadPollThreshold = ${EarlyReloadPollThreshold};
                     PinBackupPlayerType = ${PinBackupPlayerType};
                     OPT_FORCE_ACCESS_TOKEN_PLAYER_TYPE = '${OPT_FORCE_ACCESS_TOKEN_PLAYER_TYPE}';
                     gql_device_id = ${gql_device_id ? "'" + gql_device_id + "'" : null};
@@ -602,6 +613,17 @@
         // content vs the thin per-segment recovery cache. Falls back to the per-segment
         // cache if the snapshot is stale or missing.
         if (hasStrippedAdSegments && liveSegments.length === 0) {
+            streamInfo.ConsecutiveAllStrippedPolls = (streamInfo.ConsecutiveAllStrippedPolls || 0) + 1;
+            // Early reload: if recovery cache is thin (<3 segments), fire on first poll;
+            // otherwise wait for EarlyReloadPollThreshold polls (~10s).
+            const recoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
+            const effectiveThreshold = recoveryThin ? 1 : EarlyReloadPollThreshold;
+            if (EarlyReloadPollThreshold > 0 && streamInfo.ConsecutiveAllStrippedPolls >= effectiveThreshold && !streamInfo.EarlyReloadTriggered) {
+                streamInfo.EarlyReloadTriggered = true;
+                const reason = recoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
+                console.log('[AD DEBUG] Early reload triggered — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + reason);
+                postMessage({ key: 'UboReloadPlayer' });
+            }
             // Primary: fresh full-playlist snapshot (< 1.5s old, must not itself contain ad markers)
             const snapshotAge = streamInfo.LastCleanNativePlaylistAt ? (Date.now() - streamInfo.LastCleanNativePlaylistAt) : Infinity;
             if (streamInfo.LastCleanNativeM3U8 && snapshotAge <= 1500 && !hasAdTags(streamInfo.LastCleanNativeM3U8)) {
@@ -709,6 +731,8 @@
                             }
                             streamInfo.HasConfirmedAdAttrs = false;
                             streamInfo.HasLoggedCsaiFastPath = false;
+                            streamInfo.ConsecutiveAllStrippedPolls = 0;
+                            streamInfo.EarlyReloadTriggered = false;
                             streamInfo.IsMovingOffBackupEncodings = true;
                             streamInfo.BackupEncodings = null;
                             streamInfo.BackupEncodingsStatus.clear();
@@ -1190,6 +1214,24 @@
         if (player.isPaused() || player.core?.paused) {
             return;
         }
+        // Reload cooldown — skip if last reload was too recent (breaks CSAI cascades)
+        if (!isPausePlay && ReloadCooldownSeconds > 0) {
+            const now = Date.now();
+            const cooldownMs = ReloadCooldownSeconds * 1000;
+            if (lastReloadTimestamp && now - lastReloadTimestamp < cooldownMs) {
+                console.log('[AD DEBUG] Skipping reload — cooldown active (' + Math.round((cooldownMs - (now - lastReloadTimestamp)) / 1000) + 's remaining)');
+                return;
+            }
+            // Auto-escalate: if 3+ reloads in 5 minutes, triple the cooldown
+            reloadTimestamps.push(now);
+            const fiveMinAgo = now - 300000;
+            while (reloadTimestamps.length > 0 && reloadTimestamps[0] < fiveMinAgo) { reloadTimestamps.shift(); }
+            if (reloadTimestamps.length >= 3 && ReloadCooldownSeconds < 90) {
+                ReloadCooldownSeconds = 90;
+                console.log('[AD DEBUG] Auto-escalated reload cooldown to 90s (3+ reloads in 5 minutes)');
+            }
+            lastReloadTimestamp = now;
+        }
         if (isPausePlay) {
             player.pause();
             player.play()?.catch?.(() => {});
@@ -1354,6 +1396,14 @@
         const lsPinBackup = localStorage.getItem('twitchAdSolutions_pinBackupPlayerType');
         if (lsPinBackup !== null) {
             PinBackupPlayerType = lsPinBackup === 'true';
+        }
+        const lsCooldown = parseInt(localStorage.getItem('twitchAdSolutions_reloadCooldownSeconds'));
+        if (!isNaN(lsCooldown) && lsCooldown >= 0) {
+            ReloadCooldownSeconds = lsCooldown;
+        }
+        const lsEarlyReload = parseInt(localStorage.getItem('twitchAdSolutions_earlyReloadPollThreshold'));
+        if (!isNaN(lsEarlyReload) && lsEarlyReload >= 0) {
+            EarlyReloadPollThreshold = lsEarlyReload;
         }
         const lsHideAdOverlay = localStorage.getItem('twitchAdSolutions_hideAdOverlay');
         if (lsHideAdOverlay === 'true') {


### PR DESCRIPTION
## Summary
Port two features from vaft to video-swap-new:

- **Early reload on prolonged freeze** — when all m3u8 segments are stripped for consecutive polls, trigger a reload to break out of the recovery loop instead of looping thin recovery content indefinitely
- **Reload cooldown with auto-escalation** — 30s minimum between reloads, auto-escalates to 90s after 3+ reloads in 5 minutes. Prevents CSAI cascade reload loops.

## Details

### Early reload
- Tracks `ConsecutiveAllStrippedPolls` in `stripAdSegments`
- When recovery cache is thin (<3 segments): fires on first all-stripped poll (~2s)
- When cache is healthy (≥3 segments): fires at `EarlyReloadPollThreshold` (default 5, ~10s)
- Sends `UboReloadPlayer` message to main thread (same path as end-of-ad reload)
- Resets on ad break end

### Reload cooldown
- Checks `lastReloadTimestamp` before allowing a full reload (pause/play exempt)
- If 3+ reloads in a 5-minute window, escalates cooldown from 30s to 90s
- Configurable via `localStorage.twitchAdSolutions_reloadCooldownSeconds`

## New localStorage options
- `twitchAdSolutions_reloadCooldownSeconds` — number, default `30` (0 to disable)
- `twitchAdSolutions_earlyReloadPollThreshold` — number, default `5` (0 to disable)

## Test plan
- [ ] SSAI break with all segments stripped → early reload fires after threshold
- [ ] Thin cache preroll → early reload fires on first poll
- [ ] Multiple reloads in quick succession → cooldown prevents cascade
- [ ] 3+ reloads in 5 min → cooldown auto-escalates to 90s with log message