### PR TITLE
reload to restore Source quality after autoplay (360p) fallback

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1197,6 +1197,18 @@ twitch-videoad.js text/javascript
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');
                     streamInfo.IsUsingModifiedM3U8 = false;
+                    // Exception: if the committed backup was autoplay (360p), clearing the
+                    // flag restores native m3u8 delivery but the player's access token is
+                    // still autoplay-scoped — variant ladder is 360p-only and viewer stays
+                    // stuck at 360p until a future break forces a reload. Trigger a hard
+                    // reload now to refresh the token and restore Source quality.
+                    if (streamInfo.LastCommittedBackupPlayerType === 'autoplay') {
+                        console.log('[AD DEBUG] Post-escape on autoplay (360p) — forcing reload to restore Source quality');
+                        streamInfo.LastPlayerReload = Date.now();
+                        if (!streamInfo.ReloadTimestamps) streamInfo.ReloadTimestamps = [];
+                        streamInfo.ReloadTimestamps.push(Date.now());
+                        postMessage({ key: 'ReloadPlayer', kind: 'early' });
+                    }
                 } else {
                 // Auto-escalate cooldown: if 3+ reloads in last 5 min, triple the cooldown
                 if (!streamInfo.ReloadTimestamps) streamInfo.ReloadTimestamps = [];

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1229,6 +1229,18 @@
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');
                     streamInfo.IsUsingModifiedM3U8 = false;
+                    // Exception: if the committed backup was autoplay (360p), clearing the
+                    // flag restores native m3u8 delivery but the player's access token is
+                    // still autoplay-scoped — variant ladder is 360p-only and viewer stays
+                    // stuck at 360p until a future break forces a reload. Trigger a hard
+                    // reload now to refresh the token and restore Source quality.
+                    if (streamInfo.LastCommittedBackupPlayerType === 'autoplay') {
+                        console.log('[AD DEBUG] Post-escape on autoplay (360p) — forcing reload to restore Source quality');
+                        streamInfo.LastPlayerReload = Date.now();
+                        if (!streamInfo.ReloadTimestamps) streamInfo.ReloadTimestamps = [];
+                        streamInfo.ReloadTimestamps.push(Date.now());
+                        postMessage({ key: 'ReloadPlayer', kind: 'early' });
+                    }
                 } else {
                 // Auto-escalate cooldown: if 3+ reloads in last 5 min, triple the cooldown
                 if (!streamInfo.ReloadTimestamps) streamInfo.ReloadTimestamps = [];


### PR DESCRIPTION
## Summary

Fix latent bug observed for the first time on `l0ok_at_me` preroll:

```
[AD DEBUG] Backup stream (embed) also has ads
[AD DEBUG] Backup stream (site) also has ads
[AD DEBUG] Backup stream (popout) also has ads
[AD DEBUG] Backup stream (mobile_web) also has ads
[AD DEBUG] Autoplay backup committed — 360p fallback after Source types ad-laden (PreferLowQualityBackup)
[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action
```

When all 4 Source types are ad-laden (rare but it happens), autoplay (360p) commits as last-resort backup. When the break ends, the `CSAI-only` path clears `IsUsingModifiedM3U8` **without triggering a reload** — but the player's access token is still **autoplay-scoped**, so its variant ladder only contains 360p. Clearing the backup flag restores native m3u8 delivery, but the viewer stays stuck at 360p until a future break forces a reload via strip+post-ad.

## Fix

In the CSAI-only branch, check `LastCommittedBackupPlayerType`. If it's `'autoplay'`, trigger a hard reload (`kind: 'early'`) to refresh the access token. Source variant ladder restored.

Natural source-type recoveries (`popout`/`embed`/`site` as backup) keep the existing no-reload behavior — only autoplay's variant ladder is quality-restricted, so only autoplay needs the reload.

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js` (autoplay fallback is vaft-only)

Testing variants landed as commit `8eae9ec`.

## Default-off users

Only reachable when `twitchAdSolutions_preferLowQualityBackup = 'true'` — autoplay fallback is part of that opt-in. Default-off users are unaffected. (PR #159 flips the default to on, which would make this PR's fix the common path on all-Source-ad-laden channels.)

## Test plan

- [ ] With `preferLowQualityBackup=true`, force all 4 Source types to be ad-laden (hard to reproduce deterministically — depends on Twitch's ad-serving state)
- [ ] If autoplay commits: verify `[AD DEBUG] Post-escape on autoplay (360p) — forcing reload to restore Source quality` fires after break ends
- [ ] Verify post-reload playback resumes at Source quality (not 360p)
- [ ] Verify natural source-type recoveries (common case) still skip the reload as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)