### PR TITLE
vaft: increase early reload budget when recovery cache is thin

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1088,6 +1088,7 @@ twitch-videoad.js text/javascript
                     streamInfo.EarlyReloadTriggered = false;
                 } else {
                     console.log('[AD DEBUG] Early reload result: still ads — continuing recovery loop');
+                    streamInfo.EarlyReloadTriggered = false;
                 }
             }
             // Early reload during prolonged freeze: if we've been looping recovery segments

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -865,8 +865,8 @@ twitch-videoad.js text/javascript
                 // break duration (observed: 35.9s freeze on pod-1 break, 3 all-stripped
                 // polls, 1-segment recovery cache).
                 // Bounded to maxEarlyReloads per ad in pod so reload loops are impossible.
-                const stickyMaxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
                 const stickyRecoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
+                const stickyMaxEarlyReloads = stickyRecoveryThin ? Math.max(2, streamInfo.PodLength || 1) : Math.max(1, streamInfo.PodLength || 1);
                 const stickyEffectiveThreshold = stickyRecoveryThin ? 1 : EarlyReloadPollThreshold;
                 if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= stickyEffectiveThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < stickyMaxEarlyReloads) {
                     streamInfo.EarlyReloadTriggered = true;
@@ -1093,8 +1093,8 @@ twitch-videoad.js text/javascript
             // Early reload during prolonged freeze: if we've been looping recovery segments
             // for N+ polls (~Nx2s), trigger a reload to attempt fresh content. Bounded to one
             // reload per ad in the pod (e.g. 2-ad pod = up to 2 early reloads).
-            const maxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
             const recoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
+            const maxEarlyReloads = recoveryThin ? Math.max(2, streamInfo.PodLength || 1) : Math.max(1, streamInfo.PodLength || 1);
             const effectiveThreshold = recoveryThin ? 1 : EarlyReloadPollThreshold;
             if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= effectiveThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < maxEarlyReloads) {
                 streamInfo.EarlyReloadTriggered = true;

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -865,6 +865,11 @@ twitch-videoad.js text/javascript
                 // break duration (observed: 35.9s freeze on pod-1 break, 3 all-stripped
                 // polls, 1-segment recovery cache).
                 // Bounded to maxEarlyReloads per ad in pod so reload loops are impossible.
+                if (streamInfo.EarlyReloadAwaitingResult) {
+                    streamInfo.EarlyReloadAwaitingResult = false;
+                    console.log('[AD DEBUG] Early reload result (sticky path): still ads — continuing recovery loop');
+                    streamInfo.EarlyReloadTriggered = false;
+                }
                 const stickyRecoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
                 const stickyMaxEarlyReloads = stickyRecoveryThin ? Math.max(2, streamInfo.PodLength || 1) : Math.max(1, streamInfo.PodLength || 1);
                 const stickyEffectiveThreshold = stickyRecoveryThin ? 1 : EarlyReloadPollThreshold;
@@ -1088,14 +1093,13 @@ twitch-videoad.js text/javascript
                     streamInfo.EarlyReloadTriggered = false;
                 } else {
                     console.log('[AD DEBUG] Early reload result: still ads — continuing recovery loop');
-                    streamInfo.EarlyReloadTriggered = false;
                 }
             }
             // Early reload during prolonged freeze: if we've been looping recovery segments
             // for N+ polls (~Nx2s), trigger a reload to attempt fresh content. Bounded to one
             // reload per ad in the pod (e.g. 2-ad pod = up to 2 early reloads).
+            const maxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
             const recoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
