### PR TITLE
fix: lockout backup types that return GQL server-error

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1039,6 +1039,12 @@ twitch-videoad.js text/javascript
                                 if (!spat) {
                                     const errInfo = accessToken?.errors ? ' errors: ' + JSON.stringify(accessToken.errors).substring(0, 300) : '';
                                     console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + realPlayerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})) + errInfo);
+                                    // Lockout for 15s so we don't re-hit this known-broken type every poll.
+                                    // Parity with the HTTP-error and exception paths above — this GQL-error path
+                                    // was the only failure mode that didn't mark FailedBackupPlayerTypes, causing
+                                    // ~34 identical retries per break on channels where embed/autoplay GQL
+                                    // consistently returns "server error" (field-observed on warn).
+                                    streamInfo.FailedBackupPlayerTypes.set(realPlayerType, Date.now());
                                     continue;
                                 }
                                 const urlInfo = new URL('https://usher.ttvnw.net/api/' + (V2API ? 'v2/' : '') + 'channel/hls/' + streamInfo.ChannelName + '.m3u8' + streamInfo.UsherParams);

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1071,6 +1071,12 @@
                                 if (!spat) {
                                     const errInfo = accessToken?.errors ? ' errors: ' + JSON.stringify(accessToken.errors).substring(0, 300) : '';
                                     console.log('[AD DEBUG] GQL response missing streamPlaybackAccessToken for ' + realPlayerType + '. Response keys: ' + JSON.stringify(Object.keys(accessToken || {})) + errInfo);
+                                    // Lockout for 15s so we don't re-hit this known-broken type every poll.
+                                    // Parity with the HTTP-error and exception paths above — this GQL-error path
+                                    // was the only failure mode that didn't mark FailedBackupPlayerTypes, causing
+                                    // ~34 identical retries per break on channels where embed/autoplay GQL
+                                    // consistently returns "server error" (field-observed on warn).
+                                    streamInfo.FailedBackupPlayerTypes.set(realPlayerType, Date.now());
                                     continue;
                                 }
                                 const urlInfo = new URL('https://usher.ttvnw.net/api/' + (V2API ? 'v2/' : '') + 'channel/hls/' + streamInfo.ChannelName + '.m3u8' + streamInfo.UsherParams);


### PR DESCRIPTION
## Summary

The `!spat` branch in the backup search was the only failure mode that didn't mark `FailedBackupPlayerTypes`. Parity fix — treat GQL-missing-`spat` identically to the HTTP-error (line 1089) and exception (line 1093) paths.

## Field evidence

From a testing run on `warn` channel (PR #177's real-time reorder active):

```
[AD DEBUG] GQL response missing streamPlaybackAccessToken for embed ... "server error"
[AD DEBUG] GQL response missing streamPlaybackAccessToken for autoplay ... "server error"
(repeated ~34 times per break for each broken type — 68 total retries)
```

Twitch consistently returns `{errors:[{message:"server error",path:["streamPlaybackAccessToken"]}]}` for embed and autoplay on this channel. Our code saw `!spat`, logged, and moved on without locking out — so every subsequent poll re-attempted the same known-broken types.

## The fix

One line per file, right before the existing `continue`:

```js
streamInfo.FailedBackupPlayerTypes.set(realPlayerType, Date.now());
```

This triggers the existing 15s lockout at line 1052:
```js
const failedAt = streamInfo.FailedBackupPlayerTypes.get(realPlayerType);
if (failedAt && (Date.now() - failedAt) < 15000) {
    continue;
}
```

`FailedBackupPlayerTypes.clear()` runs at end-of-break (line 1264), so no cross-break stale state.

## Impact

- In-break retries for a broken type: **~34 → ~4** (first attempt + 3 retries after each 15s window)
- Log noise: substantial reduction
- Bandwidth: ~30 GQL round-trips saved per affected break
- Blocking outcomes: **unchanged** — embed/autoplay are still broken on warn, site/popout/mobile_web are still contaminated; this PR just stops the retry spam

## Scope

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`

2 files, +12 / -0. Testing variants landed as `9d8ccb8` on master.

## Relationship to other open PRs

Independent of #177 (real-time contamination detection). Both touch the backup search but at different code sites — merge in any order.

## Test plan

- [x] `npx acorn --ecma2022` passes for both files
- [x] Testing variants field-validated on `warn` (where the GQL error reproduces)
- [ ] Post-merge: verify `warn` breaks show ~4 embed/autoplay failures each instead of ~34
- [ ] Verify no regression on channels where embed/autoplay actually work (e.g., a break where these types succeed should still commit them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)