### PR TITLE
sync full Response shape in worker-bridge fetch

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -317,12 +317,20 @@ twitch-videoad.js text/javascript
                                 if (responseData.error) {
                                     reject(new Error(responseData.error));
                                 } else {
-                                    // Create a Response object from the response data
+                                    // Create a Response object from the response data.
+                                    // Response constructor only takes status/statusText/headers — url/redirected/type
+                                    // must be defined on the instance. IVS WASM validates these (Spade/tracking
+                                    // requests) and throws NetworkError if they're missing — TTV-AB v6.3.5 fix.
                                     const response = new Response(responseData.body, {
                                         status: responseData.status,
                                         statusText: responseData.statusText,
                                         headers: responseData.headers
                                     });
+                                    try {
+                                        Object.defineProperty(response, 'url', { value: responseData.url || '', configurable: true });
+                                        Object.defineProperty(response, 'redirected', { value: !!responseData.redirected, configurable: true });
+                                        Object.defineProperty(response, 'type', { value: responseData.type || 'basic', configurable: true });
+                                    } catch {}
                                     resolve(response);
                                 }
                             }
@@ -1863,6 +1871,10 @@ twitch-videoad.js text/javascript
                 id: fetchRequest.id,
                 status: response.status,
                 statusText: response.statusText,
+                ok: response.ok,
+                redirected: response.redirected,
+                type: response.type,
+                url: response.url,
                 headers: Object.fromEntries(response.headers.entries()),
                 body: responseBody
             };

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -341,12 +341,20 @@
                                 if (responseData.error) {
                                     reject(new Error(responseData.error));
                                 } else {
-                                    // Create a Response object from the response data
+                                    // Create a Response object from the response data.
+                                    // Response constructor only takes status/statusText/headers — url/redirected/type
+                                    // must be defined on the instance. IVS WASM validates these (Spade/tracking
+                                    // requests) and throws NetworkError if they're missing — TTV-AB v6.3.5 fix.
                                     const response = new Response(responseData.body, {
                                         status: responseData.status,
                                         statusText: responseData.statusText,
                                         headers: responseData.headers
                                     });
+                                    try {
+                                        Object.defineProperty(response, 'url', { value: responseData.url || '', configurable: true });
+                                        Object.defineProperty(response, 'redirected', { value: !!responseData.redirected, configurable: true });
+                                        Object.defineProperty(response, 'type', { value: responseData.type || 'basic', configurable: true });
+                                    } catch {}
                                     resolve(response);
                                 }
                             }
@@ -1899,6 +1907,10 @@
                 id: fetchRequest.id,
                 status: response.status,
                 statusText: response.statusText,
+                ok: response.ok,
+                redirected: response.redirected,
+                type: response.type,
+                url: response.url,
                 headers: Object.fromEntries(response.headers.entries()),
                 body: responseBody
             };

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -260,12 +260,20 @@ twitch-videoad.js text/javascript
                                 if (responseData.error) {
                                     reject(new Error(responseData.error));
                                 } else {
-                                    // Create a Response object from the response data
+                                    // Create a Response object from the response data.
+                                    // Response constructor only takes status/statusText/headers — url/redirected/type
+                                    // must be defined on the instance. IVS WASM validates these (Spade/tracking
+                                    // requests) and throws NetworkError if they're missing — TTV-AB v6.3.5 fix.
                                     const response = new Response(responseData.body, {
                                         status: responseData.status,
                                         statusText: responseData.statusText,
                                         headers: responseData.headers
                                     });
+                                    try {
+                                        Object.defineProperty(response, 'url', { value: responseData.url || '', configurable: true });
+                                        Object.defineProperty(response, 'redirected', { value: !!responseData.redirected, configurable: true });
+                                        Object.defineProperty(response, 'type', { value: responseData.type || 'basic', configurable: true });
+                                    } catch {}
                                     resolve(response);
                                 }
                             }
