### PR TITLE
video-swap-new: guard null lowResInf in HEVC->AVC codec substitution

### DIFF
--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -447,6 +447,7 @@ twitch-videoad.js text/javascript
                                                 const resSettings = parseAttributes(normalLines[j].substring(normalLines[j].indexOf(':') + 1));
                                                 const lowResUrl = getStreamUrlForResolution(encodingsM3u8, streamInfo.Urls.get(normalLines[j + 1].trimEnd()));
                                                 const lowResInf = encodingsM3u8.match(new RegExp(`^.*(?=\n.*${lowResUrl})`, 'm'))?.[0];
+                                                if (!lowResInf) continue;
                                                 const lowResSettings = parseAttributes(lowResInf.substring(lowResInf.indexOf(':') + 1));
                                                 //console.log('map ' + resSettings['RESOLUTION'] + ' to ' + lowResSettings['RESOLUTION']);
                                                 const codecsKey = 'CODECS';

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -459,6 +459,7 @@
                                                 const resSettings = parseAttributes(normalLines[j].substring(normalLines[j].indexOf(':') + 1));
                                                 const lowResUrl = getStreamUrlForResolution(encodingsM3u8, streamInfo.Urls.get(normalLines[j + 1].trimEnd()));
                                                 const lowResInf = encodingsM3u8.match(new RegExp(`^.*(?=\n.*${lowResUrl})`, 'm'))?.[0];
+                                                if (!lowResInf) continue;
                                                 const lowResSettings = parseAttributes(lowResInf.substring(lowResInf.indexOf(':') + 1));
                                                 //console.log('map ' + resSettings['RESOLUTION'] + ' to ' + lowResSettings['RESOLUTION']);
                                                 const codecsKey = 'CODECS';


### PR DESCRIPTION
## Summary
Add a null guard when the lookbehind regex fails to match during HEVC→AVC codec substitution.

## Why
```js
const lowResInf = encodingsM3u8.match(new RegExp(`^.*(?=\n.*${lowResUrl})`, 'm'))?.[0];
const lowResSettings = parseAttributes(lowResInf.substring(lowResInf.indexOf(':') + 1));
```

The optional chaining on line 1 can return `undefined`, but the next line calls `.substring()` on it without a guard — throwing `TypeError: Cannot read properties of undefined (reading 'substring')` and aborting the substitution loop.

Cases where the regex fails:
- `lowResUrl` is `undefined` because `streamInfo.Urls.get(...)` returned nothing (v2 API URL format changes, unexpected playlist structure)
- Encodings m3u8 doesn't contain an `#EXT-X-STREAM-INF` line above the resolution URL
- Lookbehind pattern doesn't match

The substitution self-recovers on the next m3u8 poll, but the console error was noise.

## Change
One-line guard in both release files:
```js
if (!lowResInf) continue;
```

Already applied to testing (`video-swap-new-ublock-origin-testing.js`).

## Test plan
- [ ] Normal stream with HEVC→AVC substitution → no regression
- [ ] Stream where the regex fails → skips cleanly instead of throwing