### PR TITLE
reorder BackupPlayerTypes to put embed last + update FallbackPlayerType

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -45,16 +45,20 @@ twitch-videoad.js text/javascript
         scope.UriAttributeRegex = /URI="([^"]+)"/;
         scope.ClientID = 'kimne78kx3ncx6brgo4mv6wki5h1ko';
         scope.BackupPlayerTypes = [
-            'embed',//Source
+            // Order matters: first clean type wins. 'embed' moved to end — field-observed
+            // Twitch returns GQL 'server error' for streamPlaybackAccessToken on embed when
+            // requested from twitch.tv origin, wasting ~200-400ms per break as first-try.
+            // Kept in case it ever succeeds on some channel/user combo.
             'site',//Source
             'popout',//Source
             'mobile_web',//Mobile
+            'embed',//Source (unreliable — see note above)
             // 'autoplay' (360p) removed: when committed as cycle backup, the player gets stuck
             // in an endless loading circle after the CSAI-only path releases the backup —
             // autoplay variants don't transition cleanly back to main stream variants.
             //'picture-by-picture-CACHED'//360p (-CACHED is an internal suffix and is removed)
         ];
-        scope.FallbackPlayerType = 'embed';
+        scope.FallbackPlayerType = 'site';// was 'embed' — site is more reliable when all Source types end up ad-laden
         scope.ForceAccessTokenPlayerType = 'popout';
         scope.PreferLowQualityBackup = true;// Hybrid safety net for SSAI-heavy breaks: sticky escape hatch (fires after ~8s stuck in all-stripped state) + autoplay (360p) as last-resort backup when all Source types are ad-laden. Default on; set twitchAdSolutions_preferLowQualityBackup=false to disable.
         scope.SkipPlayerReloadOnHevc = false;// If true this will skip player reload on streams which have 2k/4k quality (if you enable this and you use the 2k/4k quality setting you'll get error #4000 / #3000 / spinning wheel on chrome based browsers)

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -55,16 +55,20 @@
         scope.UriAttributeRegex = /URI="([^"]+)"/;
         scope.ClientID = 'kimne78kx3ncx6brgo4mv6wki5h1ko';
         scope.BackupPlayerTypes = [
-            'embed',//Source
+            // Order matters: first clean type wins. 'embed' moved to end — field-observed
+            // Twitch returns GQL 'server error' for streamPlaybackAccessToken on embed when
+            // requested from twitch.tv origin, wasting ~200-400ms per break as first-try.
+            // Kept in case it ever succeeds on some channel/user combo.
             'site',//Source
             'popout',//Source
             'mobile_web',//Mobile
+            'embed',//Source (unreliable — see note above)
             // 'autoplay' (360p) removed: when committed as cycle backup, the player gets stuck
             // in an endless loading circle after the CSAI-only path releases the backup —
             // autoplay variants don't transition cleanly back to main stream variants.
             //'picture-by-picture-CACHED'//360p (-CACHED is an internal suffix and is removed)
         ];
