### PR TITLE
worker crash recovery for IVS WASM worker

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -377,6 +377,21 @@ twitch-videoad.js text/javascript
                         });
                     }
                 });
+                // Worker crash recovery — IVS WASM worker can fire RuntimeError
+                // (e.g. "index out of bounds") and die. A single crash fires multiple
+                // error events; dedupe via a local flag. On first error, trigger a
+                // hard reload via the main reload path — Twitch re-spawns the worker
+                // as part of the new player instance, and existing reload cooldown
+                // prevents runaway restart loops.
+                let crashed = false;
+                this.addEventListener('error', (e) => {
+                    if (crashed) return;
+                    crashed = true;
+                    console.log('[AD DEBUG] IVS WASM worker crashed: ' + ((e && e.message) || 'unknown error') + ' — triggering hard reload to recover');
+                    try { doTwitchPlayerTask(false, true, 'early'); } catch (err) {
+                        console.log('[AD DEBUG] Worker crash recovery failed: ' + err.message);
+                    }
+                });
             }
         };
         let workerInstance = reinsertWorkers(newWorker, reinsert);

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -401,6 +401,21 @@
                         });
                     }
                 });
+                // Worker crash recovery — IVS WASM worker can fire RuntimeError
+                // (e.g. "index out of bounds") and die. A single crash fires multiple
+                // error events; dedupe via a local flag. On first error, trigger a
+                // hard reload via the main reload path — Twitch re-spawns the worker
+                // as part of the new player instance, and existing reload cooldown
+                // prevents runaway restart loops.
+                let crashed = false;
+                this.addEventListener('error', (e) => {
+                    if (crashed) return;
+                    crashed = true;
+                    console.log('[AD DEBUG] IVS WASM worker crashed: ' + ((e && e.message) || 'unknown error') + ' — triggering hard reload to recover');
+                    try { doTwitchPlayerTask(false, true, 'early'); } catch (err) {
+                        console.log('[AD DEBUG] Worker crash recovery failed: ' + err.message);
+                    }
+                });
             }
         };
         let workerInstance = reinsertWorkers(newWorker, reinsert);

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -303,6 +303,20 @@ twitch-videoad.js text/javascript
                         });
                     }
                 });
+                // Worker crash recovery — IVS WASM worker can fire RuntimeError
+                // (e.g. "index out of bounds") and die. A single crash fires multiple
+                // error events; dedupe via a local flag. On first error, trigger a
+                // player reload — Twitch re-spawns the worker as part of the new
+                // player instance, and existing reload cooldown prevents restart loops.
+                let crashed = false;
+                this.addEventListener('error', (e) => {
+                    if (crashed) return;
+                    crashed = true;
+                    console.log('[AD DEBUG] IVS WASM worker crashed: ' + ((e && e.message) || 'unknown error') + ' — triggering player reload to recover');
+                    try { reloadTwitchPlayer(false); } catch (err) {
+                        console.log('[AD DEBUG] Worker crash recovery failed: ' + err.message);
+                    }
+                });
             }
         }
         let workerInstance = reinsertWorkers(newWorker, reinsert);

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -315,6 +315,20 @@
                         });
                     }
                 });
+                // Worker crash recovery — IVS WASM worker can fire RuntimeError
+                // (e.g. "index out of bounds") and die. A single crash fires multiple
+                // error events; dedupe via a local flag. On first error, trigger a
+                // player reload — Twitch re-spawns the worker as part of the new
+                // player instance, and existing reload cooldown prevents restart loops.
+                let crashed = false;
+                this.addEventListener('error', (e) => {
+                    if (crashed) return;
+                    crashed = true;
+                    console.log('[AD DEBUG] IVS WASM worker crashed: ' + ((e && e.message) || 'unknown error') + ' — triggering player reload to recover');
+                    try { reloadTwitchPlayer(false); } catch (err) {
+                        console.log('[AD DEBUG] Worker crash recovery failed: ' + err.message);
+                    }
+                });
             }
         }
         let workerInstance = reinsertWorkers(newWorker, reinsert);


### PR DESCRIPTION
## Summary

IVS WASM worker can fire `RuntimeError: index out of bounds` (and related errors) and die, leaving the player silently stalled. A single crash fires multiple error events — TTV-AB's v6.3.4 CHANGELOG flagged that a naive restart counter would exhaust its budget from duplicate events from one crash.

Add an `'error'` listener on the injected worker with a local dedupe flag (`crashed = true` on first event, subsequent events are ignored). On first error, trigger the main reload path — Twitch re-spawns the worker as part of the new player instance, and the existing reload cooldown (30s → 90s auto-escalation) prevents runaway restart loops.

## Implementation

Uses each script's natural reload entry point instead of TTV-AB's standalone worker-respawn:

- **vaft**: `doTwitchPlayerTask(false, true, 'early')` — hard reload (new MediaSource + token)
- **video-swap-new**: `reloadTwitchPlayer(false)` — standard reload path

Simpler than TTV-AB's approach. Reuses existing reload infrastructure and cooldown instead of spawning workers ourselves. Downside: full player reload instead of just worker restart (brief black screen), but acceptable for rare IVS crashes.

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js` + `video-swap-new/video-swap-new-ublock-origin.js`

Testing variants landed as commit `1043f0e`.

## Test plan

- [ ] Manually fire a synthetic error on `twitchWorkers[0]` in devtools, verify `[AD DEBUG] IVS WASM worker crashed: ... — triggering hard reload to recover` fires exactly once (dedupe working)
- [ ] Verify reload fires and player recovers
- [ ] Verify second synthetic crash within cooldown is skipped (cooldown acts as loop prevention)
- [ ] Verify no false positives — normal worker activity doesn't trigger the crash path

## Related

- TTV-AB v6.3.4 (commit `d49cc7e`) — origin of the dedupe pattern
- Our reload cooldown from PRs #133/#134 — provides the restart-loop prevention

🤖 Generated with [Claude Code](https://claude.com/claude-code)