### PR TITLE
vaft: re-apply hard/soft reload split (PR #145 orphaned by #134 squash merge)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -360,7 +360,7 @@ twitch-videoad.js text/javascript
                     } else if (e.data.key == 'PauseResumePlayer') {
                         doTwitchPlayerTask(true, false);
                     } else if (e.data.key == 'ReloadPlayer') {
-                        doTwitchPlayerTask(false, true);
+                        doTwitchPlayerTask(false, true, e.data.kind);
                     }
                 });
                 this.addEventListener('message', async event => {
@@ -880,7 +880,7 @@ twitch-videoad.js text/javascript
                     streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
                     const stickyReason = stickyRecoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
                     console.log('[AD DEBUG] Early reload triggered (sticky path) — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + stickyReason + ' [' + streamInfo.EarlyReloadCount + '/' + stickyMaxEarlyReloads + ']');
-                    postMessage({ key: 'ReloadPlayer' });
+                    postMessage({ key: 'ReloadPlayer', kind: 'early' });
                 }
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -1108,7 +1108,7 @@ twitch-videoad.js text/javascript
                 streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
                 const reason = recoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
                 console.log('[AD DEBUG] Early reload triggered — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + reason + ' [' + streamInfo.EarlyReloadCount + '/' + maxEarlyReloads + ']');
-                postMessage({ key: 'ReloadPlayer' });
+                postMessage({ key: 'ReloadPlayer', kind: 'early' });
             }
         } else if (streamInfo.IsShowingAd) {
             streamInfo.CleanPlaylistCount++;
@@ -1649,7 +1649,7 @@ twitch-videoad.js text/javascript
         };
     }
     // Pause/play or fully reload the Twitch player, preserving quality/volume settings
