### PR TITLE
video-swap-new: broaden benign cancel-error filter in fetch hook

### DIFF
--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -812,7 +812,8 @@ twitch-videoad.js text/javascript
                         realFetch(url, options).then(function(response) {
                             processAfter(response);
                         })['catch'](function(err) {
-                            if (err?.name !== 'AbortError') console.log('fetch hook err ' + err);
+                            const errMsg = String(err?.message || err);
+                            if (err?.name !== 'AbortError' && !/cancel|abort/i.test(errMsg)) console.log('fetch hook err ' + err);
                             reject(err);
                         });
                     });

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -826,7 +826,8 @@
                         realFetch(url, options).then(function(response) {
                             processAfter(response);
                         })['catch'](function(err) {
-                            if (err?.name !== 'AbortError') console.log('fetch hook err ' + err);
+                            const errMsg = String(err?.message || err);
+                            if (err?.name !== 'AbortError' && !/cancel|abort/i.test(errMsg)) console.log('fetch hook err ' + err);
                             reject(err);
                         });
                     });


### PR DESCRIPTION
## Summary
Widen the benign-cancellation filter in the fetch hook to also catch Firefox's `Error('Request cancelled')` pattern.

## Why
PR #140 silenced `AbortError` from the fetch hook catch block. But Firefox's IVS player wraps fetches with its own cancellation mechanism and throws a plain `Error` with message `"Request cancelled"`, not a DOMException. Its `err.name` is `'Error'`, not `'AbortError'`, so it slipped through the name-only check:

```
fetch hook err Request cancelled
```

This appears on every backup stream switch (same benign lifecycle as `AbortError`).

## Change
```diff
-if (err?.name !== 'AbortError') console.log('fetch hook err ' + err);
+const errMsg = String(err?.message || err);
+if (err?.name !== 'AbortError' && !/cancel|abort/i.test(errMsg)) console.log('fetch hook err ' + err);
```

Catches:
- `DOMException` with `name === 'AbortError'` (Chrome standard)
- `Error` with `message` containing "cancel"/"abort" (Firefox IVS wrapper, any similar variants)

Real errors (`NetworkError`, `TypeError: Failed to fetch`, etc.) continue to log as before — none of those contain "cancel" or "abort" in their messages.

## Scope
- `video-swap-new/video-swap-new.user.js`
- `video-swap-new/video-swap-new-ublock-origin.js`
- Testing file already patched

## Test plan
- [ ] Firefox backup cycling during ad break → no "Request cancelled" spam
- [ ] Chrome backup cycling (previously silenced AbortError) → still silent
- [ ] Simulated network error → still logs