### PR TITLE
don't fire loading-circle reload during in-flight reload

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1559,7 +1559,11 @@ twitch-videoad.js text/javascript
                     const isStalled = video.readyState < 3 && (video.paused || video.networkState === 2);
                     const stallReloadCooldown = 15000;
                     const cooldownExpired = !playerBufferState.lastAdStallReloadAt || (Date.now() - playerBufferState.lastAdStallReloadAt) > stallReloadCooldown;
-                    if (isStalled && cooldownExpired && playerBufferState.hasHadData) {
+                    // Don't fire loading-circle reload if ANY reload happened recently — readyState=0
+                    // is the expected transient state during a reload's MediaSource teardown. Without
+                    // this, an early-reload in flight can trigger a redundant loading-circle reload.
+                    const recentReload = playerBufferState.lastReloadAt && (Date.now() - playerBufferState.lastReloadAt) < stallReloadCooldown;
+                    if (isStalled && cooldownExpired && !recentReload && playerBufferState.hasHadData) {
                         if (!playerBufferState.adStallStartAt) {
                             playerBufferState.adStallStartAt = Date.now();
                         } else if ((Date.now() - playerBufferState.adStallStartAt) > 3000) {
@@ -1831,6 +1835,7 @@ twitch-videoad.js text/javascript
                 }
             } catch {}
             playerBufferState.lastReloadAt = Date.now();
+            playerBufferState.adStallStartAt = 0;// clear stale stall timer so post-reload readyState=0 isn't attributed to pre-reload stall
             playerBufferState.userPauseIntent = false;
             playerBufferState.loggedPauseIntent = false;
             // playerForMonitoringBuffering re-acquired fresh every tick — no manual invalidation needed

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1595,7 +1595,11 @@
                     const isStalled = video.readyState < 3 && (video.paused || video.networkState === 2);
                     const stallReloadCooldown = 15000;
                     const cooldownExpired = !playerBufferState.lastAdStallReloadAt || (Date.now() - playerBufferState.lastAdStallReloadAt) > stallReloadCooldown;
-                    if (isStalled && cooldownExpired && playerBufferState.hasHadData) {
+                    // Don't fire loading-circle reload if ANY reload happened recently — readyState=0
+                    // is the expected transient state during a reload's MediaSource teardown. Without
+                    // this, an early-reload in flight can trigger a redundant loading-circle reload.
+                    const recentReload = playerBufferState.lastReloadAt && (Date.now() - playerBufferState.lastReloadAt) < stallReloadCooldown;
+                    if (isStalled && cooldownExpired && !recentReload && playerBufferState.hasHadData) {
                         if (!playerBufferState.adStallStartAt) {
                             playerBufferState.adStallStartAt = Date.now();
                         } else if ((Date.now() - playerBufferState.adStallStartAt) > 3000) {
@@ -1867,6 +1871,7 @@
                 }
             } catch {}
             playerBufferState.lastReloadAt = Date.now();
+            playerBufferState.adStallStartAt = 0;// clear stale stall timer so post-reload readyState=0 isn't attributed to pre-reload stall
             playerBufferState.userPauseIntent = false;
             playerBufferState.loggedPauseIntent = false;
             // playerForMonitoringBuffering re-acquired fresh every tick — no manual invalidation needed


### PR DESCRIPTION
## Summary

Fix triple-reload scenario observed on `aspen` 2-ad midroll:

```
Early reload triggered (sticky path) ... [1/2]
Reloading Twitch player (hard)                                  ← reload #1
[AD DEBUG] Loading circle detected during ad break (29.2s stall, readyState=0) — early reload
Reloading Twitch player (hard)                                  ← reload #2 (redundant!)
MediaCapabilities found                                          ← player state after #2
Early reload triggered (sticky path) ... [2/2]
Reloading Twitch player (hard)                                  ← reload #3
```

Three hard reloads within seconds. The loading-circle reload (#2) fired *during* reload #1's MediaSource teardown — `readyState=0` is the expected transient state during that teardown, not a real stall.

## Root cause

The loading-circle detector (`monitorPlayerBuffering`) has a 15s cooldown gate (`lastAdStallReloadAt`) that only tracks its own prior firings. An early reload triggered from the worker side (via `ReloadPlayer` message → `doTwitchPlayerTask`) doesn't touch `lastAdStallReloadAt`, so the loading-circle check could fire during the just-triggered reload's initialization.

The 29.2s stall measurement is also suspect — it's clearly stale (inherited from `adStallStartAt` tracking started before the reload), not 29s of actual post-reload stall.

## Fix

Two-part:

1. **Gate loading-circle detection on `playerBufferState.lastReloadAt`** (set by any reload path, not just loading-circle ones). If a reload fired within the 15s cooldown, skip the loading-circle check entirely.

2. **Reset `adStallStartAt` in `doTwitchPlayerTask`** when any reload fires, so stale stall measurements don't carry across the reload boundary. Fresh stall tracking starts from post-reload state.

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`

Testing variants landed as commit `5591c56`.

## Test plan

- [ ] Trigger an early reload (sticky path) during an ad break, verify loading-circle reload doesn't fire immediately after (stall timer reset + 15s cooldown gate)
- [ ] Genuinely stuck player (no recent reload) still triggers loading-circle after 3s of `readyState<3` stall
- [ ] Post-reload stall timer starts fresh — a real loading circle 16s after the reload still fires
- [ ] No regression in buffer monitor's other recovery paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)