### PR TITLE
log: differentiate autoplay pinned vs fallback in commit message

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1152,7 +1152,12 @@ twitch-videoad.js text/javascript
                         const qualityTier = backupPlayerType === 'autoplay' ? '360p' : 'Source';
                         console.log('[AD DEBUG] Post-escape backup: ' + backupPlayerType + ' (' + qualityTier + ') — recovered from sticky-path freeze');
                     } else if (backupPlayerType === 'autoplay' && PreferLowQualityBackup) {
-                        console.log('[AD DEBUG] Autoplay backup committed — 360p fallback after Source types ad-laden (PreferLowQualityBackup)');
+                        const sourceTried = streamInfo.LoggedBackupAdsByType?.size || 0;
+                        if (sourceTried === 0) {
+                            console.log('[AD DEBUG] Autoplay backup committed — 360p pinned from prior break (PreferLowQualityBackup)');
+                        } else {
+                            console.log('[AD DEBUG] Autoplay backup committed — 360p fallback after ' + sourceTried + ' Source type(s) ad-laden (PreferLowQualityBackup)');
+                        }
                     }
                 }
             } else if (backupM3u8 && !streamInfo.IsShowingAd) {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1184,7 +1184,12 @@
                         const qualityTier = backupPlayerType === 'autoplay' ? '360p' : 'Source';
                         console.log('[AD DEBUG] Post-escape backup: ' + backupPlayerType + ' (' + qualityTier + ') — recovered from sticky-path freeze');
                     } else if (backupPlayerType === 'autoplay' && PreferLowQualityBackup) {
-                        console.log('[AD DEBUG] Autoplay backup committed — 360p fallback after Source types ad-laden (PreferLowQualityBackup)');
+                        const sourceTried = streamInfo.LoggedBackupAdsByType?.size || 0;
+                        if (sourceTried === 0) {
+                            console.log('[AD DEBUG] Autoplay backup committed — 360p pinned from prior break (PreferLowQualityBackup)');
+                        } else {
+                            console.log('[AD DEBUG] Autoplay backup committed — 360p fallback after ' + sourceTried + ' Source type(s) ad-laden (PreferLowQualityBackup)');
+                        }
                     }
                 }
             } else if (backupM3u8 && !streamInfo.IsShowingAd) {


### PR DESCRIPTION
## Summary

Pure cosmetic log change. Distinguishes two paths that currently share the same log message:

- **Pinned-first path**: autoplay was the last-committed backup from a prior break, gets pinned, committed on first try of the current break (no Source types tried).
- **Fallback path**: backup iteration walked through Source types this break, found them all ad-laden, fell through to autoplay last-resort.

Both emit the current log:
```
Autoplay backup committed — 360p fallback after Source types ad-laden (PreferLowQualityBackup)
```

…but only the fallback path actually matches the wording. The pinned path didn't try Source types at all, so "after Source types ad-laden" is misleading.

## Field evidence

From emongg testing log (6 consecutive breaks, v615). Break 1 iterated all 5 types, found autoplay clean, committed + pinned. Breaks 2–6 all showed:

```
[AD DEBUG] Ad detected — channel: emongg, pod: N ad(s) ...
Blocking midroll ads (autoplay) — backup found in ~330ms   ← pinned, single fetch
[AD DEBUG] Autoplay backup committed — 360p fallback after Source types ad-laden (PreferLowQualityBackup)   ← misleading
```

The `~330ms` (or 56ms cached on break 5) + no preceding "Backup stream (X) also has ads" logs confirms no Source types were tried — pinned autoplay was taken on first try.

## The fix

Check `LoggedBackupAdsByType.size` at log time:

```js
const sourceTried = streamInfo.LoggedBackupAdsByType?.size || 0;
if (sourceTried === 0) {
    console.log('[AD DEBUG] Autoplay backup committed — 360p pinned from prior break (PreferLowQualityBackup)');
} else {
    console.log('[AD DEBUG] Autoplay backup committed — 360p fallback after ' + sourceTried + ' Source type(s) ad-laden (PreferLowQualityBackup)');
}
```

## Scope

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`

2 files, +12 / -2. Testing variants landed as `87eeace` on master. video-swap-new doesn't have `PreferLowQualityBackup` / autoplay — not applicable.

## Test plan

- [x] `npx acorn --ecma2022` passes both files
- [x] Testing variants field-validated — emongg breaks now log `360p pinned from prior break` on all post-first breaks
- [ ] Post-merge: verify log message accurately reflects path on channels where Source types aren't tried (pinned autoplay) vs where they are (last-resort fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)