### PR TITLE
perf: convert SERVER-TIME RegExp to regex literal

### DIFF
--- a/strip/strip.user.js
+++ b/strip/strip.user.js
@@ -275,7 +275,7 @@
         if (V2API) {
             return newServerTime ? encodingsM3u8.replace(/(#EXT-X-SESSION-DATA:DATA-ID="SERVER-TIME",VALUE=")[^"]+(")/, `$1${newServerTime}$2`) : encodingsM3u8;
         }
-        return newServerTime ? encodingsM3u8.replace(new RegExp('(SERVER-TIME=")[0-9.]+"'), `SERVER-TIME="${newServerTime}"`) : encodingsM3u8;
+        return newServerTime ? encodingsM3u8.replace(/(SERVER-TIME=")[0-9.]+"/, `SERVER-TIME="${newServerTime}"`) : encodingsM3u8;
     }
     function stripAdSegments(textStr, stripAllSegments) {
         let hasStrippedAdSegments = false;

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -944,7 +944,7 @@ twitch-videoad.js text/javascript
         if (V2API) {
             return newServerTime ? encodingsM3u8.replace(/(#EXT-X-SESSION-DATA:DATA-ID="SERVER-TIME",VALUE=")[^"]+(")/, `$1${newServerTime}$2`) : encodingsM3u8;
         }
-        return newServerTime ? encodingsM3u8.replace(new RegExp('(SERVER-TIME=")[0-9.]+"'), `SERVER-TIME="${newServerTime}"`) : encodingsM3u8;
+        return newServerTime ? encodingsM3u8.replace(/(SERVER-TIME=")[0-9.]+"/, `SERVER-TIME="${newServerTime}"`) : encodingsM3u8;
     }
     function getStreamUrlForResolution(encodingsM3u8, resolutionInfo) {
         const encodingsLines = encodingsM3u8.split(/\r?\n/);

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -958,7 +958,7 @@
         if (V2API) {
             return newServerTime ? encodingsM3u8.replace(/(#EXT-X-SESSION-DATA:DATA-ID="SERVER-TIME",VALUE=")[^"]+(")/, `$1${newServerTime}$2`) : encodingsM3u8;
         }
-        return newServerTime ? encodingsM3u8.replace(new RegExp('(SERVER-TIME=")[0-9.]+"'), `SERVER-TIME="${newServerTime}"`) : encodingsM3u8;
+        return newServerTime ? encodingsM3u8.replace(/(SERVER-TIME=")[0-9.]+"/, `SERVER-TIME="${newServerTime}"`) : encodingsM3u8;
     }
     function getStreamUrlForResolution(encodingsM3u8, resolutionInfo) {
         const encodingsLines = encodingsM3u8.split(/\r?\n/);


### PR DESCRIPTION
## Summary

Replace `new RegExp('(SERVER-TIME=")[0-9.]+"')` with `/(SERVER-TIME=")[0-9.]+"/` in the V1 API path of `replaceServerTimeInM3u8`.

## Why

The pattern is static (no interpolation) — `new RegExp(string)` recompiles on every call, while V8 caches regex literals at the source location. Since `replaceServerTimeInM3u8` is called per m3u8 fetch during playback, this shaves a small amount off each fetch on the V1 API path.

Noise-level win individually (microseconds), but a free one — no behavior change, no risk.

## Scope

3 files, 3 insertions / 3 deletions:
- `video-swap-new/video-swap-new.user.js`
- `video-swap-new/video-swap-new-ublock-origin.js`
- `strip/strip.user.js`

Testing variant (`video-swap-new-ublock-origin-testing.js`) landed as `88801da` on master.

`vaft` is unaffected — its `replaceServerTimeInM3u8` already uses regex literals on both API paths.

## Not included (but similar pattern)

Same two files also have `encodingsM3u8.match('SERVER-TIME="([0-9.]+)"')` in `getServerTimeFromM3u8` — `.match(string)` also coerces to a fresh RegExp per call. Skipped from this PR to keep scope minimal. Happy to follow up if desired.

## Test plan
- [x] `npx acorn --ecma2022` passes for all 3 files
- [x] Pattern is byte-for-byte equivalent (no regex-escape differences; no `[`, `]`, `+`, `*`, `?` change meaning between string and literal forms here)
- [ ] Post-merge smoke: verify ad breaks on V1 API channel still get SERVER-TIME rewritten correctly (if V2API branch is false anywhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)