### PR TITLE
video-swap-new: silence benign AbortError in fetch hook

### DIFF
--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -809,7 +809,7 @@ twitch-videoad.js text/javascript
                         realFetch(url, options).then(function(response) {
                             processAfter(response);
                         })['catch'](function(err) {
-                            console.log('fetch hook err ' + err);
+                            if (err?.name !== 'AbortError') console.log('fetch hook err ' + err);
                             reject(err);
                         });
                     });

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -823,7 +823,7 @@
                         realFetch(url, options).then(function(response) {
                             processAfter(response);
                         })['catch'](function(err) {
-                            console.log('fetch hook err ' + err);
+                            if (err?.name !== 'AbortError') console.log('fetch hook err ' + err);
                             reject(err);
                         });
                     });


### PR DESCRIPTION
## Summary
Skip the `fetch hook err ...` console log when the error is an `AbortError`.

## Why
When the worker switches backup streams, in-flight fetches get cancelled via `AbortController`. This surfaces as `AbortError` in the fetch hook's catch block — an expected lifecycle event, not an error. But it spammed the console 1× per backup switch, reaching 7+ log lines per heavy SSAI break (backup cycling).

## Change
```js
})['catch'](function(err) {
    if (err?.name !== 'AbortError') console.log('fetch hook err ' + err);
    reject(err);
});
```

Real fetch errors still log as before. The rejection continues to propagate to the outer promise so any downstream handling is unaffected.

## Scope
- `video-swap-new/video-swap-new.user.js`
- `video-swap-new/video-swap-new-ublock-origin.js`
- Testing file already patched (along with PR #133 port)

## Test plan
- [ ] Normal ad break with backup cycling → no AbortError spam
- [ ] Genuine fetch error (network down) → still logs as before