### PR TITLE
force reload after ANY committed backup (not just autoplay)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1220,13 +1220,19 @@ twitch-videoad.js text/javascript
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');
                     streamInfo.IsUsingModifiedM3U8 = false;
-                    // Exception: if the committed backup was autoplay (360p), clearing the
-                    // flag restores native m3u8 delivery but the player's access token is
-                    // still autoplay-scoped — variant ladder is 360p-only and viewer stays
-                    // stuck at 360p until a future break forces a reload. Trigger a hard
-                    // reload now to refresh the token and restore Source quality.
-                    if (streamInfo.LastCommittedBackupPlayerType === 'autoplay') {
-                        console.log('[AD DEBUG] Post-escape on autoplay (360p) — forcing reload to restore Source quality');
+                    // Exception: if ANY backup was committed during this break (escape hatch
+                    // or cycle rescue that didn't meet cycleRescuedCleanly criteria), the
+                    // MediaSource buffer has accumulated mixed-source segments (backup-fetched
+                    // via alternate player-type access token + native-fetched). Mixing can
+                    // cause audio/video track timestamps to diverge, and without a reload the
+                    // drift compounds across subsequent escape-hatch breaks. Force a hard reload
+                    // to flush the MediaSource buffer + refresh the access token.
+                    // For autoplay (360p) specifically, the reload also restores Source
+                    // quality (autoplay-scoped token only serves 360p variant ladder).
+                    if (streamInfo.LastCommittedBackupPlayerType) {
+                        const isAutoplay = streamInfo.LastCommittedBackupPlayerType === 'autoplay';
+                        const reason = isAutoplay ? 'autoplay (360p) — restoring Source quality' : streamInfo.LastCommittedBackupPlayerType + ' — flushing MediaSource to prevent A/V desync accumulation';
+                        console.log('[AD DEBUG] Post-escape reload: ' + reason);
                         streamInfo.LastPlayerReload = Date.now();
                         if (!streamInfo.ReloadTimestamps) streamInfo.ReloadTimestamps = [];
                         streamInfo.ReloadTimestamps.push(Date.now());

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1252,13 +1252,19 @@
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');
                     streamInfo.IsUsingModifiedM3U8 = false;
-                    // Exception: if the committed backup was autoplay (360p), clearing the
-                    // flag restores native m3u8 delivery but the player's access token is
-                    // still autoplay-scoped — variant ladder is 360p-only and viewer stays
-                    // stuck at 360p until a future break forces a reload. Trigger a hard
-                    // reload now to refresh the token and restore Source quality.
-                    if (streamInfo.LastCommittedBackupPlayerType === 'autoplay') {
-                        console.log('[AD DEBUG] Post-escape on autoplay (360p) — forcing reload to restore Source quality');
+                    // Exception: if ANY backup was committed during this break (escape hatch
+                    // or cycle rescue that didn't meet cycleRescuedCleanly criteria), the
+                    // MediaSource buffer has accumulated mixed-source segments (backup-fetched
+                    // via alternate player-type access token + native-fetched). Mixing can
+                    // cause audio/video track timestamps to diverge, and without a reload the
+                    // drift compounds across subsequent escape-hatch breaks. Force a hard reload
+                    // to flush the MediaSource buffer + refresh the access token.
+                    // For autoplay (360p) specifically, the reload also restores Source
+                    // quality (autoplay-scoped token only serves 360p variant ladder).
+                    if (streamInfo.LastCommittedBackupPlayerType) {
+                        const isAutoplay = streamInfo.LastCommittedBackupPlayerType === 'autoplay';
+                        const reason = isAutoplay ? 'autoplay (360p) — restoring Source quality' : streamInfo.LastCommittedBackupPlayerType + ' — flushing MediaSource to prevent A/V desync accumulation';
+                        console.log('[AD DEBUG] Post-escape reload: ' + reason);
                         streamInfo.LastPlayerReload = Date.now();
                         if (!streamInfo.ReloadTimestamps) streamInfo.ReloadTimestamps = [];
                         streamInfo.ReloadTimestamps.push(Date.now());


### PR DESCRIPTION
## Summary

Extend PR #163's post-escape reload to fire after **any** committed backup, not just autoplay (360p).

## Field hypothesis

Repeated aspen logs show **audio-ahead-of-video desync that compounds across escape-hatch breaks**. Each escape-hatch break leaves MediaSource with mixed-source segments:

1. Escape hatch fires during the break → backup (e.g. `popout`) committed → player consumes backup-fetched segments
2. Break ends → CSAI-only path clears `IsUsingModifiedM3U8` flag → player flips back to native m3u8
3. MediaSource now holds both backup-sourced and native-sourced segments

Backup and native fetches use **different access tokens** (different player-type scope), which can produce slightly different timestamp encodings for the same stream time. Mixing in one MediaSource causes the audio/video decoder tracks to drift. Without a reload between breaks, drift accumulates over multiple escape-hatch breaks — manifesting as progressive audio-ahead-of-video desync.

Normal strip-based breaks don't show this because PR #148's post-ad hard reload flushes MS every time.

## Fix

Previously (PR #163) the post-escape reload fired **only** when `LastCommittedBackupPlayerType === 'autoplay'` (for 360p→Source quality restoration).

Now: fire on **any** truthy `LastCommittedBackupPlayerType` — any backup commit, even Source-quality (embed/site/popout/mobile_web), triggers the flush reload. Log differentiates the autoplay case from the desync-prevention case.

```js
if (streamInfo.LastCommittedBackupPlayerType) {
    const isAutoplay = streamInfo.LastCommittedBackupPlayerType === 'autoplay';
    const reason = isAutoplay
        ? 'autoplay (360p) — restoring Source quality'
        : streamInfo.LastCommittedBackupPlayerType + ' — flushing MediaSource to prevent A/V desync accumulation';
    console.log('[AD DEBUG] Post-escape reload: ' + reason);
    // ...trigger hard reload...
}
```

## Cost

~1-2s black screen after every escape-hatch break (previously seamless transition back to native). Tradeoff for clean audio. Pure CSAI-only breaks (no backup committed) unchanged — no MediaSource mixing, no flush needed.

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`

Testing variants landed as commit `9c752e1`.

## Test plan

- [ ] Escape-hatch break on e.g. aspen: verify `[AD DEBUG] Post-escape reload: popout — flushing MediaSource to prevent A/V desync accumulation` fires
- [ ] Over 3+ consecutive escape-hatch breaks, verify audio stays in sync with video (no progressive drift)
- [ ] Pure 1-ad CSAI breaks (no backup commit) still skip reload — no regression in the common case
- [ ] Autoplay fallback case (PR #163) still fires with correct log message

🤖 Generated with [Claude Code](https://claude.com/claude-code)