### PR TITLE
vaft: remove ad-break-card text-match hide (false-positive risk)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -165,7 +165,6 @@ twitch-videoad.js text/javascript
     // on every tick via dataset-based dedup.
     let loggedPromoOverlayHide = false;
     let loggedSdaHide = false;
-    let loggedAdBreakCardHide = false;
     // Strings used to detect and handle conflicting Twitch worker overrides (e.g. TwitchNoSub)
     const workerStringConflicts = [
         'twitch',
@@ -1546,34 +1545,6 @@ twitch-videoad.js text/javascript
                 if (!loggedSdaHide) {
                     loggedSdaHide = true;
                     console.log('[AD DEBUG] Hidden Twitch stream display ad');
-                }
-            }
-        }
-        // Hide "taking an ad break" / "stick around to support the stream" card.
-        // This overlay has its own lifecycle independent of the player's ad state — when
-        // the CSAI fast path keeps the player on the main stream, Twitch's overlay
-        // controller never receives the "player exited ad state" signal, so the card
-        // persists after the break ends. Text-match approach: scan for the distinctive
-        // phrases inside the player root (avoids chat false positives), walk up to find
-        // the overlay container. Scoped to the player root to keep cost bounded.
-        const textNodes = cachedPlayerRootDiv.querySelectorAll('span, p, h1, h2, h3');
-        for (let i = 0; i < textNodes.length; i++) {
-            const el = textNodes[i];
-            const text = (el.textContent || '').toLowerCase();
-            if (text.length === 0 || text.length > 300) continue;
-            if (text.includes('taking an ad break') ||
-                text.includes('stick around to support the stream') ||
-                text.includes('stick around to support the channel') ||
-                text.includes('right after this ad break')) {
-                const overlay = el.closest('.player-overlay-background') || el.closest('[class*="overlay"]') || el.parentElement;
-                if (overlay && !overlay.dataset.tasAdBreakHidden) {
-                    overlay.dataset.tasAdBreakHidden = '';
-                    overlay.style.setProperty('display', 'none', 'important');
-                    if (!loggedAdBreakCardHide) {
-                        loggedAdBreakCardHide = true;
-                        console.log('[AD DEBUG] Hidden Twitch ad break card (taking an ad break / stick around)');
-                    }
-                    break;// One card per tick is enough; don't over-scan
                 }
             }
         }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -188,7 +188,6 @@
     // on every tick via dataset-based dedup.
     let loggedPromoOverlayHide = false;
     let loggedSdaHide = false;
-    let loggedAdBreakCardHide = false;
     // Strings used to detect and handle conflicting Twitch worker overrides (e.g. TwitchNoSub)
     const workerStringConflicts = [
         'twitch',
@@ -1570,37 +1569,6 @@
                 if (!loggedSdaHide) {
                     loggedSdaHide = true;
                     console.log('[AD DEBUG] Hidden Twitch stream display ad');
-                }
-            }
-        }
-        // Hide "taking an ad break" / "stick around to support the stream" card.
-        // This overlay has its own lifecycle independent of the player's ad state — when
-        // the CSAI fast path keeps the player on the main stream, Twitch's overlay
-        // controller never receives the "player exited ad state" signal, so the card
-        // persists after the break ends. Text-match approach: scan for the distinctive
-        // phrases inside the player root (avoids chat false positives), walk up to find
-        // the overlay container. Scoped to the player root to keep cost bounded.
-        const textNodes = cachedPlayerRootDiv.querySelectorAll('span, p, h1, h2, h3');
-        for (let i = 0; i < textNodes.length; i++) {
-            const el = textNodes[i];
-            const text = (el.textContent || '').toLowerCase();
-            if (text.length === 0 || text.length > 300) continue;
-            if (text.includes('taking an ad break') ||
-                text.includes('stick around to support the stream') ||
-                text.includes('stick around to support the channel') ||
-                text.includes('right after this ad break')) {
-                // Walk up a few levels to find the card container (matches TTV-AB's approach).
-                // Prefer a known overlay class if one is nearby; otherwise fall back to a
-                // reasonable parent.
-                const overlay = el.closest('.player-overlay-background') || el.closest('[class*="overlay"]') || el.parentElement;
-                if (overlay && !overlay.dataset.tasAdBreakHidden) {
-                    overlay.dataset.tasAdBreakHidden = '';
-                    overlay.style.setProperty('display', 'none', 'important');
-                    if (!loggedAdBreakCardHide) {
-                        loggedAdBreakCardHide = true;
-                        console.log('[AD DEBUG] Hidden Twitch ad break card (taking an ad break / stick around)');
-                    }
-                    break;// One card per tick is enough; don't over-scan
                 }
             }
         }


### PR DESCRIPTION
## Summary
Remove the text-match ad-break-card hider added in PR #68. Keep the two safe hiders (promo overlay + SDA wrapper).

## Why
User complaint received:

> Black screen, stream freezes, the player controls disappear. Many many things are broken.

The most distinctive symptom — **player controls disappear** — points directly at the text-match hider. Its logic:

```js
const overlay = el.closest('.player-overlay-background')
             || el.closest('[class*="overlay"]')
             || el.parentElement;
overlay.style.setProperty('display', 'none', 'important');
```

Two unsafe fallbacks:
1. `[class*="overlay"]` — substring match hits many unrelated Twitch classes (`chat-overlay-*`, `tw-overlay-*`, `viewer-card-overlay`, settings/quality overlays, etc.)
2. `el.parentElement` — if the text appeared anywhere inside the controls container (tooltip, caption, notification), hiding the parent hides the controls

## TTV-AB comparison
Checked TTV-AB for their approach — they **don't match this text at all**. Their ad artifact hider uses curated specific selectors (`data-test-selector`, `data-a-target` attributes) and explicitly resets styles rather than hiding when an element contains `<video>`. No upstream precedent to mirror safely.

## Change
Remove the `for (textNodes)` block entirely. Also removes the unused `loggedAdBreakCardHide` flag.

The other two overlay hiders (exact-attribute selectors for promo links and `[data-test-selector="sda-wrapper"]`) stay in place — those are targeted and have no report of issues.

## Scope
- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- Testing files already patched

## Test plan
- [ ] Normal stream + ad break → no regression, promo/SDA hiders still work
- [ ] Ad break "stick around" card → now visible (was hidden before; side effect is the card shows during breaks)
- [ ] Player controls remain functional during and after ad breaks

## Note
If you want to re-introduce ad-break-card hiding in the future, the safe path is: ask users to inspect the card in devtools, get its actual `data-a-target` or class, and target it with an exact selector like TTV-AB does.