-    function doTwitchPlayerTask(isPausePlay, isReload) {
+    function doTwitchPlayerTask(isPausePlay, isReload, reloadKind) {
         const playerAndState = getPlayerAndState();
         if (!playerAndState) {
             console.log('Could not find react root');
@@ -1753,11 +1753,11 @@ twitch-videoad.js text/javascript
             playerBufferState.userPauseIntent = false;
             playerBufferState.loggedPauseIntent = false;
             // playerForMonitoringBuffering re-acquired fresh every tick — no manual invalidation needed
-            console.log('Reloading Twitch player');
-            // Soft reload: keep the player instance alive and reuse the cached access token.
-            // Smoother transition than the hard reload (no ~1-3s black screen during teardown).
-            // Ported from TTV-AB's post-ad reload pattern (v6.3.9 / v6.4.3).
-            playerState.setSrc({ isNewMediaPlayerInstance: false, refreshAccessToken: false });
+            // Hard reload for 'early' (mid-break escape — fresh session gets new ad-decision bucket).
+            // Soft reload for 'post-ad' (smooth transition, no black screen teardown).
+            const hardReload = reloadKind === 'early';
+            console.log('Reloading Twitch player' + (hardReload ? ' (hard)' : ' (soft)'));
+            playerState.setSrc({ isNewMediaPlayerInstance: hardReload, refreshAccessToken: hardReload });
             postTwitchWorkerMessage('TriggeredPlayerReload');
             player.play()?.catch?.(() => {});
             // Always restore muted/volume state after reload — Chrome autoplay policy can force muted

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -383,7 +383,7 @@
                     } else if (e.data.key == 'PauseResumePlayer') {
                         doTwitchPlayerTask(true, false);
                     } else if (e.data.key == 'ReloadPlayer') {
-                        doTwitchPlayerTask(false, true);
+                        doTwitchPlayerTask(false, true, e.data.kind);
                     }
                 });
                 this.addEventListener('message', async event => {
@@ -904,7 +904,7 @@
                     streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
                     const stickyReason = stickyRecoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
                     console.log('[AD DEBUG] Early reload triggered (sticky path) — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + stickyReason + ' [' + streamInfo.EarlyReloadCount + '/' + stickyMaxEarlyReloads + ']');
-                    postMessage({ key: 'ReloadPlayer' });
+                    postMessage({ key: 'ReloadPlayer', kind: 'early' });
                 }
                 postMessage({
                     key: 'UpdateAdBlockBanner',
@@ -1132,7 +1132,7 @@
                 streamInfo.EarlyReloadAtPoll = streamInfo.TotalAllStrippedPolls || streamInfo.ConsecutiveAllStrippedPolls;
                 const reason = recoveryThin ? ' (thin recovery cache: ' + (streamInfo.RecoverySegments?.length || 0) + ' segments)' : '';
                 console.log('[AD DEBUG] Early reload triggered — ' + streamInfo.ConsecutiveAllStrippedPolls + ' consecutive all-stripped polls' + reason + ' [' + streamInfo.EarlyReloadCount + '/' + maxEarlyReloads + ']');
-                postMessage({ key: 'ReloadPlayer' });
+                postMessage({ key: 'ReloadPlayer', kind: 'early' });
             }
         } else if (streamInfo.IsShowingAd) {
             streamInfo.CleanPlaylistCount++;
@@ -1673,7 +1673,7 @@
         };
     }
     // Pause/play or fully reload the Twitch player, preserving quality/volume settings
-    function doTwitchPlayerTask(isPausePlay, isReload) {
+    function doTwitchPlayerTask(isPausePlay, isReload, reloadKind) {
         const playerAndState = getPlayerAndState();
         if (!playerAndState) {
             console.log('Could not find react root');
@@ -1777,11 +1777,11 @@
             playerBufferState.userPauseIntent = false;
             playerBufferState.loggedPauseIntent = false;
             // playerForMonitoringBuffering re-acquired fresh every tick — no manual invalidation needed
-            console.log('Reloading Twitch player');
-            // Soft reload: keep the player instance alive and reuse the cached access token.
-            // Smoother transition than the hard reload (no ~1-3s black screen during teardown).
-            // Ported from TTV-AB's post-ad reload pattern (v6.3.9 / v6.4.3).
-            playerState.setSrc({ isNewMediaPlayerInstance: false, refreshAccessToken: false });
+            // Hard reload for 'early' (mid-break escape — fresh session gets new ad-decision bucket).
+            // Soft reload for 'post-ad' (smooth transition, no black screen teardown).
+            const hardReload = reloadKind === 'early';
+            console.log('Reloading Twitch player' + (hardReload ? ' (hard)' : ' (soft)'));
+            playerState.setSrc({ isNewMediaPlayerInstance: hardReload, refreshAccessToken: hardReload });
             postTwitchWorkerMessage('TriggeredPlayerReload');
             player.play()?.catch?.(() => {});
             // Always restore muted/volume state after reload — Chrome autoplay policy can force muted


### PR DESCRIPTION
## Summary
PR #145 was marked "merged" in GitHub because its base branch (`fix/thin-cache-reload-budget`) accepted it, but PR #134's squash merge to master only squashed #134's commits — #145's additional commits on top were orphaned on the deleted branch.

This re-applies #145's changes directly to master. Code is identical to the original PR #145.

## Why this matters
PR #134's thin-cache budget fix is **incomplete without this**. With #134 alone:
- Multiple early reloads now fire (budget fix works)
- But each reload uses soft reload (cached access token = same session)
- All N reloads land in the same ad-decision bucket → none escape SSAI-heavy breaks

With this PR:
- Early reloads (mid-break escape) use hard reload → fresh session each time
- Post-ad reload stays soft → smooth transition (no regression for common case)

## Change
Same as the original #145:
```js
// Worker → main ReloadPlayer messages from early-reload sites
postMessage({ key: 'ReloadPlayer', kind: 'early' });

// Main thread handler picks setSrc params based on kind
function doTwitchPlayerTask(isPausePlay, isReload, reloadKind) {
    // ...
    const hardReload = reloadKind === 'early';
    playerState.setSrc({ isNewMediaPlayerInstance: hardReload, refreshAccessToken: hardReload });
}
```

## Scope
- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- Testing files already have this (from commit `a9942d1`)

## Test plan
- [ ] SSAI-heavy break → `[1/8] ... (hard) → [2/8] ... (hard)` sequence in logs
- [ ] Normal midroll → post-ad reload still soft, no black screen