### PR TITLE
accept both streamPlaybackAccessToken GQL response shapes

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1012,13 +1012,18 @@ twitch-videoad.js text/javascript
                             const accessTokenResponse = await getAccessToken(streamInfo.ChannelName, realPlayerType);
                             if (accessTokenResponse.status === 200) {
                                 const accessToken = await accessTokenResponse.json();
-                                if (!accessToken?.data?.streamPlaybackAccessToken) {
-                                    console.log('[AD DEBUG] GQL response format changed — missing data.streamPlaybackAccessToken for ' + realPlayerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken?.data || accessToken || {})));
+                                // Twitch returns streamPlaybackAccessToken in two observed shapes:
+                                //   { data: { streamPlaybackAccessToken: {...} } } (most player types)
+                                //   { streamPlaybackAccessToken: {...} } (flatter, observed for 'embed')
+                                // Accept either. Field-observed silently dropping embed backup otherwise.
+                                const spat = accessToken?.data?.streamPlaybackAccessToken || accessToken?.streamPlaybackAccessToken;
+                                if (!spat) {
+                                    console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + realPlayerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})));
                                     continue;
                                 }
                                 const urlInfo = new URL('https://usher.ttvnw.net/api/' + (V2API ? 'v2/' : '') + 'channel/hls/' + streamInfo.ChannelName + '.m3u8' + streamInfo.UsherParams);
-                                urlInfo.searchParams.set('sig', accessToken.data.streamPlaybackAccessToken.signature);
-                                urlInfo.searchParams.set('token', accessToken.data.streamPlaybackAccessToken.value);
+                                urlInfo.searchParams.set('sig', spat.signature);
+                                urlInfo.searchParams.set('token', spat.value);
                                 const encodingsM3u8Response = await realFetch(urlInfo.href);
                                 if (encodingsM3u8Response.status === 200) {
                                     encodingsM3u8 = streamInfo.BackupEncodingsM3U8Cache[playerType] = await encodingsM3u8Response.text();

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1044,13 +1044,18 @@
                             const accessTokenResponse = await getAccessToken(streamInfo.ChannelName, realPlayerType);
                             if (accessTokenResponse.status === 200) {
                                 const accessToken = await accessTokenResponse.json();
-                                if (!accessToken?.data?.streamPlaybackAccessToken) {
-                                    console.log('[AD DEBUG] GQL response format changed — missing data.streamPlaybackAccessToken for ' + realPlayerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken?.data || accessToken || {})));
+                                // Twitch returns streamPlaybackAccessToken in two observed shapes:
+                                //   { data: { streamPlaybackAccessToken: {...} } } (most player types)
+                                //   { streamPlaybackAccessToken: {...} } (flatter, observed for 'embed')
+                                // Accept either. Field-observed silently dropping embed backup otherwise.
+                                const spat = accessToken?.data?.streamPlaybackAccessToken || accessToken?.streamPlaybackAccessToken;
+                                if (!spat) {
+                                    console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + realPlayerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})));
                                     continue;
                                 }
                                 const urlInfo = new URL('https://usher.ttvnw.net/api/' + (V2API ? 'v2/' : '') + 'channel/hls/' + streamInfo.ChannelName + '.m3u8' + streamInfo.UsherParams);
-                                urlInfo.searchParams.set('sig', accessToken.data.streamPlaybackAccessToken.signature);
-                                urlInfo.searchParams.set('token', accessToken.data.streamPlaybackAccessToken.value);
+                                urlInfo.searchParams.set('sig', spat.signature);
+                                urlInfo.searchParams.set('token', spat.value);
                                 const encodingsM3u8Response = await realFetch(urlInfo.href);
                                 if (encodingsM3u8Response.status === 200) {
                                     encodingsM3u8 = streamInfo.BackupEncodingsM3U8Cache[playerType] = await encodingsM3u8Response.text();

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -437,13 +437,18 @@ twitch-videoad.js text/javascript
                     }
                     if (accessTokenResponse != null && accessTokenResponse.status === 200) {
                         const accessToken = await accessTokenResponse.json();
-                        if (!accessToken?.data?.streamPlaybackAccessToken) {
-                            console.log('[AD DEBUG] GQL response format changed — missing data.streamPlaybackAccessToken for ' + playerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken?.data || accessToken || {})));
+                        // Twitch returns streamPlaybackAccessToken in two observed shapes:
+                        //   { data: { streamPlaybackAccessToken: {...} } } (most player types)
+                        //   { streamPlaybackAccessToken: {...} } (flatter, observed for 'embed')
+                        // Accept either. Field-observed silently dropping embed backup otherwise.
+                        const spat = accessToken?.data?.streamPlaybackAccessToken || accessToken?.streamPlaybackAccessToken;
+                        if (!spat) {
+                            console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + playerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})));
                             continue;
                         }
                         const urlInfo = new URL('https://usher.ttvnw.net/api/' + (V2API ? 'v2/' : '') + 'channel/hls/' + streamInfo.ChannelName + '.m3u8' + streamInfo.UsherParams);
