### PR TITLE
add BackupSwapFirst (TTV-AB-style backup-swap-first) — default on

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -57,6 +57,7 @@ twitch-videoad.js text/javascript
         scope.FallbackPlayerType = 'embed';
         scope.ForceAccessTokenPlayerType = 'popout';
         scope.PreferLowQualityBackup = true;// Hybrid safety net for SSAI-heavy breaks: sticky escape hatch (fires after ~8s stuck in all-stripped state) + autoplay (360p) as last-resort backup when all Source types are ad-laden. Default on; set twitchAdSolutions_preferLowQualityBackup=false to disable.
+        scope.BackupSwapFirst = true;// On ad detect, immediately swap to a backup player-type m3u8 (TTV-AB-style). Avoids MediaSource mixing from strip activity — fewer loading circles in field. Cost: extra fetches on every ad break. Default on; set twitchAdSolutions_backupSwapFirst=false to disable.
         scope.SkipPlayerReloadOnHevc = false;// If true this will skip player reload on streams which have 2k/4k quality (if you enable this and you use the 2k/4k quality setting you'll get error #4000 / #3000 / spinning wheel on chrome based browsers)
         scope.AlwaysReloadPlayerOnAd = false;// Always pause/play when entering/leaving ads
         scope.ReloadPlayerAfterAd = true;// After the ad finishes do a player reload instead of pause/play
@@ -289,6 +290,7 @@ twitch-videoad.js text/javascript
                     EarlyReloadPollThreshold = ${EarlyReloadPollThreshold};
                     PinBackupPlayerType = ${PinBackupPlayerType};
                     PreferLowQualityBackup = ${PreferLowQualityBackup};
+                    BackupSwapFirst = ${BackupSwapFirst};
                     ForceAccessTokenPlayerType = '${ForceAccessTokenPlayerType}';
                     GQLDeviceID = ${GQLDeviceID ? "'" + GQLDeviceID + "'" : null};
                     AuthorizationHeader = ${AuthorizationHeader ? "'" + AuthorizationHeader + "'" : undefined};
@@ -958,7 +960,12 @@ twitch-videoad.js text/javascript
                     break;
                 }
             }
