### PR TITLE
narrow AdSignifiers to 4 to reduce post-ad residual false positives

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -34,7 +34,7 @@ twitch-videoad.js text/javascript
     window.twitchAdSolutionsVersion = ourTwitchAdSolutionsVersion;
     // Configuration and state shared between window and worker scopes
     function declareOptions(scope) {
-        scope.AdSignifiers = ['stitched-ad', 'X-TV-TWITCH-AD', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-stream-source"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-ad-quartile"', 'SCTE35-OUT'];
+        scope.AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
         scope.AdSegmentURLPatterns = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -44,7 +44,7 @@
     window.twitchAdSolutionsVersion = ourTwitchAdSolutionsVersion;
     // Configuration and state shared between window and worker scopes
     function declareOptions(scope) {
-        scope.AdSignifiers = ['stitched-ad', 'X-TV-TWITCH-AD', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-stream-source"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-ad-quartile"', 'SCTE35-OUT'];
+        scope.AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
         scope.AdSegmentURLPatterns = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -35,7 +35,7 @@ twitch-videoad.js text/javascript
         // Options / globals
         scope.OPT_BACKUP_PLAYER_TYPES = [ 'embed', 'popout', 'mobile_web' ];
         scope.OPT_FORCE_ACCESS_TOKEN_PLAYER_TYPE = 'popout';
-        scope.AD_SIGNIFIERS = ['stitched-ad', 'X-TV-TWITCH-AD', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-stream-source"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-ad-quartile"', 'SCTE35-OUT'];
+        scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
         scope.AD_SEGMENT_URL_PATTERNS = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -46,7 +46,7 @@
         // Options / globals
         scope.OPT_BACKUP_PLAYER_TYPES = [ 'embed', 'popout', 'mobile_web' ];
         scope.OPT_FORCE_ACCESS_TOKEN_PLAYER_TYPE = 'popout';
-        scope.AD_SIGNIFIERS = ['stitched-ad', 'X-TV-TWITCH-AD', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-stream-source"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-ad-quartile"', 'SCTE35-OUT'];
+        scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
         scope.AD_SEGMENT_URL_PATTERNS = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals


### PR DESCRIPTION
## Summary

Narrow the ad-marker detection list from 9 signifiers to 4 on both vaft and video-swap-new, dropping markers known (per TTV-AB's own CHANGELOG) to linger in the playlist after the actual ad ends. Residual markers were causing false re-entry into ad-blocking state on natural post-ad polls.

TTV-AB narrowed their own primary detection to just \`\"stitched\"\` + explicit ad-URL patterns after diagnosing this exact issue. This PR follows the same direction but keeps a few well-scoped ad-start markers for robustness.

## Dropped (residual-prone / ambiguous)

- \`X-TV-TWITCH-AD\` — known to linger as residual metadata after ad-end
- \`SCTE35-OUT\` — known to linger
- \`EXT-X-DATERANGE:CLASS=\"twitch-stream-source\"\` — ambiguous; \"stream-source\" isn't ad-specific
- \`EXT-X-DATERANGE:CLASS=\"twitch-trigger\"\` — trigger markers aren't ad-specific
- \`EXT-X-DATERANGE:CLASS=\"twitch-ad-quartile\"\` — quartile tracking pixels persist past ad end

## Kept (ad-start signals)

- \`stitched-ad\` — primary, matches TTV-AB's \`\"stitched\"\` substring
- \`EXT-X-CUE-OUT\` — SCTE ad-break start marker (start signal, not residual)
- \`EXT-X-DATERANGE:CLASS=\"twitch-stitched-ad\"\` — explicit ad class
- \`EXT-X-DATERANGE:CLASS=\"twitch-maf-ad\"\` — explicit MAF ad class

URL-pattern detection (\`AdSegmentURLPatterns\` / \`AD_SEGMENT_URL_PATTERNS\`) is **unchanged** — it remains the backup signal for known-ad segments.

## Scope

Release: vaft (\`vaft.user.js\`, \`vaft-ublock-origin.js\`) + video-swap-new (\`video-swap-new.user.js\`, \`video-swap-new-ublock-origin.js\`).
Testing variants already landed as direct commit 7aa466d.

## Test plan

- [ ] Normal CSAI ad break still detected (at least one of the kept markers fires on ad-start playlists)
- [ ] After ad-end reload, playlist with residual \`X-TV-TWITCH-AD\` or \`SCTE35-OUT\` tags no longer re-triggers ad detection
- [ ] Pure-URL-pattern ads (\`/adsquared/\`, \`/_404/\`, \`/processing\`) still detected via \`AdSegmentURLPatterns\`
- [ ] \`[AD DEBUG] Ad detected — ... signifiers: ...\` log shows narrower set of matched markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)