### PR TITLE
exempt post-ad reload from CSAI cascade cooldown

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1215,7 +1215,11 @@ twitch-videoad.js text/javascript
                 if (cycleRescuedCleanly) {
                     console.log('[AD DEBUG] Cycle rescue handled the break cleanly — skipping end-of-break reload');
                 }
-                const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments && !tooSoonSinceLastReload && !cycleRescuedCleanly);
+                // Post-ad reload bypasses cooldown: it's a buffer flush tied to natural break
+                // end, not a cascade-risk retry. The ad break cycle itself rate-limits this
+                // path (once per break). Cooldown still gates buffer-monitor and other
+                // cascade-risk paths that can fire repeatedly in-break.
+                const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments && !cycleRescuedCleanly);
                 if (shouldReload) {
                     streamInfo.ReloadTimestamps.push(Date.now());
                     streamInfo.IsUsingModifiedM3U8 = false;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1247,7 +1247,11 @@
                 if (cycleRescuedCleanly) {
                     console.log('[AD DEBUG] Cycle rescue handled the break cleanly — skipping end-of-break reload');
                 }
-                const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments && !tooSoonSinceLastReload && !cycleRescuedCleanly);
+                // Post-ad reload bypasses cooldown: it's a buffer flush tied to natural break
+                // end, not a cascade-risk retry. The ad break cycle itself rate-limits this
+                // path (once per break). Cooldown still gates buffer-monitor and other
+                // cascade-risk paths that can fire repeatedly in-break.
+                const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments && !cycleRescuedCleanly);
                 if (shouldReload) {
                     streamInfo.ReloadTimestamps.push(Date.now());
                     streamInfo.IsUsingModifiedM3U8 = false;


### PR DESCRIPTION
## Summary

Post-ad reload fires **once per ad break** at natural break end. The ad break cycle itself rate-limits this path. The CSAI cascade cooldown was designed for paths that can fire repeatedly in-break (buffer monitor auto-reload, in-break early reload retries), not end-of-break buffer flush.

## Reproduction (field log on `karq`)

```
[AD DEBUG] Loading circle detected during ad break (3.1s stall, readyState=1) — early reload
Reloading Twitch player (hard)
... ad break continues for 27s ...
Finished blocking ads — stripped 8 ad segments, duration: 50.0s
[AD DEBUG] Reload decision: shouldReload=false IsUsingModifiedM3U8=false hadStripped=true tooSoon=true cooldown=30s
[AD DEBUG] Skipping reload — last reload was 27s ago (cooldown: 30s)
[AD DEBUG] Video state: readyState=2 networkState=2 buffered=228.7 currentTime=228.7 paused=true
```

Loading-circle hard reload fired at t=0, ad break ended at t=27, post-ad reload was blocked by cooldown. Player ended up stalled at `readyState=2 paused=true` until the buffer monitor seeked. PR #148's hard-reload buffer flush was specifically designed to prevent exactly this state.

## Fix

Drop the `!tooSoonSinceLastReload` gate from the post-ad `shouldReload` condition:

```js
// Before:
const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments && !tooSoonSinceLastReload && !cycleRescuedCleanly);

// After:
const shouldReload = streamInfo.IsUsingModifiedM3U8 || (ReloadPlayerAfterAd && hadStrippedSegments && !cycleRescuedCleanly);
```

The cooldown **still** gates other cascade-risk paths (buffer monitor's auto-reload, the separate `reloadTwitchPlayer` window-scope cooldown logic). This PR only lifts the gate on the natural end-of-break buffer flush path.

## Why this is safe

- `hadStrippedSegments` requires strip activity, so post-ad reload only fires when we actually blocked ads — not on speculative reloads
- End-of-break happens at most once per natural ad-break cycle (~30s – 90s cadence)
- PR #148's hard reload at this point uses a fresh access token + new MediaSource — exactly what buffer flush requires
- The CSAI cascade concern (reload → Twitch serves another ad → reload again) applies to in-break retries, not break-end flush

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`

video-swap-new uses a different cooldown architecture (window-scope in `reloadTwitchPlayer`) and doesn't exhibit this specific interaction.

Testing variants landed as commit `b8a6e5d`.

## Test plan

- [ ] Normal post-ad reload still fires (unchanged common path)
- [ ] After a mid-break loading-circle reload, verify post-ad reload fires at break end even if <30s has elapsed
- [ ] Verify cooldown still gates unwanted rapid reloads from the buffer monitor path

🤖 Generated with [Claude Code](https://claude.com/claude-code)