### PR TITLE
perf: convert getServerTimeFromM3u8 .match(string) to regex literal

### DIFF
--- a/strip/strip.user.js
+++ b/strip/strip.user.js
@@ -268,7 +268,7 @@
             const matches = encodingsM3u8.match(/#EXT-X-SESSION-DATA:DATA-ID="SERVER-TIME",VALUE="([^"]+)"/);
             return matches && matches.length > 1 ? matches[1] : null;
         }
-        const matches = encodingsM3u8.match('SERVER-TIME="([0-9.]+)"');
+        const matches = encodingsM3u8.match(/SERVER-TIME="([0-9.]+)"/);
         return matches && matches.length > 1 ? matches[1] : null;
     }
     function replaceServerTimeInM3u8(encodingsM3u8, newServerTime) {

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -937,7 +937,7 @@ twitch-videoad.js text/javascript
             const matches = encodingsM3u8.match(/#EXT-X-SESSION-DATA:DATA-ID="SERVER-TIME",VALUE="([^"]+)"/);
             return matches && matches.length > 1 ? matches[1] : null;
         }
-        const matches = encodingsM3u8.match('SERVER-TIME="([0-9.]+)"');
+        const matches = encodingsM3u8.match(/SERVER-TIME="([0-9.]+)"/);
         return matches && matches.length > 1 ? matches[1] : null;
     }
     function replaceServerTimeInM3u8(encodingsM3u8, newServerTime) {

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -951,7 +951,7 @@
             const matches = encodingsM3u8.match(/#EXT-X-SESSION-DATA:DATA-ID="SERVER-TIME",VALUE="([^"]+)"/);
             return matches && matches.length > 1 ? matches[1] : null;
         }
-        const matches = encodingsM3u8.match('SERVER-TIME="([0-9.]+)"');
+        const matches = encodingsM3u8.match(/SERVER-TIME="([0-9.]+)"/);
         return matches && matches.length > 1 ? matches[1] : null;
     }
     function replaceServerTimeInM3u8(encodingsM3u8, newServerTime) {


### PR DESCRIPTION
## Summary

Sibling follow-up to #174. Replaces `encodingsM3u8.match('SERVER-TIME="([0-9.]+)"')` with `encodingsM3u8.match(/SERVER-TIME="([0-9.]+)"/)` in `getServerTimeFromM3u8`.

## Why

`String.prototype.match(string)` coerces its argument to a fresh `RegExp` on every call. Regex literals are cached at the source location. Called per m3u8 fetch on the V1 API path, so the savings compound during playback.

Same justification as #174 — explicitly scoped out of that PR to keep it minimal; doing as a consistent follow-up.

## Scope

3 files, 3 insertions / 3 deletions:
- `video-swap-new/video-swap-new.user.js`
- `video-swap-new/video-swap-new-ublock-origin.js`
- `strip/strip.user.js`

Testing variant (`video-swap-new-ublock-origin-testing.js`) landed as `2c34225` on master.

`vaft` unaffected — already uses regex literals on both API paths.

## Independence from #174

These two PRs modify different lines in the same functions and can merge in either order. No conflict.

## Test plan
- [x] `npx acorn --ecma2022` passes for all 3 files
- [x] Pattern is byte-for-byte equivalent (no regex-escape differences; the `.` inside `[0-9.]` is a character class so its meaning is the same in string-form and literal-form)
- [ ] Post-merge smoke: ad breaks on V1 API channels still yield a parsed SERVER-TIME

🤖 Generated with [Claude Code](https://claude.com/claude-code)