### PR TITLE
respect user mute intent in post-reload unmute

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1796,7 +1796,11 @@ twitch-videoad.js text/javascript
                             localStorage.setItem(lsKeyVolume, currentVolumeLS);
                         }
                         const videos = document.getElementsByTagName('video');
-                        if (videos.length > 0 && videos[0].muted) {
+                        // Respect user's mute intent: only force-unmute if LS didn't say mute.
+                        // Twitch writes video-muted as '{"default":true}' when user muted via UI;
+                        // Chrome autoplay policy can mute even if user didn't (no LS signal).
+                        const userIntendedMute = currentMutedLS && currentMutedLS.includes('"default":true');
+                        if (videos.length > 0 && videos[0].muted && !userIntendedMute) {
                             videos[0].muted = false;
                         }
                         // Correct live drift after reload

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1832,7 +1832,11 @@
                             localStorage.setItem(lsKeyVolume, currentVolumeLS);
                         }
                         const videos = document.getElementsByTagName('video');
-                        if (videos.length > 0 && videos[0].muted) {
+                        // Respect user's mute intent: only force-unmute if LS didn't say mute.
+                        // Twitch writes video-muted as '{"default":true}' when user muted via UI;
+                        // Chrome autoplay policy can mute even if user didn't (no LS signal).
+                        const userIntendedMute = currentMutedLS && currentMutedLS.includes('"default":true');
+                        if (videos.length > 0 && videos[0].muted && !userIntendedMute) {
                             videos[0].muted = false;
                         }
                         // Correct live drift after reload

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -1272,7 +1272,11 @@ twitch-videoad.js text/javascript
                         localStorage.setItem(lsKeyVolume, currentVolumeLS);
                     }
                     const videos = document.getElementsByTagName('video');
-                    if (videos.length > 0 && videos[0].muted) {
+                    // Respect user's mute intent: only force-unmute if LS didn't say mute.
+                    // Twitch writes video-muted as '{"default":true}' when user muted via UI;
+                    // Chrome autoplay policy can mute even if user didn't (no LS signal).
+                    const userIntendedMute = currentMutedLS && currentMutedLS.includes('"default":true');
+                    if (videos.length > 0 && videos[0].muted && !userIntendedMute) {
                         videos[0].muted = false;
                     }
                 } catch {}

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -1288,7 +1288,11 @@
                         localStorage.setItem(lsKeyVolume, currentVolumeLS);
                     }
                     const videos = document.getElementsByTagName('video');
-                    if (videos.length > 0 && videos[0].muted) {
+                    // Respect user's mute intent: only force-unmute if LS didn't say mute.
+                    // Twitch writes video-muted as '{"default":true}' when user muted via UI;
+                    // Chrome autoplay policy can mute even if user didn't (no LS signal).
+                    const userIntendedMute = currentMutedLS && currentMutedLS.includes('"default":true');
+                    if (videos.length > 0 && videos[0].muted && !userIntendedMute) {
                         videos[0].muted = false;
                     }
                 } catch {}


### PR DESCRIPTION
## Summary

Follow-up to PR #155 (always run post-reload recovery).

The existing post-reload unmute is unconditional:

```js
if (videos.length > 0 && videos[0].muted) {
    videos[0].muted = false;
}
```

If a user intentionally muted the stream before an ad break, a reload would force-unmute them — overriding their clear intent. This PR fixes that by checking `currentMutedLS` for Twitch's `'{"default":true}'` marker (written when the user manually mutes via the UI).

## Behavior

Fix:
```js
const userIntendedMute = currentMutedLS && currentMutedLS.includes('"default":true');
if (videos.length > 0 && videos[0].muted && !userIntendedMute) {
    videos[0].muted = false;
}
```

| Scenario | LS `video-muted` | userIntendedMute | Action |
|---|---|---|---|
| User manually muted via Twitch UI | `{"default":true}` | `true` | **Leave muted** (respect intent) |
| User unmuted / never touched | `{"default":false}` or unset | `false` | Unmute (clear Chrome autoplay mute) |
| Fresh session, no LS at all | `null` | `false` | Unmute (fallback path for autoplay policy) |

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js` + `video-swap-new/video-swap-new-ublock-origin.js`

Testing variants landed as commit `b4095c6`.

## Test plan

- [ ] Manually mute the stream via Twitch's mute button, trigger an ad break with hard reload, verify stream **stays muted** post-reload
- [ ] With stream unmuted, trigger an ad break, verify unmute logic still fires if Chrome's autoplay policy muted playback
- [ ] Fresh private window (no LS), trigger an ad break, verify unmute fires (covers the PR #155 edge case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)