### PR TITLE
vaft: use hard reload for post-ad reload when strip/modify occurred

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1182,7 +1182,8 @@ twitch-videoad.js text/javascript
                     streamInfo.IsUsingModifiedM3U8 = false;
                     streamInfo.LastPlayerReload = Date.now();
                     postMessage({
-                        key: 'ReloadPlayer'
+                        key: 'ReloadPlayer',
+                        kind: 'early'
                     });
                 } else {
                     if (tooSoonSinceLastReload) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1205,8 +1205,13 @@
                     streamInfo.ReloadTimestamps.push(Date.now());
                     streamInfo.IsUsingModifiedM3U8 = false;
                     streamInfo.LastPlayerReload = Date.now();
+                    // Hard reload when buffer may be dirty from strip or m3u8 modification —
+                    // soft reload preserves the existing MediaSource buffer, and any
+                    // timestamp weirdness from strip/BLANK_MP4/recovery injection persists
+                    // across it, causing audio/video desync over time.
                     postMessage({
-                        key: 'ReloadPlayer'
+                        key: 'ReloadPlayer',
+                        kind: 'early'
                     });
                 } else {
                     if (tooSoonSinceLastReload) {


### PR DESCRIPTION
## Summary
Fix reported audio/video desync by using hard reload at the post-ad site when the buffer may be dirty (strip or modify happened).

## Why
PR #144 switched all reloads to soft reload (`isNewMediaPlayerInstance: false, refreshAccessToken: false`) to eliminate the ~1-3s black screen on post-ad transitions. The smoothness win was real — but soft reload preserves the existing MediaSource buffer.

When an ad break involved real strip activity (`BLANK_MP4` injection for ad segments, recovery segment replay, `IsUsingModifiedM3U8`), timestamp weirdness from those operations accumulates in the buffer. Soft reload keeps that dirty buffer, and over time audio and video drift out of sync.

User report: "vaft user is going out of sync, audio not matching video."

## Change
```diff
 if (shouldReload) {
     streamInfo.ReloadTimestamps.push(Date.now());
     streamInfo.IsUsingModifiedM3U8 = false;
     streamInfo.LastPlayerReload = Date.now();
     postMessage({
-        key: 'ReloadPlayer'
+        key: 'ReloadPlayer',
+        kind: 'early'
     });
 }
```

The `'early'` kind triggers hard reload (new MediaSource, fresh access token) via PR #146's routing logic. Clean slate guarantees no residual buffer desync.

## Scope
- **Post-ad reload site (`shouldReload` condition at line 1203)** → hard reload
  - Fires when `IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments)`
  - Both imply buffer modification → dirty buffer → hard reload
- Early reload sites (mid-break escape) → hard reload (unchanged, PR #146)
- HEVC force reload (line ~869) → **soft reload (unchanged)** — codec change, no strip involved

## Tradeoff
Reverts PR #144's smoothness gain for the common post-ad case. Users get back the ~1-3s black screen on every post-ad reload. But:
- Normal 30s midrolls with real strips: unavoidable (dirty buffer must be flushed)
- Pure CSAI breaks with 0 strips: `shouldReload` is false, no reload fires at all
- The only path that still uses soft reload is HEVC force (rare legacy path)

Net: audio/video reliability > transition smoothness.

## Scope
- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- Testing files already patched

## Test plan
- [ ] Normal midroll with strip → post-ad reload shows `(hard)` in log, no desync after multiple breaks
- [ ] User's reproduction → no audio/video drift over 30+ minutes