-                        urlInfo.searchParams.set('sig', accessToken.data.streamPlaybackAccessToken.signature);
-                        urlInfo.searchParams.set('token', accessToken.data.streamPlaybackAccessToken.value);
+                        urlInfo.searchParams.set('sig', spat.signature);
+                        urlInfo.searchParams.set('token', spat.value);
                         const encodingsM3u8Response = await realFetch(urlInfo.href);
                         if (encodingsM3u8Response != null && encodingsM3u8Response.status !== 200) {
                             console.log('[AD DEBUG] Usher HTTP ' + encodingsM3u8Response.status + ' for ' + playerType);

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -449,13 +449,18 @@
                     }
                     if (accessTokenResponse != null && accessTokenResponse.status === 200) {
                         const accessToken = await accessTokenResponse.json();
-                        if (!accessToken?.data?.streamPlaybackAccessToken) {
-                            console.log('[AD DEBUG] GQL response format changed — missing data.streamPlaybackAccessToken for ' + playerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken?.data || accessToken || {})));
+                        // Twitch returns streamPlaybackAccessToken in two observed shapes:
+                        //   { data: { streamPlaybackAccessToken: {...} } } (most player types)
+                        //   { streamPlaybackAccessToken: {...} } (flatter, observed for 'embed')
+                        // Accept either. Field-observed silently dropping embed backup otherwise.
+                        const spat = accessToken?.data?.streamPlaybackAccessToken || accessToken?.streamPlaybackAccessToken;
+                        if (!spat) {
+                            console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + playerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})));
                             continue;
                         }
                         const urlInfo = new URL('https://usher.ttvnw.net/api/' + (V2API ? 'v2/' : '') + 'channel/hls/' + streamInfo.ChannelName + '.m3u8' + streamInfo.UsherParams);
-                        urlInfo.searchParams.set('sig', accessToken.data.streamPlaybackAccessToken.signature);
-                        urlInfo.searchParams.set('token', accessToken.data.streamPlaybackAccessToken.value);
+                        urlInfo.searchParams.set('sig', spat.signature);
+                        urlInfo.searchParams.set('token', spat.value);
                         const encodingsM3u8Response = await realFetch(urlInfo.href);
                         if (encodingsM3u8Response != null && encodingsM3u8Response.status !== 200) {
                             console.log('[AD DEBUG] Usher HTTP ' + encodingsM3u8Response.status + ' for ' + playerType);


### PR DESCRIPTION
## Summary

Field observation during BackupSwapFirst (PR #168) testing on channel `warn`:

```
[AD DEBUG] GQL response format changed — missing data.streamPlaybackAccessToken for embed.
Response keys: ["streamPlaybackAccessToken"]
```

Twitch's GQL response for the `embed` player type returns `streamPlaybackAccessToken` at the **root** of the response, not inside `.data`. Other player types wrap it in `.data`. Our code only checked `accessToken.data.streamPlaybackAccessToken`, so embed was silently dropped as a backup option — code fell through to `site` (which worked).

## Latent bug surfaced by BackupSwapFirst

Previously this bug was less noticeable because embed is probed only when the escape hatch fires (`PreferLowQualityBackup` enabled + stuck for 8s+). PR #168's backup-swap-first iterates all backup types on **every** ad detect, so any player type with a divergent response shape becomes visible.

## Fix

Accept either response shape:
- `{ data: { streamPlaybackAccessToken: {...} } }` (most player types)
- `{ streamPlaybackAccessToken: {...} }` (flatter, observed for `embed`)

```diff
- if (!accessToken?.data?.streamPlaybackAccessToken) {
-     console.log('[AD DEBUG] GQL response format changed — missing ...');
-     continue;
- }
- urlInfo.searchParams.set('sig', accessToken.data.streamPlaybackAccessToken.signature);
- urlInfo.searchParams.set('token', accessToken.data.streamPlaybackAccessToken.value);
+ const spat = accessToken?.data?.streamPlaybackAccessToken || accessToken?.streamPlaybackAccessToken;
+ if (!spat) {
+     console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken ...');
+     continue;
+ }
+ urlInfo.searchParams.set('sig', spat.signature);
+ urlInfo.searchParams.set('token', spat.value);
```

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js` + `video-swap-new/video-swap-new-ublock-origin.js`

Testing variants landed as commit `25d3bdd`.

## Test plan

- [ ] Enable `twitchAdSolutions_backupSwapFirst=true` and verify embed is no longer silently skipped (no more "GQL response format changed — missing data.streamPlaybackAccessToken for embed" log)
- [ ] Verify other player types (site, popout, mobile_web) continue to work — their `.data.streamPlaybackAccessToken` path still resolves first
- [ ] If a response ever arrives with neither shape, the log still fires with "GQL response missing" and falls through cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)