### PR TITLE
log potential ad markers not in AdSignifiers (diagnostic)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -148,6 +148,7 @@ twitch-videoad.js text/javascript
             ReloadTimestamps: [],
             HasCheckedUnknownTags: false,
             HasLoggedAdAttributes: false,
+            HasLoggedUnknownSignifiers: false,
         };
     }
     function maskAsNative(fn, name) {
@@ -569,6 +570,24 @@ twitch-videoad.js text/javascript
             if (adAttrs && adAttrs.length > 0) {
                 streamInfo.HasLoggedAdAttributes = true;
                 console.log('[AD DEBUG] Ad tracking attributes seen: ' + [...new Set(adAttrs)].join(', '));
+            }
+        }
+        // Log potential ad markers that aren't in AdSignifiers (candidates for future inclusion)
+        if (!streamInfo.HasLoggedUnknownSignifiers) {
+            const candidates = new Set();
+            let sm;
+            const classRe = /EXT-X-DATERANGE:[^\n]*CLASS="(twitch-[^"]+)"/g;
+            while ((sm = classRe.exec(textStr)) !== null) {
+                candidates.add('EXT-X-DATERANGE:CLASS="' + sm[1] + '"');
+            }
+            const tagRe = /(SCTE35-[A-Z-]+|EXT-X-CUE-[A-Z-]+)/g;
+            while ((sm = tagRe.exec(textStr)) !== null) {
+                candidates.add(sm[1]);
+            }
+            const unknown = [...candidates].filter(c => !AdSignifiers.includes(c));
+            if (unknown.length > 0) {
+                streamInfo.HasLoggedUnknownSignifiers = true;
+                console.log('[AD DEBUG] Potential ad markers seen but not in AdSignifiers: ' + unknown.join(', ') + ' (candidates for future inclusion)');
             }
         }
         for (let i = 0; i < lines.length; i++) {
@@ -1173,6 +1192,7 @@ twitch-videoad.js text/javascript
                 streamInfo.CsaiOnlyThisBreak = false;
                 streamInfo.EscapeHatchFired = false;
                 streamInfo.HasLoggedAdAttributes = false;
+                streamInfo.HasLoggedUnknownSignifiers = false;
                 // CSAI-only ad break: no segments were stripped — skip reload entirely.
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -172,6 +172,7 @@
             // Diagnostic flags (once-per-session)
             HasCheckedUnknownTags: false,
             HasLoggedAdAttributes: false,
+            HasLoggedUnknownSignifiers: false,
         };
     }
     function maskAsNative(fn, name) {
@@ -593,6 +594,24 @@
             if (adAttrs && adAttrs.length > 0) {
                 streamInfo.HasLoggedAdAttributes = true;
                 console.log('[AD DEBUG] Ad tracking attributes seen: ' + [...new Set(adAttrs)].join(', '));
+            }
+        }
+        // Log potential ad markers that aren't in AdSignifiers (candidates for future inclusion)
+        if (!streamInfo.HasLoggedUnknownSignifiers) {
+            const candidates = new Set();
+            let sm;
+            const classRe = /EXT-X-DATERANGE:[^\n]*CLASS="(twitch-[^"]+)"/g;
+            while ((sm = classRe.exec(textStr)) !== null) {
+                candidates.add('EXT-X-DATERANGE:CLASS="' + sm[1] + '"');
+            }
+            const tagRe = /(SCTE35-[A-Z-]+|EXT-X-CUE-[A-Z-]+)/g;
+            while ((sm = tagRe.exec(textStr)) !== null) {
+                candidates.add(sm[1]);
+            }
+            const unknown = [...candidates].filter(c => !AdSignifiers.includes(c));
+            if (unknown.length > 0) {
+                streamInfo.HasLoggedUnknownSignifiers = true;
+                console.log('[AD DEBUG] Potential ad markers seen but not in AdSignifiers: ' + unknown.join(', ') + ' (candidates for future inclusion)');
             }
         }
         for (let i = 0; i < lines.length; i++) {
@@ -1205,6 +1224,7 @@
                 streamInfo.CsaiOnlyThisBreak = false;
                 streamInfo.EscapeHatchFired = false;
                 streamInfo.HasLoggedAdAttributes = false;
+                streamInfo.HasLoggedUnknownSignifiers = false;
                 // CSAI-only ad break: no segments were stripped — skip reload entirely.
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -77,6 +77,7 @@ twitch-videoad.js text/javascript
             HasCheckedUnknownTags: false,
             HasConfirmedAdAttrs: false,
             HasLoggedAdAttributes: false,
+            HasLoggedUnknownSignifiers: false,
             IsMovingOffBackupEncodings: false,
             IsMidroll: false,
             IsStrippingAdSegments: false,
@@ -507,6 +508,24 @@ twitch-videoad.js text/javascript
                 console.log('[AD DEBUG] Ad tracking attributes seen: ' + [...new Set(adAttrs)].join(', '));
             }
         }
