### PR TITLE
lower sticky CSAI escape hatch threshold from 6 to 4 polls

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -876,8 +876,8 @@ twitch-videoad.js text/javascript
             // the whole CSAI break saves ~20 wasted fetches per break — the backup wouldn't
             // help anyway since every player type has the same CSAI ads. Flag is cleared
             // only at break end (IsShowingAd=false path).
-            // Sticky CSAI escape hatch (PreferLowQualityBackup): after ~12s stuck, fall through to backup search.
-            if (PreferLowQualityBackup && streamInfo.CsaiOnlyThisBreak && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= 6) {
+            // Sticky CSAI escape hatch (PreferLowQualityBackup): after ~8s stuck, fall through to backup search.
+            if (PreferLowQualityBackup && streamInfo.CsaiOnlyThisBreak && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= 4) {
                 const stuckPolls = streamInfo.ConsecutiveAllStrippedPolls;
                 const recoveryCacheSize = streamInfo.RecoverySegments?.length || 0;
                 const earlyReloadInfo = (streamInfo.EarlyReloadCount || 0) + '/' + Math.max(1, streamInfo.PodLength || 1);

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -901,10 +901,10 @@
             // help anyway since every player type has the same CSAI ads. Flag is cleared
             // only at break end (IsShowingAd=false path).
             // Sticky CSAI escape hatch (PreferLowQualityBackup): if the sticky path has
-            // been stuck in all-stripped state for too long (~12s), fall through to backup
+            // been stuck in all-stripped state for too long (~8s), fall through to backup
             // search. Gives heavy-SSAI channels a way out of the sticky freeze by trying
             // Source backups + autoplay fallback instead of sitting in recovery loop.
-            if (PreferLowQualityBackup && streamInfo.CsaiOnlyThisBreak && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= 6) {
+            if (PreferLowQualityBackup && streamInfo.CsaiOnlyThisBreak && (streamInfo.ConsecutiveAllStrippedPolls || 0) >= 4) {
                 const stuckPolls = streamInfo.ConsecutiveAllStrippedPolls;
                 const recoveryCacheSize = streamInfo.RecoverySegments?.length || 0;
                 const earlyReloadInfo = (streamInfo.EarlyReloadCount || 0) + '/' + Math.max(1, streamInfo.PodLength || 1);


### PR DESCRIPTION
## Summary

Lower the `PreferLowQualityBackup` sticky CSAI escape hatch threshold from **6 polls (~12s)** to **4 polls (~8s)** of all-stripped state.

## Why

Field logs on `aspen` and `winton_ow2` showed a repeated 2-ad heavy-SSAI freeze pattern:

| Poll | Event |
|---|---|
| 1 | Early reload 1/2 fires (hard) → lands in ads |
| 2 | Early reload 2/2 fires (hard) → lands in ads |
| 3 | Budget exhausted, all-stripped |
| 4 | All-stripped |
| 5 | All-stripped, break ends naturally |

Current threshold `>= 6` means the escape hatch never gets a chance on these breaks — they end naturally before poll 6. With `PreferLowQualityBackup=true` the user pays the same ~35s freeze as with the flag off, defeating the purpose of the opt-in safety net.

At poll 4, the early-reload budget is already fully spent (`EarlyReloadCount = maxEarlyReloads`) and the recovery loop has produced nothing useful — a clear signal that in-session retry is not going to work. Falling through to the backup search (Source types + autoplay last-resort) is the right call.

## Risk

Low. The escape hatch is opt-in (`twitchAdSolutions_preferLowQualityBackup=true`, default off). Users on the default path see no change. For users who have opted in, this means the safety net actually fires on the common heavy-SSAI break instead of timing out past natural break end.

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js` (escape hatch only exists in vaft)
- Testing variants landed as commit `40a0e99`

## Test plan

- [ ] With `twitchAdSolutions_preferLowQualityBackup=true`, trigger a 2-ad heavy-SSAI break (e.g. `winton_ow2` or `aspen`)
- [ ] Verify `[AD DEBUG] Sticky CSAI escape hatch — stuck 4 polls (~8s), ...` fires around poll 4
- [ ] Verify `[AD DEBUG] Post-escape backup: <type> (Source/360p) — recovered from sticky-path freeze` follows
- [ ] With the flag off (default), verify no behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)