### PR TITLE
always run post-reload recovery (unmute fix)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1782,8 +1782,10 @@ twitch-videoad.js text/javascript
             playerState.setSrc({ isNewMediaPlayerInstance: hardReload, refreshAccessToken: hardReload });
             postTwitchWorkerMessage('TriggeredPlayerReload');
             player.play()?.catch?.(() => {});
-            // Always restore muted/volume state after reload — Chrome autoplay policy can force muted
-            if (currentQualityLS || currentMutedLS || currentVolumeLS) {
+            // Always restore muted/volume state after reload — Chrome autoplay policy can force muted.
+            // Block must always run: if Twitch hasn't written LS values yet (fresh session, private mode,
+            // cleared cache), the video still needs unmute after Chrome's autoplay mute on reload.
+            {
                 setTimeout(() => {
                     try {
                         if (currentQualityLS) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1818,8 +1818,10 @@
             playerState.setSrc({ isNewMediaPlayerInstance: hardReload, refreshAccessToken: hardReload });
             postTwitchWorkerMessage('TriggeredPlayerReload');
             player.play()?.catch?.(() => {});
-            // Always restore muted/volume state after reload — Chrome autoplay policy can force muted
-            if (currentQualityLS || currentMutedLS || currentVolumeLS) {
+            // Always restore muted/volume state after reload — Chrome autoplay policy can force muted.
+            // Block must always run: if Twitch hasn't written LS values yet (fresh session, private mode,
+            // cleared cache), the video still needs unmute after Chrome's autoplay mute on reload.
+            {
                 setTimeout(() => {
                     try {
                         if (currentQualityLS) {

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -1258,8 +1258,10 @@ twitch-videoad.js text/javascript
         } catch {}
         playerState.setSrc({ isNewMediaPlayerInstance: true, refreshAccessToken: true });
         player.play()?.catch?.(() => {});
-        // Always restore muted/volume state after reload — Chrome autoplay policy can force muted
-        if (currentQualityLS || currentMutedLS || currentVolumeLS) {
+        // Always restore muted/volume state after reload — Chrome autoplay policy can force muted.
+        // Block must always run: if Twitch hasn't written LS values yet (fresh session, private mode,
+        // cleared cache), the video still needs unmute after Chrome's autoplay mute on reload.
+        {
             setTimeout(() => {
                 try {
                     if (currentQualityLS) {

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -1274,8 +1274,10 @@
         } catch {}
         playerState.setSrc({ isNewMediaPlayerInstance: true, refreshAccessToken: true });
         player.play()?.catch?.(() => {});
-        // Always restore muted/volume state after reload — Chrome autoplay policy can force muted
-        if (currentQualityLS || currentMutedLS || currentVolumeLS) {
+        // Always restore muted/volume state after reload — Chrome autoplay policy can force muted.
+        // Block must always run: if Twitch hasn't written LS values yet (fresh session, private mode,
+        // cleared cache), the video still needs unmute after Chrome's autoplay mute on reload.
+        {
             setTimeout(() => {
                 try {
                     if (currentQualityLS) {


### PR DESCRIPTION
## Summary

The post-reload recovery block (LS restore + unmute + drift correction) was gated on `currentQualityLS || currentMutedLS || currentVolumeLS`. If Twitch hadn't written any of those to localStorage at reload time — fresh session, private mode, or recently-cleared cache — the entire `setTimeout` skipped, including the Chrome-autoplay unmute line:

```js
if (videos.length > 0 && videos[0].muted) {
    videos[0].muted = false;
}
```

Reported symptom: video plays post-reload but the track stays muted, with no way to recover short of a manual page reload.

## Fix

Remove the outer guard so the `setTimeout` always runs. Individual LS restores stay guarded (inside the callback) so we don't write `null` back to localStorage.

Before:
```js
if (currentQualityLS || currentMutedLS || currentVolumeLS) {
    setTimeout(() => { ... }, 3000);
}
```

After:
```js
{
    setTimeout(() => { ... }, 3000);
}
```

(Bare block preserves matched braces for minimal diff; could also be a plain unwrapped `setTimeout(...)`.)

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js` + `video-swap-new/video-swap-new-ublock-origin.js`

Testing variants landed as commit `0803654`.

## Test plan

- [ ] In a browser session where localStorage lacks `video-quality`/`video-muted`/`volume` (e.g. fresh private window), trigger an ad break that causes a hard reload
- [ ] Verify video playback resumes **unmuted** after the reload
- [ ] Verify with LS populated (normal case), behavior is unchanged — LS values are restored as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)