### PR TITLE
log GraphQL errors field in access-token diagnostic

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1025,7 +1025,8 @@ twitch-videoad.js text/javascript
                                 // Accept either. Field-observed silently dropping embed backup otherwise.
                                 const spat = accessToken?.data?.streamPlaybackAccessToken || accessToken?.streamPlaybackAccessToken;
                                 if (!spat) {
-                                    console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + realPlayerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})));
+                                    const errInfo = accessToken?.errors ? ' errors: ' + JSON.stringify(accessToken.errors).substring(0, 300) : '';
+                                    console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + realPlayerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})) + errInfo);
                                     continue;
                                 }
                                 const urlInfo = new URL('https://usher.ttvnw.net/api/' + (V2API ? 'v2/' : '') + 'channel/hls/' + streamInfo.ChannelName + '.m3u8' + streamInfo.UsherParams);

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1057,7 +1057,8 @@
                                 // Accept either. Field-observed silently dropping embed backup otherwise.
                                 const spat = accessToken?.data?.streamPlaybackAccessToken || accessToken?.streamPlaybackAccessToken;
                                 if (!spat) {
-                                    console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + realPlayerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})));
+                                    const errInfo = accessToken?.errors ? ' errors: ' + JSON.stringify(accessToken.errors).substring(0, 300) : '';
+                                    console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + realPlayerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})) + errInfo);
                                     continue;
                                 }
                                 const urlInfo = new URL('https://usher.ttvnw.net/api/' + (V2API ? 'v2/' : '') + 'channel/hls/' + streamInfo.ChannelName + '.m3u8' + streamInfo.UsherParams);

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -443,7 +443,8 @@ twitch-videoad.js text/javascript
                         // Accept either. Field-observed silently dropping embed backup otherwise.
                         const spat = accessToken?.data?.streamPlaybackAccessToken || accessToken?.streamPlaybackAccessToken;
                         if (!spat) {
-                            console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + playerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})));
+                            const errInfo = accessToken?.errors ? ' errors: ' + JSON.stringify(accessToken.errors).substring(0, 300) : '';
+                            console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + playerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})) + errInfo);
                             continue;
                         }
                         const urlInfo = new URL('https://usher.ttvnw.net/api/' + (V2API ? 'v2/' : '') + 'channel/hls/' + streamInfo.ChannelName + '.m3u8' + streamInfo.UsherParams);

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -455,7 +455,8 @@
                         // Accept either. Field-observed silently dropping embed backup otherwise.
                         const spat = accessToken?.data?.streamPlaybackAccessToken || accessToken?.streamPlaybackAccessToken;
                         if (!spat) {
-                            console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + playerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})));
+                            const errInfo = accessToken?.errors ? ' errors: ' + JSON.stringify(accessToken.errors).substring(0, 300) : '';
+                            console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + playerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})) + errInfo);
                             continue;
                         }
                         const urlInfo = new URL('https://usher.ttvnw.net/api/' + (V2API ? 'v2/' : '') + 'channel/hls/' + streamInfo.ChannelName + '.m3u8' + streamInfo.UsherParams);


### PR DESCRIPTION
## Summary

Enhance the access-token diagnostic log to include the GraphQL `errors` field content when streamPlaybackAccessToken is missing. Helps diagnose player-type specific failures like the recently observed embed failure.

Depends on / stacked after PR #169 (accept both streamPlaybackAccessToken shapes) — this PR adds error context to that same diagnostic log path.

## Background

Field log on `warn` channel showed:
```
[AD DEBUG] GQL response missing streamPlaybackAccessToken for embed. Response keys: ["errors","data","extensions"]
```

Standard GraphQL response shape with `errors` populated — embed's GQL query was **failing on Twitch's side**, not returning a different response shape. The old log only showed top-level keys, giving no insight into why Twitch rejected the request.

## Fix

Log the `errors` field when present, truncated to 300 chars:

```diff
  if (!spat) {
+     const errInfo = accessToken?.errors ? ' errors: ' + JSON.stringify(accessToken.errors).substring(0, 300) : '';
      console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' +
-         realPlayerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})));
+         realPlayerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})) + errInfo);
      continue;
  }
```

Example enhanced log:
```
[AD DEBUG] GQL response missing streamPlaybackAccessToken for embed.
Response keys: ["errors","data","extensions"]
errors: [{"message":"service error","path":["streamPlaybackAccessToken"]}]
```

Will tell us whether embed failures are:
- Missing integrity header
- Rate-limiting
- Channel-specific embed block
- Something else

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js` + `video-swap-new/video-swap-new-ublock-origin.js`

Testing variants landed as commit `b1c008d`.

## Dependencies

Stacked on PR #169. If #169 merges first, this rebases cleanly. If this merges first, #169 needs a trivial resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)