### PR TITLE
flip PreferLowQualityBackup default to true

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ All read at init, injected into worker blob:
 - `twitchAdSolutions_disableReloadCap` — `true` to revert to unlimited reloads
 - `twitchAdSolutions_driftCorrectionRate` — number, default `1.1` (0 to disable)
 - `twitchAdSolutions_earlyReloadPollThreshold` — number, default `5` (0 to disable; thin cache overrides to 1)
-- `twitchAdSolutions_preferLowQualityBackup` — `true` for hybrid mode (sticky escape hatch + autoplay last-resort backup), default `false` (vaft only)
+- `twitchAdSolutions_preferLowQualityBackup` — hybrid mode (sticky escape hatch + autoplay last-resort backup), default `true`; set to `false` to disable (vaft only)
 
 ## CSAI vs SSAI
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ The scripts support runtime configuration via `localStorage`. Set values in the 
 - Not set - buffer monitor reloads at most once per recovery window (default)
 - Only enable if you're seeing genuinely stuck playback that a single reload doesn't fix
 
-**`twitchAdSolutions_preferLowQualityBackup`** (default: `false`, vaft only)
-- `true` - enable hybrid safety net for SSAI-heavy ad breaks. Keeps the sticky CSAI fast path (no regression on clean breaks) but adds: (1) sticky escape hatch — after ~12s stuck on the sticky path with the early-reload budget exhausted, fall through to backup search instead of freezing; (2) `autoplay` (360p) appended as a last-resort backup when all Source types (embed/site/popout/mobile_web) are ad-laden
-- `false` - original behavior: sticky CSAI path stays engaged for the whole break (default)
+**`twitchAdSolutions_preferLowQualityBackup`** (default: `true`, vaft only)
+- Hybrid safety net for SSAI-heavy ad breaks. Keeps the sticky CSAI fast path (no regression on clean breaks) and adds: (1) sticky escape hatch — after ~8s stuck with the early-reload budget exhausted, fall through to backup search instead of freezing; (2) `autoplay` (360p) appended as a last-resort backup when all Source types (embed/site/popout/mobile_web) are ad-laden
+- Set to `false` to disable — sticky CSAI path only, no escape hatch or autoplay fallback
 - ⚠ **Quality caveat**: autoplay only commits when every Source backup is also ad-laden — rare, but the 360p hit is the tradeoff for avoiding long freezes on SSAI-heavy channels
 
 ```js

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -56,7 +56,7 @@ twitch-videoad.js text/javascript
         ];
         scope.FallbackPlayerType = 'embed';
         scope.ForceAccessTokenPlayerType = 'popout';
-        scope.PreferLowQualityBackup = false;// If true, force backup swap on every ad and prepend 'autoplay' (360p) to backup types. Reliability-first mode — low quality during ads, no freeze risk. Opt-in for users who prefer pixeltris's original behavior.
+        scope.PreferLowQualityBackup = true;// Hybrid safety net for SSAI-heavy breaks: sticky escape hatch (fires after ~8s stuck in all-stripped state) + autoplay (360p) as last-resort backup when all Source types are ad-laden. Default on; set twitchAdSolutions_preferLowQualityBackup=false to disable.
         scope.SkipPlayerReloadOnHevc = false;// If true this will skip player reload on streams which have 2k/4k quality (if you enable this and you use the 2k/4k quality setting you'll get error #4000 / #3000 / spinning wheel on chrome based browsers)
         scope.AlwaysReloadPlayerOnAd = false;// Always pause/play when entering/leaving ads
         scope.ReloadPlayerAfterAd = true;// After the ad finishes do a player reload instead of pause/play
@@ -2059,9 +2059,9 @@ twitch-videoad.js text/javascript
             PinBackupPlayerType = lsPinBackup === 'true';
         }
         const lsPreferLow = localStorage.getItem('twitchAdSolutions_preferLowQualityBackup');
-        if (lsPreferLow === 'true') {
-            PreferLowQualityBackup = true;
-            console.log('[AD DEBUG] PreferLowQualityBackup enabled — autoplay (360p) added as last-resort backup + sticky escape hatch after ~12s freeze');
+        if (lsPreferLow === 'false') {
+            PreferLowQualityBackup = false;
+            console.log('[AD DEBUG] PreferLowQualityBackup disabled via localStorage — sticky CSAI path only, no autoplay fallback or escape hatch');
         }
         const lsHideAdOverlay = localStorage.getItem('twitchAdSolutions_hideAdOverlay');
         if (lsHideAdOverlay === 'true') {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -66,7 +66,7 @@
         ];
         scope.FallbackPlayerType = 'embed';
         scope.ForceAccessTokenPlayerType = 'popout';
-        scope.PreferLowQualityBackup = false;// If true, force backup swap on every ad and prepend 'autoplay' (360p) to backup types. Reliability-first mode — low quality during ads, no freeze risk. Opt-in for users who prefer pixeltris's original behavior.
+        scope.PreferLowQualityBackup = true;// Hybrid safety net for SSAI-heavy breaks: sticky escape hatch (fires after ~8s stuck in all-stripped state) + autoplay (360p) as last-resort backup when all Source types are ad-laden. Default on; set twitchAdSolutions_preferLowQualityBackup=false to disable.
         scope.SkipPlayerReloadOnHevc = false;// If true this will skip player reload on streams which have 2k/4k quality (if you enable this and you use the 2k/4k quality setting you'll get error #4000 / #3000 / spinning wheel on chrome based browsers)
         scope.AlwaysReloadPlayerOnAd = false;// Always pause/play when entering/leaving ads
         scope.ReloadPlayerAfterAd = true;// After the ad finishes do a player reload instead of pause/play
@@ -2095,9 +2095,9 @@
             PinBackupPlayerType = lsPinBackup === 'true';
         }
         const lsPreferLow = localStorage.getItem('twitchAdSolutions_preferLowQualityBackup');
-        if (lsPreferLow === 'true') {
-            PreferLowQualityBackup = true;
-            console.log('[AD DEBUG] PreferLowQualityBackup enabled — autoplay (360p) added as last-resort backup + sticky escape hatch after ~12s freeze');
+        if (lsPreferLow === 'false') {
+            PreferLowQualityBackup = false;
+            console.log('[AD DEBUG] PreferLowQualityBackup disabled via localStorage — sticky CSAI path only, no autoplay fallback or escape hatch');
         }
         const lsHideAdOverlay = localStorage.getItem('twitchAdSolutions_hideAdOverlay');
         if (lsHideAdOverlay === 'true') {


### PR DESCRIPTION
## Summary

Flip `PreferLowQualityBackup` from opt-in (default `false`) to default on (default `true`). Preserves opt-out via `twitchAdSolutions_preferLowQualityBackup=false`.

## Behavior changes

Default path now includes:
1. **Sticky CSAI escape hatch** — after ~8s stuck in all-stripped state (threshold 4 polls, post-PR #158), fall through to backup search instead of sitting in recovery loop until natural break end
2. **Autoplay (360p) as last-resort backup** — appended to the backup player type list; only commits when all Source types (embed/site/popout/mobile_web) are ad-laden

Clean CSAI fast path is unchanged — common-case breaks with stripped segments still resolve via the sticky path with no backup search overhead.

## Why flip now

Field-tested across `winton_ow2`, `aspen`, `junothemartian`, `august`:
- Clean 1-ad breaks pass through untouched (consistent `CSAI fast path` log, no regression)
- 2-ad heavy-SSAI pods still freeze under default-off behavior — the whole point of the safety net
- Autoplay has never been reached in testing — Source types always clean up first, so the 360p quality hit stays theoretical for most users

Default-on also reduces support burden: users hitting SSAI freezes don't need to discover the flag to get relief.

## Opt-out

```js
localStorage.setItem('twitchAdSolutions_preferLowQualityBackup', 'false');
```

Explicit opt-out logs on load:
```
[AD DEBUG] PreferLowQualityBackup disabled via localStorage — sticky CSAI path only, no autoplay fallback or escape hatch
```

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js` (flag is vaft-only)
- `README.md` — updated Configuration section default
- `CLAUDE.md` — updated localStorage config list

Testing variants landed as commit `7ed2adf`.

## Test plan

- [ ] Fresh install, no LS — verify hybrid behavior active (escape hatch can fire on SSAI breaks; autoplay in backup list)
- [ ] `twitchAdSolutions_preferLowQualityBackup=false` — verify disabled log fires at load, sticky path behaves as before
- [ ] Clean 1-ad CSAI breaks resolve via fast path with no regression
- [ ] 2-ad heavy-SSAI break on `winton_ow2`/`aspen` — verify escape hatch fires at poll 4 and backup search commits Source type

🤖 Generated with [Claude Code](https://claude.com/claude-code)