### PR TITLE
vaft: hard reload for early-reload, soft for post-ad (stacks on #134)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -360,7 +360,7 @@ twitch-videoad.js text/javascript
                     } else if (e.data.key == 'PauseResumePlayer') {
                         doTwitchPlayerTask(true, false);
                     } else if (e.data.key == 'ReloadPlayer') {
-                        doTwitchPlayerTask(false, true);
+                        doTwitchPlayerTask(false, true, e.data.kind);
                     }
                 });
                 this.addEventListener('message', async event => {
@@ -880,7 +880,7 @@ twitch-videoad.js text/javascript
                     streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
                     const stickyReason = stickyRecoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
                     console.log('[AD DEBUG] Early reload triggered (sticky path) — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + stickyReason + ' [' + streamInfo.EarlyReloadCount + '/' + stickyMaxEarlyReloads + ']');
-                    postMessage({ key: 'ReloadPlayer' });
+                    postMessage({ key: 'ReloadPlayer', kind: 'early' });
                 }
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -1108,7 +1108,7 @@ twitch-videoad.js text/javascript
                 streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
                 const reason = recoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
                 console.log('[AD DEBUG] Early reload triggered — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + reason + ' [' + streamInfo.EarlyReloadCount + '/' + maxEarlyReloads + ']');
-                postMessage({ key: 'ReloadPlayer' });
+                postMessage({ key: 'ReloadPlayer', kind: 'early' });
             }
         } else if (streamInfo.IsShowingAd) {
             streamInfo.CleanPlaylistCount++;
@@ -1649,7 +1649,7 @@ twitch-videoad.js text/javascript
         };
     }
     // Pause/play or fully reload the Twitch player, preserving quality/volume settings
-    function doTwitchPlayerTask(isPausePlay, isReload) {
+    function doTwitchPlayerTask(isPausePlay, isReload, reloadKind) {
         const playerAndState = getPlayerAndState();
         if (!playerAndState) {
             console.log('Could not find react root');
@@ -1753,11 +1753,11 @@ twitch-videoad.js text/javascript
             playerBufferState.userPauseIntent = false;
             playerBufferState.loggedPauseIntent = false;
             // playerForMonitoringBuffering re-acquired fresh every tick — no manual invalidation needed
-            console.log('Reloading Twitch player');
-            // Soft reload: keep the player instance alive and reuse the cached access token.
-            // Smoother transition than the hard reload (no ~1-3s black screen during teardown).
-            // Ported from TTV-AB's post-ad reload pattern (v6.3.9 / v6.4.3).
-            playerState.setSrc({ isNewMediaPlayerInstance: false, refreshAccessToken: false });
+            // Hard reload for 'early' (mid-break escape — fresh session gets new ad-decision bucket).
+            // Soft reload for 'post-ad' (smooth transition, no black screen teardown).
+            const hardReload = reloadKind === 'early';
+            console.log('Reloading Twitch player' + (hardReload ? ' (hard)' : ' (soft)'));
+            playerState.setSrc({ isNewMediaPlayerInstance: hardReload, refreshAccessToken: hardReload });
             postTwitchWorkerMessage('TriggeredPlayerReload');
             player.play()?.catch?.(() => {});
             // Always restore muted/volume state after reload — Chrome autoplay policy can force muted

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -383,7 +383,7 @@
                     } else if (e.data.key == 'PauseResumePlayer') {
                         doTwitchPlayerTask(true, false);
                     } else if (e.data.key == 'ReloadPlayer') {
-                        doTwitchPlayerTask(false, true);
+                        doTwitchPlayerTask(false, true, e.data.kind);
                     }
                 });
                 this.addEventListener('message', async event => {
@@ -904,7 +904,8 @@
                     streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
                     const stickyReason = stickyRecoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
                     console.log('[AD DEBUG] Early reload triggered (sticky path) — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + stickyReason + ' [' + streamInfo.EarlyReloadCount + '/' + stickyMaxEarlyReloads + ']');
-                    postMessage({ key: 'ReloadPlayer' });
+                    // kind: 'early' → main thread uses hard reload (fresh access token = new ad-decision session)
+                    postMessage({ key: 'ReloadPlayer', kind: 'early' });
                 }
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -1132,7 +1133,8 @@
                 streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
                 const reason = recoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
                 console.log('[AD DEBUG] Early reload triggered — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + reason + ' [' + streamInfo.EarlyReloadCount + '/' + maxEarlyReloads + ']');
-                postMessage({ key: 'ReloadPlayer' });
+                // kind: 'early' → main thread uses hard reload (fresh access token = new ad-decision session)
+                postMessage({ key: 'ReloadPlayer', kind: 'early' });
             }
         } else if (streamInfo.IsShowingAd) {
             streamInfo.CleanPlaylistCount++;
@@ -1672,8 +1674,10 @@
             state: finalPlayerState
         };
     }
