### PR TITLE
vaft: reset EarlyReloadTriggered on normal-path 'still ads' log

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1093,6 +1093,7 @@ twitch-videoad.js text/javascript
                     streamInfo.EarlyReloadTriggered = false;
                 } else {
                     console.log('[AD DEBUG] Early reload result: still ads — continuing recovery loop');
+                    streamInfo.EarlyReloadTriggered = false;
                 }
             }
             // Early reload during prolonged freeze: if we've been looping recovery segments

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1117,6 +1117,7 @@
                     streamInfo.EarlyReloadTriggered = false;
                 } else {
                     console.log('[AD DEBUG] Early reload result: still ads — continuing recovery loop');
+                    streamInfo.EarlyReloadTriggered = false;
                 }
             }
             // Early reload during prolonged freeze: if we've been looping recovery segments


### PR DESCRIPTION
## Summary
One-line fix: reset `streamInfo.EarlyReloadTriggered = false` after the "Early reload result: still ads" log in the normal path.

## Why
The sticky CSAI path already has this reset (line 895). The normal path (mixed CSAI/SSAI, or non-CSAI-confirmed channels) is missing it.

Without it, when the normal-path early reload fires and lands back in ads:
- `EarlyReloadTriggered` stays `true` forever
- The budget check `(EarlyReloadCount || 0) < maxEarlyReloads` would pass…
- …but `!EarlyReloadTriggered` blocks the second reload
- The increased budget (up to 8 for PodLength=8) is effectively dead code on the normal path

This was originally part of PR #134 but got dropped by the squash merge. Only 2 of #134's 3 commits landed in master; this one was orphaned.

## Change
```diff
 } else {
     console.log('[AD DEBUG] Early reload result: still ads — continuing recovery loop');
+    streamInfo.EarlyReloadTriggered = false;
 }
```

Both release files. Testing already has this.

## Scope
- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`

## Test plan
- [ ] Mixed CSAI/SSAI break that hits normal path → see `[1/N]` then `[2/N]` etc. on subsequent polls
- [ ] Pure CSAI break (sticky path) → unchanged