-            const maxEarlyReloads = recoveryThin ? Math.max(2, streamInfo.PodLength || 1) : Math.max(1, streamInfo.PodLength || 1);
             const effectiveThreshold = recoveryThin ? 1 : EarlyReloadPollThreshold;
             if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= effectiveThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < maxEarlyReloads) {
                 streamInfo.EarlyReloadTriggered = true;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -888,6 +888,12 @@
                 // cache for the full break duration (observed: 35.9s freeze on pod-1
                 // break, 3 all-stripped polls, 1-segment recovery cache).
                 // Bounded to maxEarlyReloads per ad in pod so reload loops are impossible.
+                // Check early reload result from previous poll (sticky path returns before the normal-path check)
+                if (streamInfo.EarlyReloadAwaitingResult) {
+                    streamInfo.EarlyReloadAwaitingResult = false;
+                    console.log('[AD DEBUG] Early reload result (sticky path): still ads — continuing recovery loop');
+                    streamInfo.EarlyReloadTriggered = false;
+                }
                 const stickyRecoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
                 const stickyMaxEarlyReloads = stickyRecoveryThin ? Math.max(2, streamInfo.PodLength || 1) : Math.max(1, streamInfo.PodLength || 1);
                 const stickyEffectiveThreshold = stickyRecoveryThin ? 1 : EarlyReloadPollThreshold;
@@ -1111,14 +1117,13 @@
                     streamInfo.EarlyReloadTriggered = false;
                 } else {
                     console.log('[AD DEBUG] Early reload result: still ads — continuing recovery loop');
-                    streamInfo.EarlyReloadTriggered = false;
                 }
             }
             // Early reload during prolonged freeze: if we've been looping recovery segments
             // for N+ polls (~Nx2s), trigger a reload to attempt fresh content. Bounded to one
             // reload per ad in the pod (e.g. 2-ad pod = up to 2 early reloads).
+            const maxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
             const recoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
-            const maxEarlyReloads = recoveryThin ? Math.max(2, streamInfo.PodLength || 1) : Math.max(1, streamInfo.PodLength || 1);
             const effectiveThreshold = recoveryThin ? 1 : EarlyReloadPollThreshold;
             if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= effectiveThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < maxEarlyReloads) {
                 streamInfo.EarlyReloadTriggered = true;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -888,8 +888,8 @@
                 // cache for the full break duration (observed: 35.9s freeze on pod-1
                 // break, 3 all-stripped polls, 1-segment recovery cache).
                 // Bounded to maxEarlyReloads per ad in pod so reload loops are impossible.
-                const stickyMaxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
                 const stickyRecoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
+                const stickyMaxEarlyReloads = stickyRecoveryThin ? Math.max(2, streamInfo.PodLength || 1) : Math.max(1, streamInfo.PodLength || 1);
                 const stickyEffectiveThreshold = stickyRecoveryThin ? 1 : EarlyReloadPollThreshold;
                 if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= stickyEffectiveThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < stickyMaxEarlyReloads) {
                     streamInfo.EarlyReloadTriggered = true;
@@ -1116,8 +1116,8 @@
             // Early reload during prolonged freeze: if we've been looping recovery segments
             // for N+ polls (~Nx2s), trigger a reload to attempt fresh content. Bounded to one
             // reload per ad in the pod (e.g. 2-ad pod = up to 2 early reloads).
-            const maxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
             const recoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
+            const maxEarlyReloads = recoveryThin ? Math.max(2, streamInfo.PodLength || 1) : Math.max(1, streamInfo.PodLength || 1);
             const effectiveThreshold = recoveryThin ? 1 : EarlyReloadPollThreshold;
             if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= effectiveThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < maxEarlyReloads) {
                 streamInfo.EarlyReloadTriggered = true;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1111,6 +1111,7 @@
                     streamInfo.EarlyReloadTriggered = false;
                 } else {
                     console.log('[AD DEBUG] Early reload result: still ads — continuing recovery loop');
+                    streamInfo.EarlyReloadTriggered = false;
                 }
             }
             // Early reload during prolonged freeze: if we've been looping recovery segments


### PR DESCRIPTION
## Summary
When recovery cache has <3 segments, allow 2 early reloads per break instead of 1.

## Why
Issue #129: after the first early reload fires and lands back in ads (SSAI on all player types), the budget is exhausted at `[1/1]`. The player then loops `recovery → AVC decode error → recovery` for the remaining ad break duration (~3 minutes reported). A second reload ~10s later gives Twitch another chance to stop serving ads.

## Change
```js
// Before (both paths):
const maxEarlyReloads = Math.max(1, PodLength);

// After:
const recoveryThin = (RecoverySegments?.length || 0) < 3;
const maxEarlyReloads = recoveryThin ? Math.max(2, PodLength) : Math.max(1, PodLength);
```

When cache is healthy (≥3 segments), budget stays at `PodLength` (no change). When thin, budget is at least 2.

## Test plan
- [ ] Preroll with all-backups-ad-laden + thin cache → first reload at poll 1 `[1/2]`, second reload at poll 5 `[2/2]`
- [ ] Normal midroll with healthy cache → budget stays at `[1/1]` or `[1/2]` for 2-pod, unchanged behavior