### PR TITLE
require 3 consecutive clean polls before declaring ad-end (TTV-AB v6.6.7 parity)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1200,8 +1200,13 @@ twitch-videoad.js text/javascript
             streamInfo.CleanPlaylistCount++;
             // Check if the current playlist has live segments — if not, backup stream is dead
             const hasLiveSegments = textStr.includes(',live');
-            const cleanThreshold = streamInfo.NumStrippedAdSegments === 0 ? 1 : 2;
-            if (streamInfo.CleanPlaylistCount >= cleanThreshold || !hasLiveSegments) {
+            // Require 2 consecutive clean polls before declaring ad-end. Previously only 1
+            // when NumStrippedAdSegments === 0 (CSAI-only / backup-swap path), which let
+            // brief clean windows during ongoing breaks flip IsShowingAd false prematurely on
+            // SSAI-uniform channels. TTV-AB v6.4.8 made the equivalent change for the same
+            // reason — Twitch can serve a clean playlist mid-break before re-injecting markers.
+            // Testing variants already used unconditional 2; this aligns release.
+            if (streamInfo.CleanPlaylistCount >= 2 || !hasLiveSegments) {
                 if (!hasLiveSegments) {
                     console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
                 }

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1200,13 +1200,14 @@ twitch-videoad.js text/javascript
             streamInfo.CleanPlaylistCount++;
             // Check if the current playlist has live segments — if not, backup stream is dead
             const hasLiveSegments = textStr.includes(',live');
-            // Require 2 consecutive clean polls before declaring ad-end. Previously only 1
-            // when NumStrippedAdSegments === 0 (CSAI-only / backup-swap path), which let
-            // brief clean windows during ongoing breaks flip IsShowingAd false prematurely on
-            // SSAI-uniform channels. TTV-AB v6.4.8 made the equivalent change for the same
-            // reason — Twitch can serve a clean playlist mid-break before re-injecting markers.
-            // Testing variants already used unconditional 2; this aligns release.
-            if (streamInfo.CleanPlaylistCount >= 2 || !hasLiveSegments) {
+            // Require 3 consecutive clean polls before declaring ad-end. Previously only 1
+            // when NumStrippedAdSegments === 0 (CSAI-only / backup-swap path) and 2 otherwise,
+            // which let brief clean windows during ongoing breaks flip IsShowingAd false
+            // prematurely on SSAI-uniform channels. TTV-AB hit the same false-positive at 2
+            // probes and bumped to 3 in v6.6.7 ("Ad-End Re-Entry Stability") — Twitch can
+            // serve a clean playlist mid-break before re-injecting markers, and 2 polls
+            // (~4s) wasn't always enough to ride out the bounce.
+            if (streamInfo.CleanPlaylistCount >= 3 || !hasLiveSegments) {
                 if (!hasLiveSegments) {
                     console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
                 }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1232,8 +1232,13 @@
             streamInfo.CleanPlaylistCount++;
             // Check if the current playlist has live segments — if not, backup stream is dead
             const hasLiveSegments = textStr.includes(',live');
-            const cleanThreshold = streamInfo.NumStrippedAdSegments === 0 ? 1 : 2;
-            if (streamInfo.CleanPlaylistCount >= cleanThreshold || !hasLiveSegments) {
+            // Require 2 consecutive clean polls before declaring ad-end. Previously only 1
+            // when NumStrippedAdSegments === 0 (CSAI-only / backup-swap path), which let
+            // brief clean windows during ongoing breaks flip IsShowingAd false prematurely on
+            // SSAI-uniform channels. TTV-AB v6.4.8 made the equivalent change for the same
+            // reason — Twitch can serve a clean playlist mid-break before re-injecting markers.
+            // Testing variants already used unconditional 2; this aligns release.
+            if (streamInfo.CleanPlaylistCount >= 2 || !hasLiveSegments) {
                 if (!hasLiveSegments) {
                     console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
                 }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1232,13 +1232,14 @@
             streamInfo.CleanPlaylistCount++;
             // Check if the current playlist has live segments — if not, backup stream is dead
             const hasLiveSegments = textStr.includes(',live');
-            // Require 2 consecutive clean polls before declaring ad-end. Previously only 1
-            // when NumStrippedAdSegments === 0 (CSAI-only / backup-swap path), which let
-            // brief clean windows during ongoing breaks flip IsShowingAd false prematurely on
-            // SSAI-uniform channels. TTV-AB v6.4.8 made the equivalent change for the same
-            // reason — Twitch can serve a clean playlist mid-break before re-injecting markers.
-            // Testing variants already used unconditional 2; this aligns release.
-            if (streamInfo.CleanPlaylistCount >= 2 || !hasLiveSegments) {
+            // Require 3 consecutive clean polls before declaring ad-end. Previously only 1
+            // when NumStrippedAdSegments === 0 (CSAI-only / backup-swap path) and 2 otherwise,
+            // which let brief clean windows during ongoing breaks flip IsShowingAd false
+            // prematurely on SSAI-uniform channels. TTV-AB hit the same false-positive at 2
+            // probes and bumped to 3 in v6.6.7 ("Ad-End Re-Entry Stability") — Twitch can
+            // serve a clean playlist mid-break before re-injecting markers, and 2 polls
+            // (~4s) wasn't always enough to ride out the bounce.
+            if (streamInfo.CleanPlaylistCount >= 3 || !hasLiveSegments) {
                 if (!hasLiveSegments) {
                     console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
                 }


### PR DESCRIPTION
## Summary

Bump release `cleanThreshold` from conditional (1 when strip == 0, else 2) to unconditional `3`. Aligns with the latest TTV-AB tightening in v6.6.7 ("Ad-End Re-Entry Stability"), which raised `AD_END_MIN_NATIVE_RECOVERY_PROBES` from 2 → 3 plus longer grace/cooldown windows.

This PR initially landed with `>= 2` (matching TTV-AB v6.4.8). After TTV-AB hit the same false-positive at 2 probes and went to 3, the threshold was raised here to match.

## Why

On SSAI-uniform channels (warn / pge4 / dafran / emongg), the backup-swap-first path commonly produces `NumStrippedAdSegments === 0` for the whole break. Under the original conditional logic, **a single** clean playlist poll would flip `IsShowingAd` false. Twitch occasionally serves a brief clean window mid-break before re-injecting ad markers, which causes premature ad-end → re-detection a couple seconds later.

TTV-AB's history maps the same path:

- v6.4.8 — bumped `AD_END_MIN_NATIVE_RECOVERY_PROBES` from 1 → 2
- v6.6.7 — bumped 2 → 3, also raised `AD_END_GRACE_MS` 250 → 500ms and `AD_END_NATIVE_RECOVERY_PROBE_COOLDOWN_MS` 250 → 500ms

> **Ad-End Re-Entry Stability** — The native recovery probe required only 2 consecutive clean playlists before declaring ad ended, so the post-ad reload would frequently land on a still-ad-marked playlist and the worker would re-enter ad blocking 1-3 seconds later (logged as `Treating post-ad ad markers as continuation`). Required probes increased from 2 to 3, the grace window from 250 ms to 500 ms, and the per-probe cooldown from 250 ms to 500 ms so ad-end is declared only when the native player has stabilized.

vaft's `CleanPlaylistCount`-based check is the closest analogue. We don't have separate native-recovery-probe stages or explicit grace/cooldown windows — the m3u8 polling cadence (~2s) means 3 polls naturally take ~6s real-time, well past TTV-AB's 500ms grace, so no separate timing knobs are needed.

## The change

```js
// before (master):
const cleanThreshold = streamInfo.NumStrippedAdSegments === 0 ? 1 : 2;
if (streamInfo.CleanPlaylistCount >= cleanThreshold || !hasLiveSegments) {

// after (this PR):
if (streamInfo.CleanPlaylistCount >= 3 || !hasLiveSegments) {
```

The `cleanThreshold` const is removed.

## Behavior change

- **CSAI-only / backup-swap channels** (warn/pge4/dafran/emongg): two extra ~2s polls (~4s total) before ad-end fires. Reduces premature ad-end → re-detection thrash. Slight increase in measured `duration:` value.
- **Strip-success channels (existing 2-poll path)**: one extra ~2s poll. Similar effect — fewer false-positive declarations on bouncing markers.
- **No-live-segments path** (`!hasLiveSegments`): unchanged — still triggers immediate end regardless of `CleanPlaylistCount`.

## Scope

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`

Testing variants will be bumped to `>= 3` in a follow-up direct-to-master commit (per the testing-vs-release split).

## Test plan

- [x] `npx acorn --ecma2022` passes both files
- [ ] Post-merge field test on warn / pge4: confirm `Finished blocking ads` fires once per real break (not bouncing twice mid-break) and the new `~6s` ad-end declaration latency is acceptable
- [ ] Verify strip-success channels still end breaks promptly within the ~6s window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