-        scope.FallbackPlayerType = 'embed';
+        scope.FallbackPlayerType = 'site';// was 'embed' — site is more reliable when all Source types end up ad-laden
         scope.ForceAccessTokenPlayerType = 'popout';
         scope.PreferLowQualityBackup = true;// Hybrid safety net for SSAI-heavy breaks: sticky escape hatch (fires after ~8s stuck in all-stripped state) + autoplay (360p) as last-resort backup when all Source types are ad-laden. Default on; set twitchAdSolutions_preferLowQualityBackup=false to disable.
         scope.SkipPlayerReloadOnHevc = false;// If true this will skip player reload on streams which have 2k/4k quality (if you enable this and you use the 2k/4k quality setting you'll get error #4000 / #3000 / spinning wheel on chrome based browsers)

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -33,7 +33,9 @@ twitch-videoad.js text/javascript
     window.twitchAdSolutionsVersion = ourTwitchAdSolutionsVersion;
     function declareOptions(scope) {
         // Options / globals
-        scope.OPT_BACKUP_PLAYER_TYPES = [ 'embed', 'popout', 'mobile_web' ];
+        // 'embed' moved to end — field-observed Twitch returns GQL 'server error' for
+        // streamPlaybackAccessToken on embed when requested from twitch.tv origin.
+        scope.OPT_BACKUP_PLAYER_TYPES = [ 'popout', 'mobile_web', 'embed' ];
         scope.OPT_FORCE_ACCESS_TOKEN_PLAYER_TYPE = 'popout';
         scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
         scope.AD_SEGMENT_URL_PATTERNS = ['/adsquared/', '/_404/', '/processing'];

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -44,7 +44,9 @@
     window.twitchAdSolutionsVersion = ourTwitchAdSolutionsVersion;
     function declareOptions(scope) {
         // Options / globals
-        scope.OPT_BACKUP_PLAYER_TYPES = [ 'embed', 'popout', 'mobile_web' ];
+        // 'embed' moved to end — field-observed Twitch returns GQL 'server error' for
+        // streamPlaybackAccessToken on embed when requested from twitch.tv origin.
+        scope.OPT_BACKUP_PLAYER_TYPES = [ 'popout', 'mobile_web', 'embed' ];
         scope.OPT_FORCE_ACCESS_TOKEN_PLAYER_TYPE = 'popout';
         scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
         scope.AD_SEGMENT_URL_PATTERNS = ['/adsquared/', '/_404/', '/processing'];


### PR DESCRIPTION
## Summary

PR #170's enhanced diagnostic confirmed what field tests were hinting at:

```
[AD DEBUG] GQL response missing streamPlaybackAccessToken for embed.
Response keys: ["errors","data","extensions"]
errors: [{"message":"server error","path":["streamPlaybackAccessToken"]}]
```

Twitch's GraphQL consistently returns `"server error"` for the `streamPlaybackAccessToken` field on the `embed` player type when requested from twitch.tv origin. Observed across multiple channels (`warn`, `winton_ow2`). Likely because embed player-type is only valid from embed.twitch.tv origin, or has an integrity-header requirement we don't meet.

With embed as our first-try backup, we waste ~200-400ms per ad break on every failed token fetch before falling through to `site`.

## Changes

**1. `BackupPlayerTypes`: reorder so embed is last**
```diff
  scope.BackupPlayerTypes = [
-     'embed',   //Source
      'site',    //Source
      'popout',  //Source
      'mobile_web', //Mobile
+     'embed',   //Source (unreliable — see note)
  ];
```

Kept as an option in case embed ever succeeds in some channel/user combo. Cost of keeping it last is minimal (only tried if all three Source types ad-laden).

**2. `FallbackPlayerType`: 'embed' → 'site'**
```diff
- scope.FallbackPlayerType = 'embed';
+ scope.FallbackPlayerType = 'site';
```

The fallback is the m3u8 used as last-resort when all player types turned out ad-laden. embed being unreliable means this fallback was broken in practice. site is more dependable.

## Benefit

- Faster backup commit on channels where embed fails (saves ~200-400ms per break)
- Fallback m3u8 actually available when needed (site instead of failed embed)
- Significant win with BackupSwapFirst (PR #168) enabled since we try all backups on every break

## Scope

- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js` (both changes)
- `video-swap-new/video-swap-new.user.js` + `video-swap-new/video-swap-new-ublock-origin.js` (reorder only; no FallbackPlayerType concept in vsn)

Testing variants landed as commit `d89e2c0`.

## Test plan

- [ ] Verify first-try backup is now `site` instead of `embed` in field logs (`Blocking midroll ads (site) — backup found in Nms`)
- [ ] Verify embed is still tried last — if all other Source types fail, embed would still be attempted
- [ ] Verify no regression in channels where embed previously worked (if any)

🤖 Generated with [Claude Code](https://claude.com/claude-code)