### PR TITLE
prototype: real-time contamination detection on backup search

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1013,6 +1013,28 @@ twitch-videoad.js text/javascript
                     playerTypesToTry.unshift(streamInfo.PinnedBackupPlayerType);
                 }
             }
+            // Real-time contamination reorder: on poll 2+ of a break, move types that were
+            // already logged as ad-laden earlier in the same break to the end of iteration.
+            // Lets untried/clean types (typically autoplay on SSAI-heavy channels like warn)
+            // get tried first instead of re-checking types we already know are contaminated.
+            // LoggedBackupAdsByType is populated below at the "also has ads" log site and
+            // cleared at end-of-break, so this is per-break adaptive.
+            if (streamInfo.LoggedBackupAdsByType && streamInfo.LoggedBackupAdsByType.size > 0) {
+                const clean = [];
+                const contam = [];
+                for (const t of playerTypesToTry) {
+                    if (streamInfo.LoggedBackupAdsByType.has(t)) contam.push(t);
+                    else clean.push(t);
+                }
+                if (contam.length > 0 && clean.length > 0) {
+                    playerTypesToTry.length = 0;
+                    playerTypesToTry.push(...clean, ...contam);
+                    if (!streamInfo.LoggedContamReorderThisBreak) {
+                        streamInfo.LoggedContamReorderThisBreak = true;
+                        console.log('[AD DEBUG] Contamination-aware reorder — trying [' + clean.join(', ') + '] before known-contaminated [' + contam.join(', ') + ']');
+                    }
+                }
+            }
             for (let playerTypeIndex = startIndex; !backupM3u8 && playerTypeIndex < playerTypesToTry.length; playerTypeIndex++) {
                 const playerType = playerTypesToTry[playerTypeIndex];
                 const realPlayerType = playerType.replace('-CACHED', '');
@@ -1128,8 +1150,19 @@ twitch-videoad.js text/javascript
                 }
             }
             if (!backupM3u8 && fallbackM3u8) {
-                backupPlayerType = FallbackPlayerType;
-                backupM3u8 = fallbackM3u8;
+                // Don't fall back to a type we've already marked contaminated this break.
+                // Without this guard, when all Source types go ad-laden mid-break the iteration
+                // ends with no clean commit AND fallbackM3u8 still pointing at FallbackPlayerType's
+                // ad-laden m3u8 — we'd silently re-commit the same contaminated site on every poll
+                // (no "Blocking ads" log because ActiveBackupPlayerType unchanged), and the user
+                // sees the full ad pod with no indication of failure. Better to leave backupM3u8
+                // null and let the "No ad-free backup stream found" log fire so it's visible.
+                if (streamInfo.LoggedBackupAdsByType && streamInfo.LoggedBackupAdsByType.has(FallbackPlayerType)) {
+                    console.log('[AD DEBUG] Skipping fallback to ' + FallbackPlayerType + ' — marked contaminated this break (' + [...streamInfo.LoggedBackupAdsByType].join(', ') + ' all ad-laden)');
+                } else {
+                    backupPlayerType = FallbackPlayerType;
+                    backupM3u8 = fallbackM3u8;
+                }
             }
             // Stale-commit guard: multiple processM3U8 calls can be in flight concurrently for
             // the same streamInfo (one per m3u8 poll). If this backup search started during the
@@ -1231,6 +1264,7 @@ twitch-videoad.js text/javascript
                 streamInfo.RequestedAds.clear();
                 streamInfo.FailedBackupPlayerTypes.clear();
                 if (streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType.clear();
+                streamInfo.LoggedContamReorderThisBreak = false;
                 streamInfo.CleanPlaylistCount = 0;
                 streamInfo.ConsecutiveAllStrippedPolls = 0;
                 streamInfo.EarlyReloadTriggered = false;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1045,6 +1045,28 @@
                     playerTypesToTry.unshift(streamInfo.PinnedBackupPlayerType);
                 }
             }
+            // Real-time contamination reorder: on poll 2+ of a break, move types that were
+            // already logged as ad-laden earlier in the same break to the end of iteration.
+            // Lets untried/clean types (typically autoplay on SSAI-heavy channels like warn)
+            // get tried first instead of re-checking types we already know are contaminated.
+            // LoggedBackupAdsByType is populated below at the "also has ads" log site and
+            // cleared at end-of-break, so this is per-break adaptive.
+            if (streamInfo.LoggedBackupAdsByType && streamInfo.LoggedBackupAdsByType.size > 0) {
+                const clean = [];
+                const contam = [];
+                for (const t of playerTypesToTry) {
+                    if (streamInfo.LoggedBackupAdsByType.has(t)) contam.push(t);
+                    else clean.push(t);
+                }
+                if (contam.length > 0 && clean.length > 0) {
+                    playerTypesToTry.length = 0;
+                    playerTypesToTry.push(...clean, ...contam);
+                    if (!streamInfo.LoggedContamReorderThisBreak) {
+                        streamInfo.LoggedContamReorderThisBreak = true;
+                        console.log('[AD DEBUG] Contamination-aware reorder — trying [' + clean.join(', ') + '] before known-contaminated [' + contam.join(', ') + ']');
+                    }
+                }
+            }
             for (let playerTypeIndex = startIndex; !backupM3u8 && playerTypeIndex < playerTypesToTry.length; playerTypeIndex++) {
                 const playerType = playerTypesToTry[playerTypeIndex];
                 const realPlayerType = playerType.replace('-CACHED', '');
@@ -1160,8 +1182,19 @@
                 }
             }
             if (!backupM3u8 && fallbackM3u8) {
-                backupPlayerType = FallbackPlayerType;
-                backupM3u8 = fallbackM3u8;
+                // Don't fall back to a type we've already marked contaminated this break.
+                // Without this guard, when all Source types go ad-laden mid-break the iteration
+                // ends with no clean commit AND fallbackM3u8 still pointing at FallbackPlayerType's
+                // ad-laden m3u8 — we'd silently re-commit the same contaminated site on every poll
+                // (no "Blocking ads" log because ActiveBackupPlayerType unchanged), and the user
+                // sees the full ad pod with no indication of failure. Better to leave backupM3u8
+                // null and let the "No ad-free backup stream found" log fire so it's visible.
+                if (streamInfo.LoggedBackupAdsByType && streamInfo.LoggedBackupAdsByType.has(FallbackPlayerType)) {
+                    console.log('[AD DEBUG] Skipping fallback to ' + FallbackPlayerType + ' — marked contaminated this break (' + [...streamInfo.LoggedBackupAdsByType].join(', ') + ' all ad-laden)');
+                } else {
+                    backupPlayerType = FallbackPlayerType;
+                    backupM3u8 = fallbackM3u8;
+                }
             }
             // Stale-commit guard: multiple processM3U8 calls can be in flight concurrently for
             // the same streamInfo (one per m3u8 poll). If this backup search started during the
