### PR TITLE
fix: clear pinned backup type if contaminated this break

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1263,6 +1263,14 @@ twitch-videoad.js text/javascript
                 streamInfo.ActiveBackupPlayerType = null;
                 streamInfo.RequestedAds.clear();
                 streamInfo.FailedBackupPlayerTypes.clear();
+                // Clear pin if the pinned type was contaminated this break — avoids wasted
+                // first-try fetch on next break. Field-observed on pge4: PinnedBackupPlayerType
+                // gets set to the last-committed type via PinBackupPlayerType=true, but when
+                // that type went contaminated mid-break we'd still try it first next break.
+                if (streamInfo.PinnedBackupPlayerType && streamInfo.LoggedBackupAdsByType && streamInfo.LoggedBackupAdsByType.has(streamInfo.PinnedBackupPlayerType)) {
+                    console.log('[AD DEBUG] Clearing pinned backup type ' + streamInfo.PinnedBackupPlayerType + ' — contaminated this break, would waste first-try next break');
+                    streamInfo.PinnedBackupPlayerType = null;
+                }
                 if (streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType.clear();
                 streamInfo.LoggedContamReorderThisBreak = false;
                 streamInfo.CleanPlaylistCount = 0;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1295,6 +1295,14 @@
                 streamInfo.ActiveBackupPlayerType = null;
                 streamInfo.RequestedAds.clear();
                 streamInfo.FailedBackupPlayerTypes.clear();
+                // Clear pin if the pinned type was contaminated this break — avoids wasted
+                // first-try fetch on next break. Field-observed on pge4: PinnedBackupPlayerType
+                // gets set to the last-committed type via PinBackupPlayerType=true, but when
+                // that type went contaminated mid-break we'd still try it first next break.
+                if (streamInfo.PinnedBackupPlayerType && streamInfo.LoggedBackupAdsByType && streamInfo.LoggedBackupAdsByType.has(streamInfo.PinnedBackupPlayerType)) {
+                    console.log('[AD DEBUG] Clearing pinned backup type ' + streamInfo.PinnedBackupPlayerType + ' — contaminated this break, would waste first-try next break');
+                    streamInfo.PinnedBackupPlayerType = null;
+                }
                 if (streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType.clear();
                 streamInfo.LoggedContamReorderThisBreak = false;
                 streamInfo.CleanPlaylistCount = 0;


### PR DESCRIPTION
## Summary

At end-of-break, clear `PinnedBackupPlayerType` if it's in `LoggedBackupAdsByType` (was logged contaminated during the break). Next break uses default iteration order instead of opening with a known-bad type.

**Stacked on #177** — this uses `LoggedBackupAdsByType`, which #177 populates. If #177 merges first, GitHub will auto-retarget this to master; if this merges first, it brings #177's changes along.

## Field evidence

From a pge4 testing run (v614 — #177 + #178 active):

**Break 1** ends with `mobile_web` as the last committed type → `PinnedBackupPlayerType = 'mobile_web'`.

**Break 2** starts:
```
Blocking midroll ads (mobile_web) — backup found in 333ms
Backup stream (mobile_web) also has ads
Contamination-aware reorder — trying [site, popout, embed, autoplay] before known-contaminated [mobile_web]
```

The pinned mobile_web is attempted first (wasted 333ms fetch on a type we already know is contaminated), THEN the reorder kicks in.

## Why the pin persists

`PinBackupPlayerType=true` (default in vaft), so line 1179-1181:
```js
const sourceQualityTypes = ['embed', 'site', 'popout'];
if (PinBackupPlayerType || sourceQualityTypes.includes(backupPlayerType)) {
    streamInfo.PinnedBackupPlayerType = backupPlayerType;
}
```
…pins whatever was last committed, regardless of whether that type later went contaminated. End-of-break reset doesn't clear it.

## The fix

Added before the existing `LoggedBackupAdsByType.clear()` call (so the Set is still populated when we read it):

```js
if (streamInfo.PinnedBackupPlayerType && streamInfo.LoggedBackupAdsByType && streamInfo.LoggedBackupAdsByType.has(streamInfo.PinnedBackupPlayerType)) {
    console.log('[AD DEBUG] Clearing pinned backup type ' + streamInfo.PinnedBackupPlayerType + ' — contaminated this break, would waste first-try next break');
    streamInfo.PinnedBackupPlayerType = null;
}
```

## Impact

- On SSAI-uniform channels (pge4, warn): saves one wasted fetch per break (~300-700ms) and removes a misleading "Blocking midroll ads (X) — backup found" log for a type that's immediately reported contaminated
- On normal channels: no behavior change — `LoggedBackupAdsByType` stays empty, the condition is false, pin persists as before

## Scope

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`

2 files, +16 / -0. Testing variants landed as `4d233e8` on master.

## Test plan

- [x] `npx acorn --ecma2022` passes both files
- [x] Testing variants field-validated on pge4 in v615
- [ ] Post-merge: on pge4, verify the first log of break 2 is `Contamination-aware reorder — trying [site, popout, ...]` rather than `Blocking midroll ads (mobile_web)` followed by reorder
- [ ] Normal channel regression: verify pin still carries across breaks when last-committed type stayed clean throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)