### PR TITLE
vaft + video-swap-new: fix unhandled promise rejection in ad .ts prefetch

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -829,7 +829,7 @@ twitch-videoad.js text/javascript
                             // Only request one .ts file per .m3u8 request to avoid making too many requests
                             //console.log('Fetch ad .ts file');
                             streamInfo.RequestedAds.add(lines[i + 1]);
-                            fetch(lines[i + 1]).then((response)=>{response.blob()}).catch(()=>{});
+                            fetch(lines[i + 1]).then((response) => response.blob()).catch(() => {});
                             break;
                         }
                     }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -852,7 +852,7 @@
                             // Only request one .ts file per .m3u8 request to avoid making too many requests
                             //console.log('Fetch ad .ts file');
                             streamInfo.RequestedAds.add(lines[i + 1]);
-                            fetch(lines[i + 1]).then((response)=>{response.blob()}).catch(()=>{});
+                            fetch(lines[i + 1]).then((response) => response.blob()).catch(() => {});
                             break;
                         }
                     }

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -737,7 +737,7 @@ twitch-videoad.js text/javascript
                                         // Only request one .ts file per .m3u8 request to avoid making too many requests
                                         //console.log('Fetch ad .ts file');
                                         streamInfo.RequestedAds.add(lines[i + 1]);
-                                        fetch(lines[i + 1]).then((response)=>{response.blob()});
+                                        fetch(lines[i + 1]).then((response) => response.blob()).catch(() => {});
                                         break;
                                     }
                                 }

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -751,7 +751,7 @@
                                         // Only request one .ts file per .m3u8 request to avoid making too many requests
                                         //console.log('Fetch ad .ts file');
                                         streamInfo.RequestedAds.add(lines[i + 1]);
-                                        fetch(lines[i + 1]).then((response)=>{response.blob()});
+                                        fetch(lines[i + 1]).then((response) => response.blob()).catch(() => {});
                                         break;
                                     }
                                 }


### PR DESCRIPTION
## Summary
Fix unhandled promise rejections when prefetching ad .ts segments.

## Why
```js
// vaft (.catch exists but inner promise lost)
fetch(lines[i + 1]).then((response)=>{response.blob()}).catch(()=>{});

// video-swap-new (no .catch at all)
fetch(lines[i + 1]).then((response)=>{response.blob()});
```

The arrow body `{ response.blob() }` invokes `blob()` but discards the returned promise — if blob() rejects (parse error, abort, wrong content type), the rejection surfaces as unhandled. video-swap-new additionally has no `.catch()` on the fetch chain, so network errors also bubble as unhandled rejections.

## Change
```js
fetch(lines[i + 1]).then((response) => response.blob()).catch(() => {});
```

Returning `response.blob()` chains its rejection into the outer promise, where `.catch()` silences it.

## Scope
- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js` + `video-swap-new/video-swap-new-ublock-origin.js`
- Testing files already patched

## Test plan
- [ ] No regression in ad .ts prefetching behavior
- [ ] Network errors during ad prefetch no longer emit unhandled rejection warnings