+        // Log potential ad markers that aren't in AD_SIGNIFIERS (candidates for future inclusion)
+        if (!streamInfo.HasLoggedUnknownSignifiers) {
+            const candidates = new Set();
+            let sm;
+            const classRe = /EXT-X-DATERANGE:[^\n]*CLASS="(twitch-[^"]+)"/g;
+            while ((sm = classRe.exec(textStr)) !== null) {
+                candidates.add('EXT-X-DATERANGE:CLASS="' + sm[1] + '"');
+            }
+            const tagRe = /(SCTE35-[A-Z-]+|EXT-X-CUE-[A-Z-]+)/g;
+            while ((sm = tagRe.exec(textStr)) !== null) {
+                candidates.add(sm[1]);
+            }
+            const unknown = [...candidates].filter(c => !AD_SIGNIFIERS.includes(c));
+            if (unknown.length > 0) {
+                streamInfo.HasLoggedUnknownSignifiers = true;
+                console.log('[AD DEBUG] Potential ad markers seen but not in AD_SIGNIFIERS: ' + unknown.join(', ') + ' (candidates for future inclusion)');
+            }
+        }
         for (let i = 0; i < lines.length; i++) {
             let line = lines[i];
             // Track SCTE-35 CUE-OUT/CUE-IN ad boundaries
@@ -720,6 +739,7 @@ twitch-videoad.js text/javascript
                             streamInfo.HasConfirmedAdAttrs = false;
                             streamInfo.HasLoggedCsaiFastPath = false;
                             streamInfo.HasLoggedAdAttributes = false;
+                            streamInfo.HasLoggedUnknownSignifiers = false;
                             streamInfo.RequestedAds.clear();
                             streamInfo.ConsecutiveAllStrippedPolls = 0;
                             streamInfo.EarlyReloadTriggered = false;

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -88,6 +88,7 @@
             HasCheckedUnknownTags: false,
             HasConfirmedAdAttrs: false,
             HasLoggedAdAttributes: false,
+            HasLoggedUnknownSignifiers: false,
             IsMovingOffBackupEncodings: false,
             IsMidroll: false,
             IsStrippingAdSegments: false,
@@ -519,6 +520,24 @@
                 console.log('[AD DEBUG] Ad tracking attributes seen: ' + [...new Set(adAttrs)].join(', '));
             }
         }
+        // Log potential ad markers that aren't in AD_SIGNIFIERS (candidates for future inclusion)
+        if (!streamInfo.HasLoggedUnknownSignifiers) {
+            const candidates = new Set();
+            let sm;
+            const classRe = /EXT-X-DATERANGE:[^\n]*CLASS="(twitch-[^"]+)"/g;
+            while ((sm = classRe.exec(textStr)) !== null) {
+                candidates.add('EXT-X-DATERANGE:CLASS="' + sm[1] + '"');
+            }
+            const tagRe = /(SCTE35-[A-Z-]+|EXT-X-CUE-[A-Z-]+)/g;
+            while ((sm = tagRe.exec(textStr)) !== null) {
+                candidates.add(sm[1]);
+            }
+            const unknown = [...candidates].filter(c => !AD_SIGNIFIERS.includes(c));
+            if (unknown.length > 0) {
+                streamInfo.HasLoggedUnknownSignifiers = true;
+                console.log('[AD DEBUG] Potential ad markers seen but not in AD_SIGNIFIERS: ' + unknown.join(', ') + ' (candidates for future inclusion)');
+            }
+        }
         for (let i = 0; i < lines.length; i++) {
             let line = lines[i];
             // Track SCTE-35 CUE-OUT/CUE-IN ad boundaries
@@ -734,6 +753,7 @@
                             streamInfo.HasConfirmedAdAttrs = false;
                             streamInfo.HasLoggedCsaiFastPath = false;
                             streamInfo.HasLoggedAdAttributes = false;
+                            streamInfo.HasLoggedUnknownSignifiers = false;
                             streamInfo.RequestedAds.clear();
                             streamInfo.ConsecutiveAllStrippedPolls = 0;
                             streamInfo.EarlyReloadTriggered = false;


### PR DESCRIPTION
## Summary

Diagnostic-only change. Scans the playlist during ad-break processing for ad-marker-shaped tokens that aren't currently in `AdSignifiers` / `AD_SIGNIFIERS`, logging them once per break as candidates for future inclusion.

Scan patterns:
- `EXT-X-DATERANGE:CLASS="twitch-*"` classes
- `SCTE35-*` tags
- `EXT-X-CUE-*` tags

Output:
```
[AD DEBUG] Potential ad markers seen but not in AdSignifiers: EXT-X-DATERANGE:CLASS="twitch-session", EXT-X-DATERANGE:CLASS="twitch-assignment" (candidates for future inclusion)
```

Tracked via `HasLoggedUnknownSignifiers` flag on streamInfo, mirroring the existing `HasLoggedAdAttributes` once-per-break pattern (reset at end-of-break).

## Why

After PR #152 narrowed the signifier list from 9 to 4, we wanted a way to see what *else* is in the playlist during an ad break — both to confirm the narrowing was safe (removed markers shouldn't be needed) and to catch any new markers Twitch might introduce.

Testing variant (commit `890363d`) landed first and surfaced 5 candidates on a real session:
- `twitch-stream-source`, `twitch-trigger`, `twitch-ad-quartile` (all removed in #152 — confirmed still present in playlist but not needed for detection; `stitched-ad` alone fired)
- `twitch-session`, `twitch-assignment` (new — look like session/pod metadata, not ad-start markers)

## Scope

- `vaft.user.js` + `vaft-ublock-origin.js`
- `video-swap-new.user.js` + `video-swap-new-ublock-origin.js`

Testing variants already landed as `890363d`.

## Test plan

- [ ] Confirm log fires once per ad break when unknown markers are present
- [ ] Confirm log does NOT fire if every marker in the playlist is already in AdSignifiers
- [ ] Confirm flag resets cleanly at end-of-break so next break logs again
- [ ] No behavioral change — detection and strip logic unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)