### PR TITLE
fix: reset ConsecutiveZeroStripBreaks on any positive signal

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1221,7 +1221,12 @@ twitch-videoad.js text/javascript
                     if (streamInfo.ConsecutiveZeroStripBreaks >= 3) {
                         console.log('[AD DEBUG] Warning: ' + streamInfo.ConsecutiveZeroStripBreaks + ' consecutive unconfirmed ad breaks with 0 segments stripped — possible false positive from ad signifiers');
                     }
-                } else if (hadStrippedSegments) {
+                } else if (hadStrippedSegments || streamInfo.HasConfirmedAdAttrs) {
+                    // Reset is symmetric with the increment guard above — any positive "break
+                    // was handled cleanly" signal resets the false-positive history. Previously
+                    // only stripped>0 reset the counter, which let stale suspicious history
+                    // bleed across legitimately-handled backup-swap breaks (0 stripped + real
+                    // ad attrs) and trigger the warning on partially-stale state.
                     streamInfo.ConsecutiveZeroStripBreaks = 0;
                 }
                 streamInfo.IsShowingAd = false;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1253,7 +1253,12 @@
                     if (streamInfo.ConsecutiveZeroStripBreaks >= 3) {
                         console.log('[AD DEBUG] Warning: ' + streamInfo.ConsecutiveZeroStripBreaks + ' consecutive unconfirmed ad breaks with 0 segments stripped — possible false positive from ad signifiers');
                     }
-                } else if (hadStrippedSegments) {
+                } else if (hadStrippedSegments || streamInfo.HasConfirmedAdAttrs) {
+                    // Reset is symmetric with the increment guard above — any positive "break
+                    // was handled cleanly" signal resets the false-positive history. Previously
+                    // only stripped>0 reset the counter, which let stale suspicious history
+                    // bleed across legitimately-handled backup-swap breaks (0 stripped + real
+                    // ad attrs) and trigger the warning on partially-stale state.
                     streamInfo.ConsecutiveZeroStripBreaks = 0;
                 }
                 streamInfo.IsShowingAd = false;


### PR DESCRIPTION
## Summary

Flagged in code review: the `ConsecutiveZeroStripBreaks` reset branch only fires on `hadStrippedSegments`, but the increment guard covers two positive signals (also `HasConfirmedAdAttrs`). Asymmetric — stale suspicious history can bleed across legitimately-handled backup-swap breaks.

## The gap

Four possible states at end-of-break:

| stripped | confirmed attrs | current action | correct? |
|---|---|---|---|
| false | false | increment | ✅ |
| true | any | **reset** | ✅ |
| false | true | **nothing** ← gap | ❌ should reset |

Row 3 is the bug: a real confirmed ad cleanly blocked via backup-swap (0 stripped + confirmed attrs) isn't a false positive, but it also doesn't reset prior suspicious history.

## Example sequence that fires misleadingly today

1. Break A: 0 strip, no confirmed attrs → counter = 1 (genuinely suspicious)
2. Break B: 0 strip, no confirmed attrs → counter = 2
3. Break C: 0 strip, **confirmed attrs** (real ad, backup-swap path) → counter = 2 (persists)
4. Break D: 0 strip, no confirmed attrs → counter = 3 → **warning fires**

Break C proved detection was correct — counter should reset there.

## The fix

One-line change, mirrored in both release files:

```js
// before:
} else if (hadStrippedSegments) {
    streamInfo.ConsecutiveZeroStripBreaks = 0;
}

// after:
} else if (hadStrippedSegments || streamInfo.HasConfirmedAdAttrs) {
    streamInfo.ConsecutiveZeroStripBreaks = 0;
}
```

Comment added explaining the symmetry with the increment guard.

## Why the bug existed

Archaeology: the reset was added before `HasConfirmedAdAttrs` existed. When `HasConfirmedAdAttrs` was later introduced and wired into the increment guard (PR that added confirmed-attrs support), the symmetric reset update was missed. Oversight, not intent.

## Scope

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`

2 files, +12 / -2.

**Testing variants** use different signals (`SawCSAIFastPath` + `BackupSwapFirst` instead of `HasConfirmedAdAttrs`) but the same principle applies — equivalent fix landed as `baa5db8` on master.

## Test plan

- [x] `npx acorn --ecma2022` passes both files
- [x] Testing variants field-validated
- [ ] Post-merge: verify the `possible false positive from ad signifiers` warning no longer fires on channels with mixed confirmed/unconfirmed breaks (warn, pge4, dafran — where confirmed attrs appear but strip is 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)