### PR TITLE
fix: rate-limit position-jump drift detector to once per 30s

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1553,11 +1553,19 @@ twitch-videoad.js text/javascript
                             playerBufferState.fixAttempts = 0;
                             playerBufferState.recoveryReloadUsed = false;
                         }
-                        // Detect position jump (native gap recovery) — drift to catch up
-                        // Skip during ad breaks and 10s after: backup stream switching causes buffer gaps that trigger false jumps
-                        if (playerBufferState.position > 0 && position - playerBufferState.position > 5 && !playerBufferState.inAdBreak && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000)) {
+                        // Detect position jump (native gap recovery) — drift to catch up.
+                        // Skip during ad breaks and 10s after: backup stream switching causes buffer gaps that trigger false jumps.
+                        // Rate-limit to once per 30s: field-observed on warn that Twitch's player.core.state.position
+                        // jumps ~60s every ~12s on reload-heavy channels (likely batch updates from m3u8 manifest
+                        // refreshes / program-date-time sync points, not real drift). Our 1.1x videoElement.playbackRate
+                        // doesn't affect state.position anyway, so re-firing every 12s is useless log spam — the catch-up
+                        // operates on currentTime which is already at live edge. Rate-limit collapses the spam to a
+                        // single drift attempt per 30s window, leaving real-drift paths (buffer-gap seek, post-reload)
+                        // unaffected since they call startDriftCorrection() directly without going through this detector.
+                        if (playerBufferState.position > 0 && position - playerBufferState.position > 5 && !playerBufferState.inAdBreak && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000) && (!playerBufferState.lastDriftStartedAt || Date.now() - playerBufferState.lastDriftStartedAt >= 30000)) {
                             console.log('[AD DEBUG] Position jumped ' + (position - playerBufferState.position).toFixed(1) + 's — starting drift correction');
                             startDriftCorrection(player.getHTMLVideoElement?.());
+                            playerBufferState.lastDriftStartedAt = Date.now();
                         }
                         playerBufferState.position = position;
                         playerBufferState.bufferedPosition = bufferedPosition;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1589,11 +1589,19 @@
                             playerBufferState.fixAttempts = 0;
                             playerBufferState.recoveryReloadUsed = false;
                         }
-                        // Detect position jump (native gap recovery) — drift to catch up
-                        // Skip during ad breaks and 10s after: backup stream switching causes buffer gaps that trigger false jumps
-                        if (playerBufferState.position > 0 && position - playerBufferState.position > 5 && !playerBufferState.inAdBreak && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000)) {
+                        // Detect position jump (native gap recovery) — drift to catch up.
+                        // Skip during ad breaks and 10s after: backup stream switching causes buffer gaps that trigger false jumps.
+                        // Rate-limit to once per 30s: field-observed on warn that Twitch's player.core.state.position
+                        // jumps ~60s every ~12s on reload-heavy channels (likely batch updates from m3u8 manifest
+                        // refreshes / program-date-time sync points, not real drift). Our 1.1x videoElement.playbackRate
+                        // doesn't affect state.position anyway, so re-firing every 12s is useless log spam — the catch-up
+                        // operates on currentTime which is already at live edge. Rate-limit collapses the spam to a
+                        // single drift attempt per 30s window, leaving real-drift paths (buffer-gap seek, post-reload)
+                        // unaffected since they call startDriftCorrection() directly without going through this detector.
+                        if (playerBufferState.position > 0 && position - playerBufferState.position > 5 && !playerBufferState.inAdBreak && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000) && (!playerBufferState.lastDriftStartedAt || Date.now() - playerBufferState.lastDriftStartedAt >= 30000)) {
                             console.log('[AD DEBUG] Position jumped ' + (position - playerBufferState.position).toFixed(1) + 's — starting drift correction');
                             startDriftCorrection(player.getHTMLVideoElement?.());
+                            playerBufferState.lastDriftStartedAt = Date.now();
                         }
                         playerBufferState.position = position;
                         playerBufferState.bufferedPosition = bufferedPosition;


### PR DESCRIPTION
## Replaces #182 (closed — misdiagnosed)

#182 added a 15s post-reload guard. That was wrong: the recurring jumps continue indefinitely past 15s, so the guard would only catch the first.

## Real cause

Field log on warn (release v58, post-ad reload):

```
Reloading Twitch player (hard)
...
Position jumped 10.3s — starting drift correction
[~12s]  Position jumped 52.0s
[~12s]  Position jumped 60.1s
[~12s]  Position jumped 59.8s
[~12s]  Position jumped 60.1s
[~12s]  Position jumped 60.0s
... (continues indefinitely)
```

Buffer monitor polls every 600ms (`PlayerBufferingDelay`). 12s = 20 polls between visible jumps. The jump magnitude (~60s) and consistency strongly suggests Twitch's `player.core.state.position` is **updated in batches** — likely on m3u8 manifest refreshes / program-date-time sync points — not continuously. Between batches, `state.position` is approximately frozen; when a batch arrives, it leaps forward to track live edge.

Critically: our `videoElement.playbackRate = 1.1` doesn't affect `state.position`. The drift correction operates on `video.currentTime`, which is already at live edge. We're firing 1.1x catch-ups for a "drift" that doesn't exist in any value we control — `state.position` diverges from `currentTime` by Twitch's internal clock choice, not ours.

## Fix

Rate-limit the position-jump detector to once per 30s:

```js
if (playerBufferState.position > 0
    && position - playerBufferState.position > 5
    && !playerBufferState.inAdBreak
    && (!playerBufferState.lastBackupSwitchAt || Date.now() - playerBufferState.lastBackupSwitchAt >= 10000)
    && (!playerBufferState.lastDriftStartedAt || Date.now() - playerBufferState.lastDriftStartedAt >= 30000)) {
    console.log('[AD DEBUG] Position jumped ' + ... + ' — starting drift correction');
    startDriftCorrection(player.getHTMLVideoElement?.());
    playerBufferState.lastDriftStartedAt = Date.now();
}
```

Real-drift paths bypass this detector entirely:
- Buffer-gap seek (line 1569) — calls `startDriftCorrection()` directly when seeking past a gap
- Post-reload drift in `doTwitchPlayerTask` (line 1952) — calls `startDriftCorrection()` directly when post-reload live drift > 2s

Both unaffected by the rate limit; the only behavior change is collapsing the spam from the position-jump-based detector.

## Behavior change

- **Reload-heavy channels (warn-class SSAI):** drift detector fires at most once per 30s instead of every 12s. Eliminates the recurring useless 1.1x catch-up cycle and log spam.
- **Stable channels:** no observable difference. `state.position` advances continuously without batch jumps; the > 5s threshold rarely triggers.
- **Real drift events:** still detected after the 30s window, plus the bypass paths fire immediately for known cases.

## Scope

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`

2 files, +22 / -6. Testing variants landed as `dffcbce` on master.

## Test plan

- [x] `npx acorn --ecma2022` passes both files
- [ ] Post-merge: on warn, observe at most one `Position jumped` log per 30s window
- [ ] Verify real-drift paths still fire (buffer gap detection, post-reload drift correction unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)