### PR TITLE
unknown-signifier diagnostic: substring-match against AdSignifiers

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -607,7 +607,10 @@ twitch-videoad.js text/javascript
             while ((sm = tagRe.exec(textStr)) !== null) {
                 candidates.add(sm[1]);
             }
-            const unknown = [...candidates].filter(c => !AdSignifiers.includes(c));
+            // Substring check (not exact): a candidate is "known" if any AdSignifier
+            // appears within it. This handles prefix signifiers like 'twitch-stitched'
+            // covering 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"' etc.
+            const unknown = [...candidates].filter(c => !AdSignifiers.some(s => c.includes(s)));
             if (unknown.length > 0) {
                 streamInfo.HasLoggedUnknownSignifiers = true;
                 console.log('[AD DEBUG] Potential ad markers seen but not in AdSignifiers: ' + unknown.join(', ') + ' (candidates for future inclusion)');

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -631,7 +631,10 @@
             while ((sm = tagRe.exec(textStr)) !== null) {
                 candidates.add(sm[1]);
             }
-            const unknown = [...candidates].filter(c => !AdSignifiers.includes(c));
+            // Substring check (not exact): a candidate is "known" if any AdSignifier
+            // appears within it. This handles prefix signifiers like 'twitch-stitched'
+            // covering 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"' etc.
+            const unknown = [...candidates].filter(c => !AdSignifiers.some(s => c.includes(s)));
             if (unknown.length > 0) {
                 streamInfo.HasLoggedUnknownSignifiers = true;
                 console.log('[AD DEBUG] Potential ad markers seen but not in AdSignifiers: ' + unknown.join(', ') + ' (candidates for future inclusion)');

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -542,7 +542,10 @@ twitch-videoad.js text/javascript
             while ((sm = tagRe.exec(textStr)) !== null) {
                 candidates.add(sm[1]);
             }
-            const unknown = [...candidates].filter(c => !AD_SIGNIFIERS.includes(c));
+            // Substring check (not exact): a candidate is "known" if any AD_SIGNIFIER
+            // appears within it. This handles prefix signifiers like 'twitch-stitched'
+            // covering 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"' etc.
+            const unknown = [...candidates].filter(c => !AD_SIGNIFIERS.some(s => c.includes(s)));
             if (unknown.length > 0) {
                 streamInfo.HasLoggedUnknownSignifiers = true;
                 console.log('[AD DEBUG] Potential ad markers seen but not in AD_SIGNIFIERS: ' + unknown.join(', ') + ' (candidates for future inclusion)');

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -554,7 +554,10 @@
             while ((sm = tagRe.exec(textStr)) !== null) {
                 candidates.add(sm[1]);
             }
-            const unknown = [...candidates].filter(c => !AD_SIGNIFIERS.includes(c));
+            // Substring check (not exact): a candidate is "known" if any AD_SIGNIFIER
+            // appears within it. This handles prefix signifiers like 'twitch-stitched'
+            // covering 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"' etc.
+            const unknown = [...candidates].filter(c => !AD_SIGNIFIERS.some(s => c.includes(s)));
             if (unknown.length > 0) {
                 streamInfo.HasLoggedUnknownSignifiers = true;
                 console.log('[AD DEBUG] Potential ad markers seen but not in AD_SIGNIFIERS: ' + unknown.join(', ') + ' (candidates for future inclusion)');


### PR DESCRIPTION
## Summary

PR #166 added `'twitch-stitched'` as a prefix signifier. Detection correctly catches `EXT-X-DATERANGE:CLASS="twitch-stitched-ad"` via the substring match in `hasAdTags`, but the **unknown-signifier diagnostic** (PR #153) still does **exact-string** comparison against `AdSignifiers` — so it reports `twitch-stitched-ad` as "unknown":

```
Potential ad markers seen but not in AdSignifiers: ... EXT-X-DATERANGE:CLASS="twitch-stitched-ad" ...
```

Harmless log noise but confusing: the diagnostic suggests we're missing a marker that we're actually catching via the prefix.

## Fix

Make the diagnostic's filter use the same substring semantic as detection:

```diff
- const unknown = [...candidates].filter(c => !AdSignifiers.includes(c));
+ const unknown = [...candidates].filter(c => !AdSignifiers.some(s => c.includes(s)));
```

A candidate is "known" if any AdSignifier appears within it — matching `hasAdTags`'s behavior.

## Verification

- `EXT-X-DATERANGE:CLASS="twitch-stitched-ad"` → `'twitch-stitched'.includes()` matches → filtered out (known) ✓
- `EXT-X-DATERANGE:CLASS="twitch-session"` → no AdSignifier substring match → reported (unknown) ✓
- `EXT-X-CUE-OUT` → exact match → filtered out (known) ✓
- `EXT-X-CUE-IN` → no AdSignifier substring match → reported (unknown) ✓

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js` + `video-swap-new/video-swap-new-ublock-origin.js`

Testing variants landed as commit `eb75960`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)