### PR TITLE
broaden twitch-stitched-* DATERANGE coverage via prefix signifier

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -34,7 +34,12 @@ twitch-videoad.js text/javascript
     window.twitchAdSolutionsVersion = ourTwitchAdSolutionsVersion;
     // Configuration and state shared between window and worker scopes
     function declareOptions(scope) {
-        scope.AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
+        // 'twitch-stitched' catches the twitch-stitched-* DATERANGE class family
+        // (-ad, -mid, -pod, etc.) without requiring an exact -ad suffix. Twitch-
+        // prefixed so we don't re-introduce the PR #120 false-positive from bare
+        // 'stitched' substring match. The specific twitch-stitched-ad DATERANGE
+        // marker is a subset of this prefix.
+        scope.AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
         scope.AdSegmentURLPatterns = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -44,7 +44,12 @@
     window.twitchAdSolutionsVersion = ourTwitchAdSolutionsVersion;
     // Configuration and state shared between window and worker scopes
     function declareOptions(scope) {
-        scope.AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
+        // 'twitch-stitched' catches the twitch-stitched-* DATERANGE class family
+        // (-ad, -mid, -pod, etc.) without requiring an exact -ad suffix. Twitch-
+        // prefixed so we don't re-introduce the PR #120 false-positive from bare
+        // 'stitched' substring match. The specific twitch-stitched-ad DATERANGE
+        // marker is a subset of this prefix.
+        scope.AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
         scope.AdSegmentURLPatterns = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -35,7 +35,11 @@ twitch-videoad.js text/javascript
         // Options / globals
         scope.OPT_BACKUP_PLAYER_TYPES = [ 'embed', 'popout', 'mobile_web' ];
         scope.OPT_FORCE_ACCESS_TOKEN_PLAYER_TYPE = 'popout';
-        scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
+        // 'twitch-stitched' catches the twitch-stitched-* DATERANGE class family
+        // (-ad, -mid, -pod, etc.) without requiring an exact -ad suffix. Twitch-
+        // prefixed so we don't re-introduce the PR #120 false-positive from bare
+        // 'stitched' substring match.
+        scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
         scope.AD_SEGMENT_URL_PATTERNS = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -46,7 +46,11 @@
         // Options / globals
         scope.OPT_BACKUP_PLAYER_TYPES = [ 'embed', 'popout', 'mobile_web' ];
         scope.OPT_FORCE_ACCESS_TOKEN_PLAYER_TYPE = 'popout';
-        scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
+        // 'twitch-stitched' catches the twitch-stitched-* DATERANGE class family
+        // (-ad, -mid, -pod, etc.) without requiring an exact -ad suffix. Twitch-
+        // prefixed so we don't re-introduce the PR #120 false-positive from bare
+        // 'stitched' substring match.
+        scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
         scope.AD_SEGMENT_URL_PATTERNS = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals


### PR DESCRIPTION
## Summary

Address code-review finding: the narrowed `AdSignifiers` list (PR #120, then PR #152) removed bare `'stitched'` to eliminate CDN-hostname false positives, but left a gap for **future Twitch DATERANGE variants**. If Twitch introduces `twitch-stitched-mid`, `twitch-stitched-pod`, or similar, the current exact match on `twitch-stitched-ad` misses them — detection falls through to `EXT-X-CUE-OUT` or the substring `'stitched-ad'` (which requires the literal `-ad` suffix).

## Fix

Replace the exact DATERANGE marker with a **prefix** match on `'twitch-stitched'`:

```diff
- scope.AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
+ scope.AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
```

Coverage before:
- `twitch-stitched-ad` → matches via exact DATERANGE marker ✓
- `twitch-stitched-mid` → **misses**
- `twitch-stitched-pod` → **misses**

Coverage after:
- `twitch-stitched-ad` → matches via prefix ✓
- `twitch-stitched-mid` → matches via prefix ✓
- `twitch-stitched-pod` → matches via prefix ✓
- any future `twitch-stitched-*` → matches via prefix ✓

## Why this doesn't re-introduce the PR #120 false-positive

PR #120 removed bare `'stitched'` because that 8-char substring matched any playlist containing the word — including CDN hostnames like `something-stitched-cdn.net` and UGC embedded in attribute values.

`'twitch-stitched'` has the `twitch-` prefix anchor, which:
- Doesn't appear in third-party CDN hostnames
- Is Twitch-specific, so UGC substrings are extremely unlikely to match
- Still catches all Twitch's own `twitch-stitched-*` DATERANGE variants

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js` + `video-swap-new/video-swap-new-ublock-origin.js`

Testing variants landed as commit `8249aa7`.

## Test plan

- [ ] Normal CSAI break still detected via `stitched-ad` or `twitch-stitched` (whichever fires first) — no regression
- [ ] Verify unknown-signifier diagnostic (PR #153) still surfaces non-`twitch-stitched` markers (e.g., `twitch-session`, `twitch-assignment`)
- [ ] No false positive on channels with CDN hostnames containing unrelated words

🤖 Generated with [Claude Code](https://claude.com/claude-code)