@@ -1263,6 +1296,7 @@
                 streamInfo.RequestedAds.clear();
                 streamInfo.FailedBackupPlayerTypes.clear();
                 if (streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType.clear();
+                streamInfo.LoggedContamReorderThisBreak = false;
                 streamInfo.CleanPlaylistCount = 0;
                 streamInfo.ConsecutiveAllStrippedPolls = 0;
                 streamInfo.EarlyReloadTriggered = false;


### PR DESCRIPTION
## The problem

Field-observed on `warn` channel (5+ consecutive midroll breaks, identical pattern):

```
[AD DEBUG] Ad detected — type: midroll, channel: warn, pod: 2 ad(s) (~60s expected)
Blocking midroll ads (site) — backup found in 330ms
[AD DEBUG] Backup stream (site) also has ads
Finished blocking ads — stripped 0 ad segments, duration: 65.3s
[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action
```

User sits through full 47-79s ad pod with no visible failure signal. Investigating the backup search:

1. Poll 1: site is clean, committed as backup (330ms)
2. Poll 2+: site's m3u8 is now ad-laden too — logged once via `LoggedBackupAdsByType`
3. Iteration continues, but fallbackM3u8 is set to site's ad-laden m3u8 (line 1103-1105 saves it regardless of ad state)
4. No clean backup found; the fallback catch at line 1162 silently re-commits `FallbackPlayerType` (='site') with its cached ad-laden m3u8
5. Because `ActiveBackupPlayerType` is unchanged (still site), the "Blocking ads" change-log at line 1176 doesn't fire — no visible signal

Confirmed TTV-AB doesn't solve this either — its mid-break re-probe only fires during the ad-end wait phase, which hasn't arrived when ads are still playing.

## The fix (two narrow changes, no new config)

### 1. Contamination-aware iteration reorder

At start of backup search, if `LoggedBackupAdsByType` has entries from earlier in this break, move those types to the end of `playerTypesToTry`. Untried/clean types get tried first on subsequent polls.

**Example on warn poll 2** — `LoggedBackupAdsByType = {site}`:
- Before: `[site, popout, mobile_web, embed, autoplay]` → iteration hits site-contaminated first, saves fallbackM3u8
- After: `[popout, mobile_web, embed, autoplay, site]` → if `autoplay` (360p, often uncontaminated) is clean, commits directly

Per-break adaptive. `LoggedBackupAdsByType` is cleared at end-of-break so the reorder resets.

### 2. Fallback catch guard

Skip the `FallbackPlayerType` fallback when it's in `LoggedBackupAdsByType`. Instead of silently re-committing the contaminated m3u8, the existing "No ad-free backup stream found" log fires at line 1193 so the failure is observable.

Adds one `[AD DEBUG] Skipping fallback to X — marked contaminated this break (...)` log so future investigations have a signal.

## What this changes for users

**On channels where autoplay stays clean during SSAI breaks (hypothesis for warn):** user gets autoplay (360p) backup committed by poll 2 instead of silently sitting through ads. Quality drops to 360p during the break; back to Source after.

**On channels where autoplay is also contaminated:** reorder doesn't help (nothing clean exists), but the fallback guard prevents silent re-commit — user now gets the visible "No ad-free backup stream found" log instead of apparent success. Fails loudly instead of failing silently.

**On channels without this issue (99% of cases):** no behavior change. `LoggedBackupAdsByType` stays empty, reorder condition is false, fallback is unchanged.

## Prototype disclaimer

Field validation on `warn` (and similar SSAI-heavy channels) is needed to confirm the autoplay hypothesis. If autoplay IS contaminated too, the reorder is neutral but the fallback guard still converts silent failure into visible failure — valuable on its own.

## Scope

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`

2 files, +72 / -4. Testing variants landed as `b0ac0a0` on master. `video-swap-new` doesn't use this backup-search architecture.

## Test plan

- [x] `npx acorn --ecma2022` passes for both release files
- [x] Testing variants validated on master
- [ ] Field test on `warn`: observe whether autoplay gets committed on poll 2+ with new log `Contamination-aware reorder — trying [popout, ..., autoplay] before known-contaminated [site]`
- [ ] Field test on other SSAI-heavy channels (from prior field-test list: `winton_ow2`, `aspen`, `karq`)
- [ ] Verify no regression on clean channels (nothing logged = no reorder fired = correct)
- [ ] Verify `Skipping fallback` log fires when all types truly contaminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)