### PR TITLE
vaft + video-swap-new: revoke previous injected blob URL on worker replacement

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -228,10 +228,11 @@ twitch-videoad.js text/javascript
     }
     // Replace window.Worker to intercept Twitch's video worker and inject ad-blocking logic
     let injectedBlobUrl = null;
+    let originalRevokeObjectURL = null;
     function hookWindowWorker() {
         // Prevent Twitch from revoking our injected worker blob URL
         if (!URL.revokeObjectURL.__tasMasked) {
-            const originalRevokeObjectURL = URL.revokeObjectURL;
+            originalRevokeObjectURL = URL.revokeObjectURL;
             URL.revokeObjectURL = maskAsNative(function(url) {
                 if (url === injectedBlobUrl) return;
                 return originalRevokeObjectURL.call(this, url);
@@ -337,6 +338,9 @@ twitch-videoad.js text/javascript
                     hookWorkerFetch();
                     eval(workerString);
                 `;
+                if (injectedBlobUrl && originalRevokeObjectURL) {
+                    try { originalRevokeObjectURL.call(URL, injectedBlobUrl); } catch {}
+                }
                 injectedBlobUrl = URL.createObjectURL(new Blob([newBlobStr]));
                 super(injectedBlobUrl, options);
                 twitchWorkers.length = 0;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -251,10 +251,11 @@
     }
     // Replace window.Worker to intercept Twitch's video worker and inject ad-blocking logic
     let injectedBlobUrl = null;
+    let originalRevokeObjectURL = null;
     function hookWindowWorker() {
         // Prevent Twitch from revoking our injected worker blob URL
         if (!URL.revokeObjectURL.__tasMasked) {
-            const originalRevokeObjectURL = URL.revokeObjectURL;
+            originalRevokeObjectURL = URL.revokeObjectURL;
             URL.revokeObjectURL = maskAsNative(function(url) {
                 if (url === injectedBlobUrl) return;
                 return originalRevokeObjectURL.call(this, url);
@@ -360,6 +361,10 @@
                     hookWorkerFetch();
                     eval(workerString);
                 `;
+                // Revoke previous blob URL to prevent memory accumulation across worker replacements
+                if (injectedBlobUrl && originalRevokeObjectURL) {
+                    try { originalRevokeObjectURL.call(URL, injectedBlobUrl); } catch {}
+                }
                 injectedBlobUrl = URL.createObjectURL(new Blob([newBlobStr]));
                 super(injectedBlobUrl, options);
                 twitchWorkers.length = 0;

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -178,10 +178,11 @@ twitch-videoad.js text/javascript
         return !hasConflict || hasAllow || hasReinsert;
     }
     let injectedBlobUrl = null;
+    let originalRevokeObjectURL = null;
     function hookWindowWorker() {
         // Prevent Twitch from revoking our injected worker blob URL
         if (!URL.revokeObjectURL.__tasMasked) {
-            const originalRevokeObjectURL = URL.revokeObjectURL;
+            originalRevokeObjectURL = URL.revokeObjectURL;
             URL.revokeObjectURL = maskAsNative(function(url) {
                 if (url === injectedBlobUrl) return;
                 return originalRevokeObjectURL.call(this, url);
@@ -278,6 +279,9 @@ twitch-videoad.js text/javascript
                     hookWorkerFetch();
                     eval(workerString);
                 `
+                if (injectedBlobUrl && originalRevokeObjectURL) {
+                    try { originalRevokeObjectURL.call(URL, injectedBlobUrl); } catch {}
+                }
                 injectedBlobUrl = URL.createObjectURL(new Blob([newBlobStr]));
                 super(injectedBlobUrl, options);
                 twitchWorkers.length = 0;

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -190,10 +190,11 @@
         return !hasConflict || hasAllow || hasReinsert;
     }
     let injectedBlobUrl = null;
+    let originalRevokeObjectURL = null;
     function hookWindowWorker() {
         // Prevent Twitch from revoking our injected worker blob URL
         if (!URL.revokeObjectURL.__tasMasked) {
-            const originalRevokeObjectURL = URL.revokeObjectURL;
+            originalRevokeObjectURL = URL.revokeObjectURL;
             URL.revokeObjectURL = maskAsNative(function(url) {
                 if (url === injectedBlobUrl) return;
                 return originalRevokeObjectURL.call(this, url);
@@ -290,6 +291,9 @@
                     hookWorkerFetch();
                     eval(workerString);
                 `
+                if (injectedBlobUrl && originalRevokeObjectURL) {
+                    try { originalRevokeObjectURL.call(URL, injectedBlobUrl); } catch {}
+                }
                 injectedBlobUrl = URL.createObjectURL(new Blob([newBlobStr]));
                 super(injectedBlobUrl, options);
                 twitchWorkers.length = 0;


### PR DESCRIPTION
## Summary
Fix a memory leak where orphaned blob URLs accumulated in browser memory until page unload.

## Why
Each time Twitch creates a new Web Worker (channel switch, player reload), the script creates a new blob URL and overwrites `injectedBlobUrl`:

```js
injectedBlobUrl = URL.createObjectURL(new Blob([newBlobStr]));
```

The old blob URL is never revoked:
- Our `revokeObjectURL` hook only blocks revocation of the CURRENT `injectedBlobUrl` (Twitch uses this to try to revoke, we ignore it)
- After reassignment, the OLD URL is technically revokable — but nothing calls revoke on it (Twitch doesn't know about our blob)
- Browser's blob URL registry holds the reference until page unload

Each blob is ~100 KB of worker JS. Long channel-hopping sessions or many player reloads accumulate 1-5 MB of orphaned blobs.

## Change
- Promote `originalRevokeObjectURL` from a closure-local const to module-scope `let`, so the Worker constructor can reach it
- Before each new `URL.createObjectURL`, call the original (un-hooked) `revokeObjectURL` on the previous `injectedBlobUrl`

```js
if (injectedBlobUrl && originalRevokeObjectURL) {
    try { originalRevokeObjectURL.call(URL, injectedBlobUrl); } catch {}
}
injectedBlobUrl = URL.createObjectURL(new Blob([newBlobStr]));
```

Uses the captured original function to bypass our own hook, which would otherwise block the revoke (since it guards against revocation of the current URL — but by this point, we're about to replace it anyway).

## Scope
- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js` + `video-swap-new/video-swap-new-ublock-origin.js`
- Testing files already patched

## Test plan
- [ ] Normal stream → no regression in worker init
- [ ] Channel switch → new worker created successfully
- [ ] Long channel-hopping session → memory doesn't grow proportional to switches