### PR TITLE
fix: skip drift correction within 15s of player reload

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1555,7 +1555,12 @@ twitch-videoad.js text/javascript
                         }
                         // Detect position jump (native gap recovery) — drift to catch up
                         // Skip during ad breaks and 10s after: backup stream switching causes buffer gaps that trigger false jumps
-                        if (playerBufferState.position > 0 && position - playerBufferState.position > 5 && !playerBufferState.inAdBreak && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000)) {
+                        // Also skip 15s after a player reload: hard reloads jump the player to live edge,
+                        // which our previous-position tracking sees as a ~60s "drift" that doesn't need
+                        // catch-up — we ARE at live edge now. Field-observed on warn (release v58):
+                        // post-ad reload + ~60s position jump every break, drift correction firing
+                        // unnecessarily for the rest of the inter-break period.
+                        if (playerBufferState.position > 0 && position - playerBufferState.position > 5 && !playerBufferState.inAdBreak && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000) && (!playerBufferState.lastReloadAt || Date.now() - playerBufferState.lastReloadAt >= 15000)) {
                             console.log('[AD DEBUG] Position jumped ' + (position - playerBufferState.position).toFixed(1) + 's — starting drift correction');
                             startDriftCorrection(player.getHTMLVideoElement?.());
                         }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1591,7 +1591,12 @@
                         }
                         // Detect position jump (native gap recovery) — drift to catch up
                         // Skip during ad breaks and 10s after: backup stream switching causes buffer gaps that trigger false jumps
-                        if (playerBufferState.position > 0 && position - playerBufferState.position > 5 && !playerBufferState.inAdBreak && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000)) {
+                        // Also skip 15s after a player reload: hard reloads jump the player to live edge,
+                        // which our previous-position tracking sees as a ~60s "drift" that doesn't need
+                        // catch-up — we ARE at live edge now. Field-observed on warn (release v58):
+                        // post-ad reload + ~60s position jump every break, drift correction firing
+                        // unnecessarily for the rest of the inter-break period.
+                        if (playerBufferState.position > 0 && position - playerBufferState.position > 5 && !playerBufferState.inAdBreak && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000) && (!playerBufferState.lastReloadAt || Date.now() - playerBufferState.lastReloadAt >= 15000)) {
                             console.log('[AD DEBUG] Position jumped ' + (position - playerBufferState.position).toFixed(1) + 's — starting drift correction');
                             startDriftCorrection(player.getHTMLVideoElement?.());
                         }


### PR DESCRIPTION
## Field evidence (warn, release v58)

```
Reloading Twitch player (hard)
Replaced 'site' player type with 'popout' player type
[playback resumes at live edge]
Position jumped 60.0s — starting drift correction
Drift correction: catching up at 1.1x
Drift correction complete — resumed normal playback speed
[~12s later]
Position jumped 60.0s — starting drift correction
...
```

7 such cycles in 5 minutes. Each one a useless 1.1x catch-up.

## Cause

Hard reloads jump the player to **live edge**. Our drift detector compares the new live-edge `position` against `playerBufferState.position` (the previous tick's value, taken pre-reload ~60s behind live). It sees a 60s delta, treats it as drift, fires `startDriftCorrection()` at 1.1x. But the player is already at live — there's no drift to catch up to.

Then ~12s later, another reload (post-ad-break on this SSAI-heavy channel), same cycle.

## Fix

The detector already guards against:
- Ad break artifacts (`!playerBufferState.inAdBreak`)
- Backup switch artifacts (`Date.now() - lastBackupSwitchAt >= 10000`)

Add a parallel guard for reloads (matches the existing post-reload grace window the stall-detector uses at line 1517):

```js
&& (!playerBufferState.lastReloadAt || Date.now() - playerBufferState.lastReloadAt >= 15000)
```

15s window > the 60s position jump observation interval would cover all observed cases. `lastReloadAt` is already maintained at line 1904 of release.

## Scope

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`

2 files, +12 / -2. Testing variants landed as `3bcd0cb` on master.

## Behavior change

- On reload-heavy channels (warn-class SSAI breaks): the recurring drift cycle stops firing
- On stable channels: no observable difference (`lastReloadAt` is set rarely, condition rarely false)
- True position jumps from genuine native gap recovery (not reload-induced): still detected after the 15s window passes

## Test plan

- [x] `npx acorn --ecma2022` passes both files
- [x] Testing variants field-validated
- [ ] Post-merge: on warn, observe that `Position jumped 60.0s` no longer fires within 15s of `Reloading Twitch player (hard)`
- [ ] Verify drift correction still fires on stalls/seeks unrelated to reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)