### PR TITLE
vaft + video-swap-new: reset HasLoggedAdAttributes on end-of-break

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1149,6 +1149,7 @@ twitch-videoad.js text/javascript
                 streamInfo.EarlyReloadAtPoll = 0;
                 streamInfo.TotalAllStrippedPolls = 0;
                 streamInfo.CsaiOnlyThisBreak = false;
+                streamInfo.HasLoggedAdAttributes = false;
                 // CSAI-only ad break: no segments were stripped — skip reload entirely.
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1172,6 +1172,7 @@
                 streamInfo.EarlyReloadAtPoll = 0;
                 streamInfo.TotalAllStrippedPolls = 0;
                 streamInfo.CsaiOnlyThisBreak = false;
+                streamInfo.HasLoggedAdAttributes = false;
                 // CSAI-only ad break: no segments were stripped — skip reload entirely.
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -717,6 +717,7 @@ twitch-videoad.js text/javascript
                             }
                             streamInfo.HasConfirmedAdAttrs = false;
                             streamInfo.HasLoggedCsaiFastPath = false;
+                            streamInfo.HasLoggedAdAttributes = false;
                             streamInfo.ConsecutiveAllStrippedPolls = 0;
                             streamInfo.EarlyReloadTriggered = false;
                             streamInfo.IsMovingOffBackupEncodings = true;

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -731,6 +731,7 @@
                             }
                             streamInfo.HasConfirmedAdAttrs = false;
                             streamInfo.HasLoggedCsaiFastPath = false;
+                            streamInfo.HasLoggedAdAttributes = false;
                             streamInfo.ConsecutiveAllStrippedPolls = 0;
                             streamInfo.EarlyReloadTriggered = false;
                             streamInfo.IsMovingOffBackupEncodings = true;


### PR DESCRIPTION
## Summary
Reset `HasLoggedAdAttributes` to `false` in end-of-break cleanup.

## Why
The flag was set to `true` on first detection but never reset. The `[AD DEBUG] Ad tracking attributes seen: ...` log only fired on the first ad break of a session. Subsequent breaks silently skipped the log.

Impact: if Twitch adds a new ad tracking attribute mid-session (which they do periodically — e.g., `X-TV-TWITCH-AD-DSA-VERSION` was added recently), we wouldn't log it, making it harder to notice changes.

## Change
One line added to end-of-break cleanup:
```js
streamInfo.HasLoggedAdAttributes = false;
```

Converts the log from "once per session" to "once per ad break".

## Scope
- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js` + `video-swap-new/video-swap-new-ublock-origin.js`
- Testing files already patched

## Test plan
- [ ] First ad break → logs attributes as before
- [ ] Second ad break in same session → logs attributes again (not silent)