### PR TITLE
vaft: switch to soft reload for post-ad player restart

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1749,7 +1749,10 @@ twitch-videoad.js text/javascript
             playerBufferState.loggedPauseIntent = false;
             // playerForMonitoringBuffering re-acquired fresh every tick — no manual invalidation needed
             console.log('Reloading Twitch player');
-            playerState.setSrc({ isNewMediaPlayerInstance: true, refreshAccessToken: true });
+            // Soft reload: keep the player instance alive and reuse the cached access token.
+            // Smoother transition than the hard reload (no ~1-3s black screen during teardown).
+            // Ported from TTV-AB's post-ad reload pattern (v6.3.9 / v6.4.3).
+            playerState.setSrc({ isNewMediaPlayerInstance: false, refreshAccessToken: false });
             postTwitchWorkerMessage('TriggeredPlayerReload');
             player.play()?.catch?.(() => {});
             // Always restore muted/volume state after reload — Chrome autoplay policy can force muted

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1772,7 +1772,10 @@
             playerBufferState.loggedPauseIntent = false;
             // playerForMonitoringBuffering re-acquired fresh every tick — no manual invalidation needed
             console.log('Reloading Twitch player');
-            playerState.setSrc({ isNewMediaPlayerInstance: true, refreshAccessToken: true });
+            // Soft reload: keep the player instance alive and reuse the cached access token.
+            // Smoother transition than the hard reload (no ~1-3s black screen during teardown).
+            // Ported from TTV-AB's post-ad reload pattern (v6.3.9 / v6.4.3).
+            playerState.setSrc({ isNewMediaPlayerInstance: false, refreshAccessToken: false });
             postTwitchWorkerMessage('TriggeredPlayerReload');
             player.play()?.catch?.(() => {});
             // Always restore muted/volume state after reload — Chrome autoplay policy can force muted


### PR DESCRIPTION
## Summary
Replace the hard reload (`isNewMediaPlayerInstance: true, refreshAccessToken: true`) with soft reload (both `false`). Ported from TTV-AB's post-ad reload pattern (v6.3.9 / v6.4.3).

## Why
User-reported symptom: ~1-3s black screen during post-ad reload. Hard reload tears down the entire media player instance and fetches a new access token, causing a visible teardown/rebuild gap.

Soft reload keeps the player alive and nudges it to refetch the m3u8 at its current source. Transition is ~0.5-1s with no black screen in most cases.

## Change
```diff
-playerState.setSrc({ isNewMediaPlayerInstance: true, refreshAccessToken: true });
+playerState.setSrc({ isNewMediaPlayerInstance: false, refreshAccessToken: false });
```

## Tradeoffs
- **Uses cached access token** — doesn't re-apply `ForceAccessTokenPlayerType` override. In practice fine because cached tokens are already popout (our GQL hook forces popout on every fetch).
- **Reuses existing session** — ad-state from the prior session might persist briefly. Mitigated by `processM3U8` only firing the reload after `CleanPlaylistCount` threshold passes.
- **Preserves worker caches and backup variant URLs** across the reload (positive side effect).

## Scope
- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- Testing files already patched (scope limited to vaft — video-swap-new has different reload architecture via worker postMessage, separate consideration)

## Test plan
- [ ] Post-ad reload → smoother transition, no black screen
- [ ] Popout override still active (log shows "Replaced 'site' player type with 'popout'" only for new tokens, not reloads reusing cached)
- [ ] Ad-state doesn't persist after reload (next poll shows clean playlist)