-            if (!hasNonLiveSegment && !streamInfo.IsUsingModifiedM3U8) {
+            // BackupSwapFirst (opt-in): skip sticky CSAI path entirely, always fall through to
+            // backup search on ad detect. Mimics TTV-AB's backup-swap-first flow — avoids
+            // MediaSource mixing from strip activity (no BLANK_MP4 injection, no recovery
+            // segment replay), which users report produces fewer loading circles. Cost: extra
+            // fetches on every ad break (token requests for each backup type tried).
+            if (!hasNonLiveSegment && !streamInfo.IsUsingModifiedM3U8 && !BackupSwapFirst) {
                 streamInfo.CsaiOnlyThisBreak = true;// Mark break as confirmed CSAI so subsequent polls stay on the fast path
                 console.log('[AD DEBUG] CSAI fast path — all segments live, skipping backup search');
                 if (IsAdStrippingEnabled) {
@@ -2116,6 +2123,11 @@ twitch-videoad.js text/javascript
         if (lsPreferLow === 'false') {
             PreferLowQualityBackup = false;
             console.log('[AD DEBUG] PreferLowQualityBackup disabled via localStorage — sticky CSAI path only, no autoplay fallback or escape hatch');
+        }
+        const lsBackupSwapFirst = localStorage.getItem('twitchAdSolutions_backupSwapFirst');
+        if (lsBackupSwapFirst === 'false') {
+            BackupSwapFirst = false;
+            console.log('[AD DEBUG] BackupSwapFirst disabled via localStorage — using sticky CSAI path (strip on native stream)');
         }
         const lsHideAdOverlay = localStorage.getItem('twitchAdSolutions_hideAdOverlay');
         if (lsHideAdOverlay === 'true') {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -67,6 +67,7 @@
         scope.FallbackPlayerType = 'embed';
         scope.ForceAccessTokenPlayerType = 'popout';
         scope.PreferLowQualityBackup = true;// Hybrid safety net for SSAI-heavy breaks: sticky escape hatch (fires after ~8s stuck in all-stripped state) + autoplay (360p) as last-resort backup when all Source types are ad-laden. Default on; set twitchAdSolutions_preferLowQualityBackup=false to disable.
+        scope.BackupSwapFirst = true;// On ad detect, immediately swap to a backup player-type m3u8 (TTV-AB-style). Avoids MediaSource mixing from strip activity — fewer loading circles in field. Cost: extra fetches on every ad break. Default on; set twitchAdSolutions_backupSwapFirst=false to disable.
         scope.SkipPlayerReloadOnHevc = false;// If true this will skip player reload on streams which have 2k/4k quality (if you enable this and you use the 2k/4k quality setting you'll get error #4000 / #3000 / spinning wheel on chrome based browsers)
         scope.AlwaysReloadPlayerOnAd = false;// Always pause/play when entering/leaving ads
         scope.ReloadPlayerAfterAd = true;// After the ad finishes do a player reload instead of pause/play
@@ -313,6 +314,7 @@
                     EarlyReloadPollThreshold = ${EarlyReloadPollThreshold};
                     PinBackupPlayerType = ${PinBackupPlayerType};
                     PreferLowQualityBackup = ${PreferLowQualityBackup};
+                    BackupSwapFirst = ${BackupSwapFirst};
                     ForceAccessTokenPlayerType = '${ForceAccessTokenPlayerType}';
                     GQLDeviceID = ${GQLDeviceID ? "'" + GQLDeviceID + "'" : null};
                     AuthorizationHeader = ${AuthorizationHeader ? "'" + AuthorizationHeader + "'" : undefined};
@@ -986,7 +988,12 @@
                     break;
                 }
             }
-            if (!hasNonLiveSegment && !streamInfo.IsUsingModifiedM3U8) {
+            // BackupSwapFirst (opt-in): skip sticky CSAI path entirely, always fall through to
+            // backup search on ad detect. Mimics TTV-AB's backup-swap-first flow — avoids
+            // MediaSource mixing from strip activity (no BLANK_MP4 injection, no recovery
+            // segment replay), which users report produces fewer loading circles. Cost: extra
+            // fetches on every ad break (token requests for each backup type tried).
+            if (!hasNonLiveSegment && !streamInfo.IsUsingModifiedM3U8 && !BackupSwapFirst) {
                 streamInfo.CsaiOnlyThisBreak = true;// Mark break as confirmed CSAI so subsequent polls stay on the fast path
                 console.log('[AD DEBUG] CSAI fast path — all segments live, skipping backup search');
                 if (IsAdStrippingEnabled) {
@@ -2152,6 +2159,11 @@
         if (lsPreferLow === 'false') {
             PreferLowQualityBackup = false;
             console.log('[AD DEBUG] PreferLowQualityBackup disabled via localStorage — sticky CSAI path only, no autoplay fallback or escape hatch');
+        }
+        const lsBackupSwapFirst = localStorage.getItem('twitchAdSolutions_backupSwapFirst');
+        if (lsBackupSwapFirst === 'false') {
+            BackupSwapFirst = false;
+            console.log('[AD DEBUG] BackupSwapFirst disabled via localStorage — using sticky CSAI path (strip on native stream)');
         }
         const lsHideAdOverlay = localStorage.getItem('twitchAdSolutions_hideAdOverlay');
         if (lsHideAdOverlay === 'true') {


### PR DESCRIPTION
## Summary

Add backup-swap-first flow (TTV-AB-style) as the default ad-blocking path in vaft. On ad detect, immediately fetch a backup player-type m3u8 and swap to it, skipping strip + BLANK_MP4 + recovery.

## Motivation

User feedback: TTV-AB produces noticeably fewer loading circles than our strip-first approach. Our MediaSource mixing (BLANK_MP4 injection + recovery segment replay) is the root cause of A/V decoder issues and loading circles.

## Flow change

**Old default:** Ad detect → sticky CSAI strip → (if stuck) escape hatch → backup

**New default:** Ad detect → backup search immediately → swap → end-of-break reload

## Field validation

Tested across winton_ow2, warn, aspen, karq, jwantedl, hiimsky, junothemartian — no regressions, fewer loading circles, backup commit times 415-861ms.

## Opt-out

`localStorage.setItem(\"twitchAdSolutions_backupSwapFirst\", \"false\")`

## Scope

vaft pair only. Testing variants landed as b4910e1.