### PR TITLE
preserve lowLatencyModeEnabled + persistenceEnabled across reloads

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1850,13 +1850,19 @@ twitch-videoad.js text/javascript
             const lsKeyQuality = 'video-quality';
             const lsKeyMuted = 'video-muted';
             const lsKeyVolume = 'volume';
+            const lsKeyLowLatency = 'lowLatencyModeEnabled';// Preserve user's low-latency toggle across reloads (TTV-AB parity)
+            const lsKeyPersistence = 'persistenceEnabled';// Preserve autoplay/persistence toggle across reloads (TTV-AB parity)
             let currentQualityLS = null;
             let currentMutedLS = null;
             let currentVolumeLS = null;
+            let currentLowLatencyLS = null;
+            let currentPersistenceLS = null;
             try {
                 currentQualityLS = localStorage.getItem(lsKeyQuality);
                 currentMutedLS = localStorage.getItem(lsKeyMuted);
                 currentVolumeLS = localStorage.getItem(lsKeyVolume);
+                currentLowLatencyLS = localStorage.getItem(lsKeyLowLatency);
+                currentPersistenceLS = localStorage.getItem(lsKeyPersistence);
                 if (localStorageHookFailed && player?.core?.state) {
                     localStorage.setItem(lsKeyMuted, JSON.stringify({default:player.core.state.muted}));
                     localStorage.setItem(lsKeyVolume, player.core.state.volume);
@@ -1891,6 +1897,12 @@ twitch-videoad.js text/javascript
                         }
                         if (currentVolumeLS) {
                             localStorage.setItem(lsKeyVolume, currentVolumeLS);
+                        }
+                        if (currentLowLatencyLS !== null) {
+                            localStorage.setItem(lsKeyLowLatency, currentLowLatencyLS);
+                        }
+                        if (currentPersistenceLS !== null) {
+                            localStorage.setItem(lsKeyPersistence, currentPersistenceLS);
                         }
                         const videos = document.getElementsByTagName('video');
                         // Respect user's mute intent: only force-unmute if LS didn't say mute.

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1886,13 +1886,19 @@
             const lsKeyQuality = 'video-quality';
             const lsKeyMuted = 'video-muted';
             const lsKeyVolume = 'volume';
+            const lsKeyLowLatency = 'lowLatencyModeEnabled';// Preserve user's low-latency toggle across reloads (TTV-AB parity)
+            const lsKeyPersistence = 'persistenceEnabled';// Preserve autoplay/persistence toggle across reloads (TTV-AB parity)
             let currentQualityLS = null;
             let currentMutedLS = null;
             let currentVolumeLS = null;
+            let currentLowLatencyLS = null;
+            let currentPersistenceLS = null;
             try {
                 currentQualityLS = localStorage.getItem(lsKeyQuality);
                 currentMutedLS = localStorage.getItem(lsKeyMuted);
                 currentVolumeLS = localStorage.getItem(lsKeyVolume);
+                currentLowLatencyLS = localStorage.getItem(lsKeyLowLatency);
+                currentPersistenceLS = localStorage.getItem(lsKeyPersistence);
                 if (localStorageHookFailed && player?.core?.state) {
                     localStorage.setItem(lsKeyMuted, JSON.stringify({default:player.core.state.muted}));
                     localStorage.setItem(lsKeyVolume, player.core.state.volume);
@@ -1927,6 +1933,12 @@
                         }
                         if (currentVolumeLS) {
                             localStorage.setItem(lsKeyVolume, currentVolumeLS);
+                        }
+                        if (currentLowLatencyLS !== null) {
+                            localStorage.setItem(lsKeyLowLatency, currentLowLatencyLS);
+                        }
+                        if (currentPersistenceLS !== null) {
+                            localStorage.setItem(lsKeyPersistence, currentPersistenceLS);
                         }
                         const videos = document.getElementsByTagName('video');
                         // Respect user's mute intent: only force-unmute if LS didn't say mute.

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -1302,13 +1302,19 @@ twitch-videoad.js text/javascript
         const lsKeyQuality = 'video-quality';
         const lsKeyMuted = 'video-muted';
         const lsKeyVolume = 'volume';
+        const lsKeyLowLatency = 'lowLatencyModeEnabled';// Preserve user's low-latency toggle across reloads (TTV-AB parity)
+        const lsKeyPersistence = 'persistenceEnabled';// Preserve autoplay/persistence toggle across reloads (TTV-AB parity)
         let currentQualityLS = null;
         let currentMutedLS = null;
         let currentVolumeLS = null;
+        let currentLowLatencyLS = null;
+        let currentPersistenceLS = null;
         try {
             currentQualityLS = localStorage.getItem(lsKeyQuality);
             currentMutedLS = localStorage.getItem(lsKeyMuted);
             currentVolumeLS = localStorage.getItem(lsKeyVolume);
+            currentLowLatencyLS = localStorage.getItem(lsKeyLowLatency);
+            currentPersistenceLS = localStorage.getItem(lsKeyPersistence);
             if (localStorageHookFailed && player?.core?.state) {
                 localStorage.setItem(lsKeyMuted, JSON.stringify({default:player.core.state.muted}));
                 localStorage.setItem(lsKeyVolume, player.core.state.volume);
@@ -1333,6 +1339,12 @@ twitch-videoad.js text/javascript
                     }
                     if (currentVolumeLS) {
                         localStorage.setItem(lsKeyVolume, currentVolumeLS);
+                    }
+                    if (currentLowLatencyLS !== null) {
+                        localStorage.setItem(lsKeyLowLatency, currentLowLatencyLS);
+                    }
+                    if (currentPersistenceLS !== null) {
+                        localStorage.setItem(lsKeyPersistence, currentPersistenceLS);
                     }
                     const videos = document.getElementsByTagName('video');
                     // Respect user's mute intent: only force-unmute if LS didn't say mute.

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -1318,13 +1318,19 @@
         const lsKeyQuality = 'video-quality';
         const lsKeyMuted = 'video-muted';
         const lsKeyVolume = 'volume';
+        const lsKeyLowLatency = 'lowLatencyModeEnabled';// Preserve user's low-latency toggle across reloads (TTV-AB parity)
+        const lsKeyPersistence = 'persistenceEnabled';// Preserve autoplay/persistence toggle across reloads (TTV-AB parity)
         let currentQualityLS = null;
         let currentMutedLS = null;
         let currentVolumeLS = null;
+        let currentLowLatencyLS = null;
+        let currentPersistenceLS = null;
         try {
             currentQualityLS = localStorage.getItem(lsKeyQuality);
             currentMutedLS = localStorage.getItem(lsKeyMuted);
             currentVolumeLS = localStorage.getItem(lsKeyVolume);
+            currentLowLatencyLS = localStorage.getItem(lsKeyLowLatency);
+            currentPersistenceLS = localStorage.getItem(lsKeyPersistence);
             if (localStorageHookFailed && player?.core?.state) {
                 localStorage.setItem(lsKeyMuted, JSON.stringify({default:player.core.state.muted}));
                 localStorage.setItem(lsKeyVolume, player.core.state.volume);
@@ -1349,6 +1355,12 @@
                     }
                     if (currentVolumeLS) {
                         localStorage.setItem(lsKeyVolume, currentVolumeLS);
+                    }
+                    if (currentLowLatencyLS !== null) {
+                        localStorage.setItem(lsKeyLowLatency, currentLowLatencyLS);
+                    }
+                    if (currentPersistenceLS !== null) {
+                        localStorage.setItem(lsKeyPersistence, currentPersistenceLS);
                     }
                     const videos = document.getElementsByTagName('video');
                     // Respect user's mute intent: only force-unmute if LS didn't say mute.


### PR DESCRIPTION
## Summary

Port TTV-AB's `_PLAYER_PREFERENCE_KEYS` coverage for `lowLatencyModeEnabled` and `persistenceEnabled`. We already preserve `video-quality`, `video-muted`, and `volume` across reloads — this extends the same capture/restore pattern to these two keys so our reload path doesn't silently clobber them.

## Motivation

User reported occasional "Is video buffering? Use the Low Latency toggle..." popup after ad-break reloads. That popup is driven by Twitch's player-side buffer heuristic (not LS), so this change is **unlikely to directly suppress it** — but it's defensive parity with TTV-AB and guards against any edge case where our reload clobbers the user's low-latency setting.

- TTV-AB reference: `_PLAYER_PREFERENCE_KEYS` includes both keys in the extension's reload-across-state preservation list
- Capture happens in the same block that already snapshots quality/muted/volume
- Restore runs inside the existing `setTimeout` restore block
- Guarded with `!== null` (LS returns `null` for missing keys)

## Scope

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js`
- `video-swap-new/video-swap-new-ublock-origin.js`

Testing variants already landed direct to master as commit `0d6258e`.

## Test plan
- [x] Validated all 4 files with `npx acorn --ecma2022`
- [x] Testing variants field-tested (low-latency toggle survived multiple ad-break reloads)
- [ ] Post-merge field test on release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)