### PR TITLE
vaft: remove promo/Turbo overlay hide (last .player-overlay-background use)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -163,7 +163,6 @@ twitch-videoad.js text/javascript
     // hide-and-log fires hundreds of times. Log the first occurrence of each
     // hide type per page load, then stay silent — the hide itself still runs
     // on every tick via dataset-based dedup.
-    let loggedPromoOverlayHide = false;
     let loggedSdaHide = false;
     // Strings used to detect and handle conflicting Twitch worker overrides (e.g. TwitchNoSub)
     const workerStringConflicts = [
@@ -1523,20 +1522,6 @@ twitch-videoad.js text/javascript
     // Hide Twitch's ad break / Turbo promo / stream display ad overlays when we're already blocking ads
     function hideTwitchAdOverlays() {
         if (!cachedPlayerRootDiv || !cachedPlayerRootDiv.isConnected) return;
-        const promoLinks = cachedPlayerRootDiv.querySelectorAll(
-            'a[href*="/how-to-allow-ads-browser"], a[href="https://www.twitch.tv/turbo"]'
-        );
-        for (let i = 0; i < promoLinks.length; i++) {
-            const overlay = promoLinks[i].closest('.player-overlay-background');
-            if (overlay && !overlay.dataset.tasHidden) {
-                overlay.dataset.tasHidden = '';
-                overlay.style.setProperty('display', 'none', 'important');
-                if (!loggedPromoOverlayHide) {
-                    loggedPromoOverlayHide = true;
-                    console.log('[AD DEBUG] Hidden Twitch ad/Turbo promo overlay');
-                }
-            }
-        }
         // Hide stream display ad (SDA) wrapper
         const sdaElements = document.querySelectorAll('[data-test-selector="sda-wrapper"]');
         for (let i = 0; i < sdaElements.length; i++) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -186,7 +186,6 @@
     // hide-and-log fires hundreds of times. Log the first occurrence of each
     // hide type per page load, then stay silent — the hide itself still runs
     // on every tick via dataset-based dedup.
-    let loggedPromoOverlayHide = false;
     let loggedSdaHide = false;
     // Strings used to detect and handle conflicting Twitch worker overrides (e.g. TwitchNoSub)
     const workerStringConflicts = [
@@ -1546,21 +1545,6 @@
     // Hide Twitch's ad break / Turbo promo / stream display ad overlays when we're already blocking ads
     function hideTwitchAdOverlays() {
         if (!cachedPlayerRootDiv || !cachedPlayerRootDiv.isConnected) return;
-        // Hide "allow ads" and Turbo promo overlays (walk up to their background container)
-        const promoLinks = cachedPlayerRootDiv.querySelectorAll(
-            'a[href*="/how-to-allow-ads-browser"], a[href="https://www.twitch.tv/turbo"]'
-        );
-        for (let i = 0; i < promoLinks.length; i++) {
-            const overlay = promoLinks[i].closest('.player-overlay-background');
-            if (overlay && !overlay.dataset.tasHidden) {
-                overlay.dataset.tasHidden = '';
-                overlay.style.setProperty('display', 'none', 'important');
-                if (!loggedPromoOverlayHide) {
-                    loggedPromoOverlayHide = true;
-                    console.log('[AD DEBUG] Hidden Twitch ad/Turbo promo overlay');
-                }
-            }
-        }
         // Hide stream display ad (SDA) wrapper
         const sdaElements = document.querySelectorAll('[data-test-selector="sda-wrapper"]');
         for (let i = 0; i < sdaElements.length; i++) {


### PR DESCRIPTION
## Summary
Remove the "allow ads" / Turbo promo overlay hider. This is the last remaining use of `.player-overlay-background` in the codebase.

## Why
Same modal-scrim safety concern as PR #141 (ad-break-card removal). The `.player-overlay-background` class is Twitch's generic modal scrim, used for many full-player overlays:

- Content classification gates (18+ warnings, "click to watch")
- Mature content warnings
- Subscription-only gates
- Chat ban / mod action notices
- Error dialogs ("Sorry, this stream isn't available")
- Stream offline indicators

The href pre-filter (`a[href*="/how-to-allow-ads-browser"]` + `a[href="https://www.twitch.tv/turbo"]`) narrows the trigger to specific ad/Turbo promo URLs. In practice, those links only appear in the dedicated ad promo overlay. But if Twitch ever nests them inside an unexpected container, we could hide critical UI.

Following the same conservative approach as #141.

## Change
Remove the `for (promoLinks)` block from `hideTwitchAdOverlays()` and the unused `loggedPromoOverlayHide` flag.

## Scope
- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- Testing files already patched

## What remains
- **SDA wrapper hide** — exact `[data-test-selector="sda-wrapper"]` match, no parent walking, zero false-positive risk
- **`adBlockDiv`** — our own UI element
- **`.tas-adblock-overlay`** CSS opt-in — our own class

## Tradeoff
Users now see the "allow ads" / Turbo promo overlay during ad breaks. Minor visual annoyance, but zero risk of accidentally hiding content gates, error dialogs, or other player UI.

## Test plan
- [ ] Ad break → promo overlay visible (was hidden before)
- [ ] SDA during stream → still hidden
- [ ] Content gate / mature warning overlay → works normally (no risk of hide)