### PR TITLE
video-swap-new: clear RequestedAds on end-of-break to prevent memory leak

### DIFF
--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -718,6 +718,7 @@ twitch-videoad.js text/javascript
                             streamInfo.HasConfirmedAdAttrs = false;
                             streamInfo.HasLoggedCsaiFastPath = false;
                             streamInfo.HasLoggedAdAttributes = false;
+                            streamInfo.RequestedAds.clear();
                             streamInfo.ConsecutiveAllStrippedPolls = 0;
                             streamInfo.EarlyReloadTriggered = false;
                             streamInfo.IsMovingOffBackupEncodings = true;

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -732,6 +732,7 @@
                             streamInfo.HasConfirmedAdAttrs = false;
                             streamInfo.HasLoggedCsaiFastPath = false;
                             streamInfo.HasLoggedAdAttributes = false;
+                            streamInfo.RequestedAds.clear();
                             streamInfo.ConsecutiveAllStrippedPolls = 0;
                             streamInfo.EarlyReloadTriggered = false;
                             streamInfo.IsMovingOffBackupEncodings = true;


### PR DESCRIPTION
## Summary
Add `streamInfo.RequestedAds.clear()` to video-swap-new's end-of-break cleanup.

## Why
`RequestedAds` is a Set used to dedupe ad .ts prefetches within an ad break. Without clearing it, the Set accumulates every ad URL seen across the entire session — on long streams (12+ hours, many ad breaks) this grows unboundedly.

vaft already clears it at the end of each break. video-swap-new was missing the corresponding cleanup.

## Change
One line added to end-of-break cleanup block, next to the existing `BackupEncodingsStatus.clear()`:

```js
streamInfo.RequestedAds.clear();
```

## Scope
- `video-swap-new/video-swap-new.user.js`
- `video-swap-new/video-swap-new-ublock-origin.js`
- Testing file already patched

## Test plan
- [ ] Normal ad break → no regression in prefetch dedup (still dedupes within a break)
- [ ] Multi-hour stream with many breaks → Set size doesn't grow across breaks