@@ -1042,6 +1050,10 @@ twitch-videoad.js text/javascript
                 id: fetchRequest.id,
                 status: response.status,
                 statusText: response.statusText,
+                ok: response.ok,
+                redirected: response.redirected,
+                type: response.type,
+                url: response.url,
                 headers: Object.fromEntries(response.headers.entries()),
                 body: responseBody
             };

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -272,12 +272,20 @@
                                 if (responseData.error) {
                                     reject(new Error(responseData.error));
                                 } else {
-                                    // Create a Response object from the response data
+                                    // Create a Response object from the response data.
+                                    // Response constructor only takes status/statusText/headers — url/redirected/type
+                                    // must be defined on the instance. IVS WASM validates these (Spade/tracking
+                                    // requests) and throws NetworkError if they're missing — TTV-AB v6.3.5 fix.
                                     const response = new Response(responseData.body, {
                                         status: responseData.status,
                                         statusText: responseData.statusText,
                                         headers: responseData.headers
                                     });
+                                    try {
+                                        Object.defineProperty(response, 'url', { value: responseData.url || '', configurable: true });
+                                        Object.defineProperty(response, 'redirected', { value: !!responseData.redirected, configurable: true });
+                                        Object.defineProperty(response, 'type', { value: responseData.type || 'basic', configurable: true });
+                                    } catch {}
                                     resolve(response);
                                 }
                             }
@@ -1056,6 +1064,10 @@
                 id: fetchRequest.id,
                 status: response.status,
                 statusText: response.statusText,
+                ok: response.ok,
+                redirected: response.redirected,
+                type: response.type,
+                url: response.url,
                 headers: Object.fromEntries(response.headers.entries()),
                 body: responseBody
             };


### PR DESCRIPTION
## Summary

Fabricated `Response` objects in the worker-bridge `FetchResponse` path were missing native `url`, `ok`, `redirected`, and `type` properties. TTV-AB v6.3.5 diagnosed that IVS WASM (`amazon-ivs-wasmworker`) validates these properties on tracking (Spade) and media requests and throws internal `NetworkError` when they're missing, halting playback.

## Fix

Two-sided change:

**Main thread (`handleWorkerFetchRequest`)** — include the full shape in the payload:
```js
const responseObject = {
    id: fetchRequest.id,
    status: response.status,
    statusText: response.statusText,
    ok: response.ok,
    redirected: response.redirected,
    type: response.type,
    url: response.url,
    headers: Object.fromEntries(response.headers.entries()),
    body: responseBody
};
```

**Worker blob (`FetchResponse` handler)** — apply `url`/`redirected`/`type` to the reconstructed `Response` via `Object.defineProperty` (the Response constructor doesn't accept them as options). `ok` is auto-derived from `status`, so we don't need to override it.

```js
const response = new Response(responseData.body, {
    status: responseData.status,
    statusText: responseData.statusText,
    headers: responseData.headers
});
try {
    Object.defineProperty(response, 'url', { value: responseData.url || '', configurable: true });
    Object.defineProperty(response, 'redirected', { value: !!responseData.redirected, configurable: true });
    Object.defineProperty(response, 'type', { value: responseData.type || 'basic', configurable: true });
} catch {}
```

`try/catch` guards against engine quirks (some environments may refuse to override the getter on the Response prototype).

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js` + `video-swap-new/video-swap-new-ublock-origin.js`

Testing variants landed as commit `6c2646a`.

## Test plan

- [ ] During an ad break, watch for reduced `NetworkError` occurrences from the IVS WASM worker (particularly on Spade/tracking requests)
- [ ] Verify reconstructed Response in the worker has `.url`, `.type`, `.redirected` matching the original fetch (check `Object.getOwnPropertyDescriptor(response, 'url')`)
- [ ] Verify no regression in normal m3u8 fetch path — Response body and headers still populated correctly

## Related

- TTV-AB v6.3.5 (commit `cd32a60`) — origin of the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)