### PR TITLE
refactor: array-driven LS preservation snapshot

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1847,28 +1847,20 @@ twitch-videoad.js text/javascript
             }
         }
         if (isReload) {
-            const lsKeyQuality = 'video-quality';
-            const lsKeyMuted = 'video-muted';
-            const lsKeyVolume = 'volume';
-            const lsKeyLowLatency = 'lowLatencyModeEnabled';// Preserve user's low-latency toggle across reloads (TTV-AB parity)
-            const lsKeyPersistence = 'persistenceEnabled';// Preserve autoplay/persistence toggle across reloads (TTV-AB parity)
-            let currentQualityLS = null;
-            let currentMutedLS = null;
-            let currentVolumeLS = null;
-            let currentLowLatencyLS = null;
-            let currentPersistenceLS = null;
+            // Snapshot player preference LS keys before reload; restored in setTimeout below.
+            // Mirrors TTV-AB's _PLAYER_PREFERENCE_KEYS coverage.
+            const PRESERVED_LS_KEYS = ['video-quality', 'video-muted', 'volume', 'lowLatencyModeEnabled', 'persistenceEnabled'];
+            const lsSnapshot = {};
             try {
-                currentQualityLS = localStorage.getItem(lsKeyQuality);
-                currentMutedLS = localStorage.getItem(lsKeyMuted);
-                currentVolumeLS = localStorage.getItem(lsKeyVolume);
-                currentLowLatencyLS = localStorage.getItem(lsKeyLowLatency);
-                currentPersistenceLS = localStorage.getItem(lsKeyPersistence);
+                for (const k of PRESERVED_LS_KEYS) {
+                    lsSnapshot[k] = localStorage.getItem(k);
+                }
                 if (localStorageHookFailed && player?.core?.state) {
-                    localStorage.setItem(lsKeyMuted, JSON.stringify({default:player.core.state.muted}));
-                    localStorage.setItem(lsKeyVolume, player.core.state.volume);
+                    localStorage.setItem('video-muted', JSON.stringify({default:player.core.state.muted}));
+                    localStorage.setItem('volume', player.core.state.volume);
                 }
                 if (player?.core?.state?.quality?.group) {
-                    localStorage.setItem(lsKeyQuality, JSON.stringify({default:player.core.state.quality.group}));
+                    localStorage.setItem('video-quality', JSON.stringify({default:player.core.state.quality.group}));
                 }
             } catch {}
             playerBufferState.lastReloadAt = Date.now();
@@ -1889,26 +1881,16 @@ twitch-videoad.js text/javascript
             {
                 setTimeout(() => {
                     try {
-                        if (currentQualityLS) {
-                            localStorage.setItem(lsKeyQuality, currentQualityLS);
-                        }
-                        if (currentMutedLS) {
-                            localStorage.setItem(lsKeyMuted, currentMutedLS);
-                        }
-                        if (currentVolumeLS) {
-                            localStorage.setItem(lsKeyVolume, currentVolumeLS);
-                        }
-                        if (currentLowLatencyLS !== null) {
-                            localStorage.setItem(lsKeyLowLatency, currentLowLatencyLS);
-                        }
-                        if (currentPersistenceLS !== null) {
-                            localStorage.setItem(lsKeyPersistence, currentPersistenceLS);
+                        for (const [k, v] of Object.entries(lsSnapshot)) {
+                            if (v !== null) {
+                                localStorage.setItem(k, v);
+                            }
                         }
                         const videos = document.getElementsByTagName('video');
                         // Respect user's mute intent: only force-unmute if LS didn't say mute.
                         // Twitch writes video-muted as '{"default":true}' when user muted via UI;
                         // Chrome autoplay policy can mute even if user didn't (no LS signal).
-                        const userIntendedMute = currentMutedLS && currentMutedLS.includes('"default":true');
+                        const userIntendedMute = lsSnapshot['video-muted']?.includes('"default":true');
                         if (videos.length > 0 && videos[0].muted && !userIntendedMute) {
                             videos[0].muted = false;
                         }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1883,28 +1883,20 @@
             }
         }
         if (isReload) {
-            const lsKeyQuality = 'video-quality';
-            const lsKeyMuted = 'video-muted';
-            const lsKeyVolume = 'volume';
-            const lsKeyLowLatency = 'lowLatencyModeEnabled';// Preserve user's low-latency toggle across reloads (TTV-AB parity)
-            const lsKeyPersistence = 'persistenceEnabled';// Preserve autoplay/persistence toggle across reloads (TTV-AB parity)
-            let currentQualityLS = null;
-            let currentMutedLS = null;
-            let currentVolumeLS = null;
-            let currentLowLatencyLS = null;
-            let currentPersistenceLS = null;
+            // Snapshot player preference LS keys before reload; restored in setTimeout below.
+            // Mirrors TTV-AB's _PLAYER_PREFERENCE_KEYS coverage.
+            const PRESERVED_LS_KEYS = ['video-quality', 'video-muted', 'volume', 'lowLatencyModeEnabled', 'persistenceEnabled'];
+            const lsSnapshot = {};
             try {
-                currentQualityLS = localStorage.getItem(lsKeyQuality);
-                currentMutedLS = localStorage.getItem(lsKeyMuted);
-                currentVolumeLS = localStorage.getItem(lsKeyVolume);
-                currentLowLatencyLS = localStorage.getItem(lsKeyLowLatency);
-                currentPersistenceLS = localStorage.getItem(lsKeyPersistence);
+                for (const k of PRESERVED_LS_KEYS) {
+                    lsSnapshot[k] = localStorage.getItem(k);
+                }
                 if (localStorageHookFailed && player?.core?.state) {
-                    localStorage.setItem(lsKeyMuted, JSON.stringify({default:player.core.state.muted}));
-                    localStorage.setItem(lsKeyVolume, player.core.state.volume);
+                    localStorage.setItem('video-muted', JSON.stringify({default:player.core.state.muted}));
+                    localStorage.setItem('volume', player.core.state.volume);
                 }
                 if (player?.core?.state?.quality?.group) {
-                    localStorage.setItem(lsKeyQuality, JSON.stringify({default:player.core.state.quality.group}));
+                    localStorage.setItem('video-quality', JSON.stringify({default:player.core.state.quality.group}));
                 }
             } catch {}
             playerBufferState.lastReloadAt = Date.now();
@@ -1925,26 +1917,16 @@
             {
                 setTimeout(() => {
                     try {
-                        if (currentQualityLS) {
-                            localStorage.setItem(lsKeyQuality, currentQualityLS);
-                        }
-                        if (currentMutedLS) {
-                            localStorage.setItem(lsKeyMuted, currentMutedLS);
-                        }
-                        if (currentVolumeLS) {
-                            localStorage.setItem(lsKeyVolume, currentVolumeLS);
-                        }
-                        if (currentLowLatencyLS !== null) {
-                            localStorage.setItem(lsKeyLowLatency, currentLowLatencyLS);
-                        }
-                        if (currentPersistenceLS !== null) {
-                            localStorage.setItem(lsKeyPersistence, currentPersistenceLS);
+                        for (const [k, v] of Object.entries(lsSnapshot)) {
+                            if (v !== null) {
+                                localStorage.setItem(k, v);
+                            }
                         }
                         const videos = document.getElementsByTagName('video');
                         // Respect user's mute intent: only force-unmute if LS didn't say mute.
                         // Twitch writes video-muted as '{"default":true}' when user muted via UI;
                         // Chrome autoplay policy can mute even if user didn't (no LS signal).
-                        const userIntendedMute = currentMutedLS && currentMutedLS.includes('"default":true');
+                        const userIntendedMute = lsSnapshot['video-muted']?.includes('"default":true');
                         if (videos.length > 0 && videos[0].muted && !userIntendedMute) {
                             videos[0].muted = false;
                         }

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -1299,28 +1299,20 @@ twitch-videoad.js text/javascript
             console.log('[AD DEBUG] Downgraded reload to pause/play to preserve PiP');
             return;
         }
-        const lsKeyQuality = 'video-quality';
-        const lsKeyMuted = 'video-muted';
-        const lsKeyVolume = 'volume';
-        const lsKeyLowLatency = 'lowLatencyModeEnabled';// Preserve user's low-latency toggle across reloads (TTV-AB parity)
-        const lsKeyPersistence = 'persistenceEnabled';// Preserve autoplay/persistence toggle across reloads (TTV-AB parity)
-        let currentQualityLS = null;
-        let currentMutedLS = null;
-        let currentVolumeLS = null;
-        let currentLowLatencyLS = null;
-        let currentPersistenceLS = null;
+        // Snapshot player preference LS keys before reload; restored in setTimeout below.
+        // Mirrors TTV-AB's _PLAYER_PREFERENCE_KEYS coverage.
+        const PRESERVED_LS_KEYS = ['video-quality', 'video-muted', 'volume', 'lowLatencyModeEnabled', 'persistenceEnabled'];
+        const lsSnapshot = {};
         try {
-            currentQualityLS = localStorage.getItem(lsKeyQuality);
-            currentMutedLS = localStorage.getItem(lsKeyMuted);
-            currentVolumeLS = localStorage.getItem(lsKeyVolume);
-            currentLowLatencyLS = localStorage.getItem(lsKeyLowLatency);
-            currentPersistenceLS = localStorage.getItem(lsKeyPersistence);
+            for (const k of PRESERVED_LS_KEYS) {
+                lsSnapshot[k] = localStorage.getItem(k);
+            }
             if (localStorageHookFailed && player?.core?.state) {
-                localStorage.setItem(lsKeyMuted, JSON.stringify({default:player.core.state.muted}));
-                localStorage.setItem(lsKeyVolume, player.core.state.volume);
+                localStorage.setItem('video-muted', JSON.stringify({default:player.core.state.muted}));
+                localStorage.setItem('volume', player.core.state.volume);
             }
             if (player?.core?.state?.quality?.group) {
-                localStorage.setItem(lsKeyQuality, JSON.stringify({default:player.core.state.quality.group}));
+                localStorage.setItem('video-quality', JSON.stringify({default:player.core.state.quality.group}));
             }
         } catch {}
         playerState.setSrc({ isNewMediaPlayerInstance: true, refreshAccessToken: true });
@@ -1331,26 +1323,16 @@ twitch-videoad.js text/javascript
         {
             setTimeout(() => {
                 try {
-                    if (currentQualityLS) {
-                        localStorage.setItem(lsKeyQuality, currentQualityLS);
-                    }
-                    if (currentMutedLS) {
-                        localStorage.setItem(lsKeyMuted, currentMutedLS);
-                    }
-                    if (currentVolumeLS) {
-                        localStorage.setItem(lsKeyVolume, currentVolumeLS);
-                    }
-                    if (currentLowLatencyLS !== null) {
-                        localStorage.setItem(lsKeyLowLatency, currentLowLatencyLS);
-                    }
-                    if (currentPersistenceLS !== null) {
-                        localStorage.setItem(lsKeyPersistence, currentPersistenceLS);
+                    for (const [k, v] of Object.entries(lsSnapshot)) {
+                        if (v !== null) {
+                            localStorage.setItem(k, v);
+                        }
                     }
                     const videos = document.getElementsByTagName('video');
                     // Respect user's mute intent: only force-unmute if LS didn't say mute.
                     // Twitch writes video-muted as '{"default":true}' when user muted via UI;
                     // Chrome autoplay policy can mute even if user didn't (no LS signal).
-                    const userIntendedMute = currentMutedLS && currentMutedLS.includes('"default":true');
+                    const userIntendedMute = lsSnapshot['video-muted']?.includes('"default":true');
                     if (videos.length > 0 && videos[0].muted && !userIntendedMute) {
                         videos[0].muted = false;
                     }

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -1315,28 +1315,20 @@
             console.log('[AD DEBUG] Downgraded reload to pause/play to preserve PiP');
             return;
         }
-        const lsKeyQuality = 'video-quality';
-        const lsKeyMuted = 'video-muted';
-        const lsKeyVolume = 'volume';
-        const lsKeyLowLatency = 'lowLatencyModeEnabled';// Preserve user's low-latency toggle across reloads (TTV-AB parity)
-        const lsKeyPersistence = 'persistenceEnabled';// Preserve autoplay/persistence toggle across reloads (TTV-AB parity)
-        let currentQualityLS = null;
-        let currentMutedLS = null;
-        let currentVolumeLS = null;
-        let currentLowLatencyLS = null;
-        let currentPersistenceLS = null;
+        // Snapshot player preference LS keys before reload; restored in setTimeout below.
+        // Mirrors TTV-AB's _PLAYER_PREFERENCE_KEYS coverage.
+        const PRESERVED_LS_KEYS = ['video-quality', 'video-muted', 'volume', 'lowLatencyModeEnabled', 'persistenceEnabled'];
+        const lsSnapshot = {};
         try {
-            currentQualityLS = localStorage.getItem(lsKeyQuality);
-            currentMutedLS = localStorage.getItem(lsKeyMuted);
-            currentVolumeLS = localStorage.getItem(lsKeyVolume);
-            currentLowLatencyLS = localStorage.getItem(lsKeyLowLatency);
-            currentPersistenceLS = localStorage.getItem(lsKeyPersistence);
+            for (const k of PRESERVED_LS_KEYS) {
+                lsSnapshot[k] = localStorage.getItem(k);
+            }
             if (localStorageHookFailed && player?.core?.state) {
-                localStorage.setItem(lsKeyMuted, JSON.stringify({default:player.core.state.muted}));
-                localStorage.setItem(lsKeyVolume, player.core.state.volume);
+                localStorage.setItem('video-muted', JSON.stringify({default:player.core.state.muted}));
+                localStorage.setItem('volume', player.core.state.volume);
             }
             if (player?.core?.state?.quality?.group) {
-                localStorage.setItem(lsKeyQuality, JSON.stringify({default:player.core.state.quality.group}));
+                localStorage.setItem('video-quality', JSON.stringify({default:player.core.state.quality.group}));
             }
         } catch {}
         playerState.setSrc({ isNewMediaPlayerInstance: true, refreshAccessToken: true });
@@ -1347,26 +1339,16 @@
         {
             setTimeout(() => {
                 try {
-                    if (currentQualityLS) {
-                        localStorage.setItem(lsKeyQuality, currentQualityLS);
-                    }
-                    if (currentMutedLS) {
-                        localStorage.setItem(lsKeyMuted, currentMutedLS);
-                    }
-                    if (currentVolumeLS) {
-                        localStorage.setItem(lsKeyVolume, currentVolumeLS);
-                    }
-                    if (currentLowLatencyLS !== null) {
-                        localStorage.setItem(lsKeyLowLatency, currentLowLatencyLS);
-                    }
-                    if (currentPersistenceLS !== null) {
-                        localStorage.setItem(lsKeyPersistence, currentPersistenceLS);
+                    for (const [k, v] of Object.entries(lsSnapshot)) {
+                        if (v !== null) {
+                            localStorage.setItem(k, v);
+                        }
                     }
                     const videos = document.getElementsByTagName('video');
                     // Respect user's mute intent: only force-unmute if LS didn't say mute.
                     // Twitch writes video-muted as '{"default":true}' when user muted via UI;
                     // Chrome autoplay policy can mute even if user didn't (no LS signal).
-                    const userIntendedMute = currentMutedLS && currentMutedLS.includes('"default":true');
+                    const userIntendedMute = lsSnapshot['video-muted']?.includes('"default":true');
                     if (videos.length > 0 && videos[0].muted && !userIntendedMute) {
                         videos[0].muted = false;
                     }


### PR DESCRIPTION
## Summary

Collapses the five paired `const lsKey…` + `let currentXLS` declarations and the five conditional restore blocks into a `PRESERVED_LS_KEYS` array + snapshot object with two `for` loops.

**Stacked on #172** — this branch targets `fix/preserve-lowlatency-persistence` as its base. If #172 merges first, GitHub will auto-retarget this to `master` with a clean 4-file diff. If this merges first, #172 becomes obsolete and can be closed (this PR contains the same end-state).

Testing variants landed as `c89f417` on master.

## Scope

4 release files, 60 insertions / 132 deletions:
- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js`
- `video-swap-new/video-swap-new-ublock-origin.js`

## Before / after shape

Capture:
```js
// BEFORE — 24 lines
const lsKeyQuality = 'video-quality';
const lsKeyMuted = 'video-muted';
// …3 more consts, 5 lets, 5 getItems…

// AFTER — 14 lines
const PRESERVED_LS_KEYS = ['video-quality', 'video-muted', 'volume', 'lowLatencyModeEnabled', 'persistenceEnabled'];
const lsSnapshot = {};
try {
    for (const k of PRESERVED_LS_KEYS) {
        lsSnapshot[k] = localStorage.getItem(k);
    }
```

Restore:
```js
// BEFORE — 17 lines of repeated if-setItem pairs
// AFTER — 5 lines:
for (const [k, v] of Object.entries(lsSnapshot)) {
    if (v !== null) {
        localStorage.setItem(k, v);
    }
}
```

## Safety review

Preserved behavior:
- **Mid-flow derived writes** (`localStorageHookFailed` branch + `player.core.state.quality.group` setter) untouched — they still synchronously write to LS between capture and reload so the new player instance reads them during init.
- **Restore timing** — same `setTimeout(…, 3000)`, same iteration order (Object.entries preserves insertion order; PRESERVED_LS_KEYS ordering matches prior capture order).
- **userIntendedMute** — now reads `lsSnapshot['video-muted']?.includes(…)`. Optional chaining on null returns undefined (falsy), identical to the old `mutedLS && mutedLS.includes(…)` form.

Semantic change:
- The old code used `if (currentXLS)` (truthy) for quality/muted/volume and `!== null` for the two new keys. Unified to `!== null`. This means an empty-string LS value (`""`) is now restored instead of silently skipped.
- Real-world impact is nil: Twitch writes these keys as JSON strings (`'{"default":"chunked"}'`, `'{"default":true}'`) or numeric strings (volume like `'0.5'`). Empty strings shouldn't exist outside of manual tampering.

Worker serialization: this block lives in `doTwitchPlayerTask`, which is **not** serialized into the worker blob. No `.toString()` constraints apply. ✓

## Test plan
- [x] `npx acorn --ecma2022` passes for all 4 files
- [x] Testing variants field-validated (c89f417 on master — low-latency / persistence toggles still survive reloads)
- [ ] Post-merge smoke test: trigger an ad-break reload, verify `localStorage.getItem('video-quality')` / `video-muted` / `volume` retain pre-reload values
- [ ] Verify force-unmute still respects user mute intent (muted before ad break stays muted after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)