### PR TITLE
vaft: match sticky path's thin-cache early-reload budget on normal path

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1117,8 +1117,8 @@ twitch-videoad.js text/javascript
             // Early reload during prolonged freeze: if we've been looping recovery segments
             // for N+ polls (~Nx2s), trigger a reload to attempt fresh content. Bounded to one
             // reload per ad in the pod (e.g. 2-ad pod = up to 2 early reloads).
-            const maxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
             const recoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
+            const maxEarlyReloads = recoveryThin ? Math.max(2, streamInfo.PodLength || 1) : Math.max(1, streamInfo.PodLength || 1);
             const effectiveThreshold = recoveryThin ? 1 : EarlyReloadPollThreshold;
             if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= effectiveThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < maxEarlyReloads) {
                 streamInfo.EarlyReloadTriggered = true;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1149,8 +1149,8 @@
             // Early reload during prolonged freeze: if we've been looping recovery segments
             // for N+ polls (~Nx2s), trigger a reload to attempt fresh content. Bounded to one
             // reload per ad in the pod (e.g. 2-ad pod = up to 2 early reloads).
-            const maxEarlyReloads = Math.max(1, streamInfo.PodLength || 1);
             const recoveryThin = (streamInfo.RecoverySegments?.length || 0) < 3;
+            const maxEarlyReloads = recoveryThin ? Math.max(2, streamInfo.PodLength || 1) : Math.max(1, streamInfo.PodLength || 1);
             const effectiveThreshold = recoveryThin ? 1 : EarlyReloadPollThreshold;
             if (EarlyReloadPollThreshold > 0 && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= effectiveThreshold && !streamInfo.EarlyReloadTriggered && (streamInfo.EarlyReloadCount || 0) < maxEarlyReloads) {
                 streamInfo.EarlyReloadTriggered = true;


### PR DESCRIPTION
## Summary

- Asymmetric early-reload budgets between sticky CSAI path and normal backup-search path in vaft. PR #134 bumped the sticky path's budget to `max(2, PodLength)` when the recovery cache has <3 segments, but the normal path was left at `max(1, PodLength)` even though it shared the same 1-poll thin-cache threshold.
- Apply the same `recoveryThin ? max(2, PodLength) : max(1, PodLength)` formula to the normal path. Matches the rationale from PR #134: when the cache is near-empty, one reload isn't enough — if it lands back in ads, there's nothing left to serve.
- Testing files (`vaft_testing.user.js`, `vaft-testing-ublock-origin.js`) already had this formula. This PR brings the release scripts in line.

## Why this matters

Users on SSAI-heavy channels with prerolls (common case for the thin-cache fast path) were getting a single reload in the normal path vs two in the sticky path, meaning the "thin-cache fast path" wasn't fully effective when the sticky CSAI gate hadn't been triggered. One misdirected reload would exhaust the budget.

## Test plan

- [ ] Normal path, thin cache (<3 recovery segments), reload lands back in ads → verify a second reload fires (previously stuck after first)
- [ ] Normal path, fat cache → verify budget stays at `max(1, PodLength)` (unchanged)
- [ ] Sticky path behavior unchanged (PR #134 logic preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)