-    // Pause/play or fully reload the Twitch player, preserving quality/volume settings
-    function doTwitchPlayerTask(isPausePlay, isReload) {
+    // Pause/play or fully reload the Twitch player, preserving quality/volume settings.
+    // reloadKind: 'early' → hard reload (fresh session, for SSAI-on-all-backups breakout).
+    //             undefined/'post-ad' → soft reload (smooth transition).
+    function doTwitchPlayerTask(isPausePlay, isReload, reloadKind) {
         const playerAndState = getPlayerAndState();
         if (!playerAndState) {
             console.log('Could not find react root');
@@ -1777,11 +1781,11 @@
             playerBufferState.userPauseIntent = false;
             playerBufferState.loggedPauseIntent = false;
             // playerForMonitoringBuffering re-acquired fresh every tick — no manual invalidation needed
-            console.log('Reloading Twitch player');
-            // Soft reload: keep the player instance alive and reuse the cached access token.
-            // Smoother transition than the hard reload (no ~1-3s black screen during teardown).
-            // Ported from TTV-AB's post-ad reload pattern (v6.3.9 / v6.4.3).
-            playerState.setSrc({ isNewMediaPlayerInstance: false, refreshAccessToken: false });
+            // Hard reload for 'early' (mid-break escape attempt — fresh session gets new ad-decision bucket).
+            // Soft reload for 'post-ad' (smooth transition, no black screen teardown).
+            const hardReload = reloadKind === 'early';
+            console.log('Reloading Twitch player' + (hardReload ? ' (hard)' : ' (soft)'));
+            playerState.setSrc({ isNewMediaPlayerInstance: hardReload, refreshAccessToken: hardReload });
             postTwitchWorkerMessage('TriggeredPlayerReload');
             player.play()?.catch?.(() => {});
             // Always restore muted/volume state after reload — Chrome autoplay policy can force muted


### PR DESCRIPTION
## Summary
Split post-ad reload (soft) from mid-break early reload (hard). Gets back the SSAI-escape capability that PR #144's universal soft reload accidentally removed.

**Stacks on PR #134** — merge #134 first, then this. (Base branch is set to #134's branch; will auto-retarget to master after #134 merges.)

## Why
PR #144 switched all reloads to soft (`isNewMediaPlayerInstance: false, refreshAccessToken: false`) for smoother transitions. But soft reload reuses the cached access token — same session, same ad-decision bucket.

During heavy SSAI breaks (user report: 3-minute break with `PodLength=8`), every early reload after PR #134 would fire with its full budget... but each one lands back in ads because the session hasn't changed. The budget is effectively wasted.

## Change

Worker → main thread messages:
```diff
-postMessage({ key: 'ReloadPlayer' });         // early reload sites
+postMessage({ key: 'ReloadPlayer', kind: 'early' });
```

Main thread handler:
```diff
-doTwitchPlayerTask(false, true);
+doTwitchPlayerTask(false, true, e.data.kind);
```

`doTwitchPlayerTask` picks setSrc params based on kind:
```js
const hardReload = reloadKind === 'early';
playerState.setSrc({ isNewMediaPlayerInstance: hardReload, refreshAccessToken: hardReload });
```

Log shows `Reloading Twitch player (hard)` vs `(soft)` so you can tell them apart.

## Per-site outcome

| Site | Kind | Reload type | Reason |
|---|---|---|---|
| Sticky CSAI early reload (worker) | `early` | hard | escape SSAI-on-all-backups |
| Normal path early reload (worker) | `early` | hard | escape SSAI-on-all-backups |
| Post-ad reload (worker) | undefined | soft | smooth transition (common case) |
| HEVC force reload (worker) | undefined | soft | codec swap, session OK |

## Scope
- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- Testing files already patched

## Test plan
- [ ] Normal ad break → post-ad reload is soft (no black screen, same as v60.0.0)
- [ ] SSAI-heavy break (simulate by forcing all backups ad-laden) → early reloads fire with `(hard)` log, budget actually makes progress
- [ ] `[1/8]` → `[2/8]` → `[3/8]` etc. on the user's 3-minute break reproduction