### PR TITLE
ad-end: bounce-tolerant candidate-end + slow-path max-wait gate (TTV-AB v6.6.7 #1/#4)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -131,6 +131,8 @@ twitch-videoad.js text/javascript
             PodLength: 1,
             HasConfirmedAdAttrs: false,
             CleanPlaylistCount: 0,
+            PendingAdEndAt: 0,
+            AdEndBounceCount: 0,
             ConsecutiveZeroStripBreaks: 0,
             CsaiOnlyThisBreak: false,
             IsStrippingAdSegments: false,
@@ -851,6 +853,16 @@ twitch-videoad.js text/javascript
             streamInfo.LastCleanNativePlaylistAt = Date.now();
         }
         if (haveAdTags) {
+            // Bounce-tolerant reset: keep PendingAdEndAt alive across short flips back to ad-marked
+            // so the slow-path max-wait gate can still fire when bouncing markers prevent
+            // CleanPlaylistCount from reaching threshold. Mirrors TTV-AB v6.6.7 #1.
+            const adEndStalenessMs = 12000;
+            if (streamInfo.PendingAdEndAt && (Date.now() - streamInfo.PendingAdEndAt) < adEndStalenessMs) {
+                streamInfo.AdEndBounceCount = (streamInfo.AdEndBounceCount || 0) + 1;
+            } else {
+                streamInfo.PendingAdEndAt = 0;
+                streamInfo.AdEndBounceCount = 0;
+            }
             streamInfo.CleanPlaylistCount = 0;
             streamInfo.IsMidroll = textStr.includes('"MIDROLL"') || textStr.includes('"midroll"');
             if (!streamInfo.IsShowingAd) {
@@ -1241,9 +1253,24 @@ twitch-videoad.js text/javascript
                 postMessage({ key: 'ReloadPlayer', kind: 'early' });
             }
         } else if (streamInfo.IsShowingAd) {
+            // Mark first candidate-end timestamp on the first clean poll seen this break,
+            // so the slow-path max-wait gate below can fire even if subsequent polls bounce
+            // back to ad-marked. The bounce-tolerant haveAdTags reset keeps this alive
+            // across short flips. Mirrors TTV-AB v6.6.7 #1.
+            if (!streamInfo.PendingAdEndAt) {
+                streamInfo.PendingAdEndAt = Date.now();
+            }
             streamInfo.CleanPlaylistCount++;
             // Check if the current playlist has live segments — if not, backup stream is dead
             const hasLiveSegments = textStr.includes(',live');
+            // Independent slow-path max-wait escalation — ends the visible ad cycle even when
+            // marker bouncing keeps CleanPlaylistCount below threshold. Without this, the player
+            // could be wedged on backup indefinitely on channels where Twitch flips markers
+            // in/out faster than 3 consecutive clean polls can land. Mirrors TTV-AB v6.6.7 #4
+            // ("Decoupled Slow-Path Recovery from Clean-Count").
+            const adEndMaxWaitMs = 12000;
+            const elapsedSinceCandidate = Date.now() - streamInfo.PendingAdEndAt;
+            const slowPathReady = streamInfo.PendingAdEndAt > 0 && elapsedSinceCandidate >= adEndMaxWaitMs;
             // Require 3 consecutive clean polls before declaring ad-end. Previously only 1
             // when NumStrippedAdSegments === 0 (CSAI-only / backup-swap path) and 2 otherwise,
             // which let brief clean windows during ongoing breaks flip IsShowingAd false
@@ -1251,7 +1278,10 @@ twitch-videoad.js text/javascript
             // probes and bumped to 3 in v6.6.7 ("Ad-End Re-Entry Stability") — Twitch can
             // serve a clean playlist mid-break before re-injecting markers, and 2 polls
             // (~4s) wasn't always enough to ride out the bounce.
-            if (streamInfo.CleanPlaylistCount >= 3 || !hasLiveSegments) {
+            if (streamInfo.CleanPlaylistCount >= 3 || !hasLiveSegments || slowPathReady) {
+                if (slowPathReady && streamInfo.CleanPlaylistCount < 3) {
+                    console.log('[AD DEBUG] Slow-path ad-end escalation — ' + (streamInfo.AdEndBounceCount || 0) + ' marker bounces, ' + (elapsedSinceCandidate / 1000).toFixed(1) + 's since first clean poll');
+                }
                 if (!hasLiveSegments) {
                     console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
                 }
@@ -1283,11 +1313,13 @@ twitch-videoad.js text/javascript
                 streamInfo.IsStrippingAdSegments = false;
                 streamInfo.NumStrippedAdSegments = 0;
                 streamInfo.ActiveBackupPlayerType = null;
-                streamInfo.RequestedAds.clear();
-                streamInfo.FailedBackupPlayerTypes.clear();
+                streamInfo.RequestedAds?.clear?.();
+                streamInfo.FailedBackupPlayerTypes?.clear?.();
                 if (streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType.clear();
                 streamInfo.LoggedContamReorderThisBreak = false;
                 streamInfo.CleanPlaylistCount = 0;
+                streamInfo.PendingAdEndAt = 0;
+                streamInfo.AdEndBounceCount = 0;
                 streamInfo.ConsecutiveAllStrippedPolls = 0;
                 streamInfo.EarlyReloadTriggered = false;
                 streamInfo.EarlyReloadAwaitingResult = false;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -148,6 +148,8 @@
             PodLength: 1,
             HasConfirmedAdAttrs: false,
             CleanPlaylistCount: 0,
+            PendingAdEndAt: 0,// Timestamp of first clean poll seen this break — drives the bounce-tolerant max-wait escalation gate (TTV-AB v6.6.7 #1/#4)
+            AdEndBounceCount: 0,// Count of ad-marker bounces while PendingAdEndAt is alive — telemetry only
             ConsecutiveZeroStripBreaks: 0,
             CsaiOnlyThisBreak: false,
             // Strip state
@@ -875,6 +877,16 @@
             streamInfo.LastCleanNativePlaylistAt = Date.now();
         }
         if (haveAdTags) {
+            // Bounce-tolerant reset: keep PendingAdEndAt alive across short flips back to ad-marked
+            // so the slow-path max-wait gate can still fire when bouncing markers prevent
+            // CleanPlaylistCount from reaching threshold. Mirrors TTV-AB v6.6.7 #1.
+            const adEndStalenessMs = 12000;
+            if (streamInfo.PendingAdEndAt && (Date.now() - streamInfo.PendingAdEndAt) < adEndStalenessMs) {
+                streamInfo.AdEndBounceCount = (streamInfo.AdEndBounceCount || 0) + 1;
+            } else {
+                streamInfo.PendingAdEndAt = 0;
+                streamInfo.AdEndBounceCount = 0;
+            }
             streamInfo.CleanPlaylistCount = 0;
             streamInfo.IsMidroll = textStr.includes('"MIDROLL"') || textStr.includes('"midroll"');
             if (!streamInfo.IsShowingAd) {
@@ -1273,9 +1285,24 @@
                 postMessage({ key: 'ReloadPlayer', kind: 'early' });
             }
         } else if (streamInfo.IsShowingAd) {
+            // Mark first candidate-end timestamp on the first clean poll seen this break,
+            // so the slow-path max-wait gate below can fire even if subsequent polls bounce
+            // back to ad-marked. The bounce-tolerant haveAdTags reset keeps this alive
+            // across short flips. Mirrors TTV-AB v6.6.7 #1.
+            if (!streamInfo.PendingAdEndAt) {
+                streamInfo.PendingAdEndAt = Date.now();
+            }
             streamInfo.CleanPlaylistCount++;
             // Check if the current playlist has live segments — if not, backup stream is dead
             const hasLiveSegments = textStr.includes(',live');
+            // Independent slow-path max-wait escalation — ends the visible ad cycle even when
+            // marker bouncing keeps CleanPlaylistCount below threshold. Without this, the player
+            // could be wedged on backup indefinitely on channels where Twitch flips markers
+            // in/out faster than 3 consecutive clean polls can land. Mirrors TTV-AB v6.6.7 #4
+            // ("Decoupled Slow-Path Recovery from Clean-Count").
+            const adEndMaxWaitMs = 12000;
+            const elapsedSinceCandidate = Date.now() - streamInfo.PendingAdEndAt;
+            const slowPathReady = streamInfo.PendingAdEndAt > 0 && elapsedSinceCandidate >= adEndMaxWaitMs;
             // Require 3 consecutive clean polls before declaring ad-end. Previously only 1
             // when NumStrippedAdSegments === 0 (CSAI-only / backup-swap path) and 2 otherwise,
             // which let brief clean windows during ongoing breaks flip IsShowingAd false
@@ -1283,7 +1310,10 @@
             // probes and bumped to 3 in v6.6.7 ("Ad-End Re-Entry Stability") — Twitch can
             // serve a clean playlist mid-break before re-injecting markers, and 2 polls
             // (~4s) wasn't always enough to ride out the bounce.
-            if (streamInfo.CleanPlaylistCount >= 3 || !hasLiveSegments) {
+            if (streamInfo.CleanPlaylistCount >= 3 || !hasLiveSegments || slowPathReady) {
+                if (slowPathReady && streamInfo.CleanPlaylistCount < 3) {
+                    console.log('[AD DEBUG] Slow-path ad-end escalation — ' + (streamInfo.AdEndBounceCount || 0) + ' marker bounces, ' + (elapsedSinceCandidate / 1000).toFixed(1) + 's since first clean poll');
+                }
                 if (!hasLiveSegments) {
                     console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
                 }
@@ -1315,11 +1345,13 @@
                 streamInfo.IsStrippingAdSegments = false;
                 streamInfo.NumStrippedAdSegments = 0;
                 streamInfo.ActiveBackupPlayerType = null;
-                streamInfo.RequestedAds.clear();
-                streamInfo.FailedBackupPlayerTypes.clear();
+                streamInfo.RequestedAds?.clear?.();
+                streamInfo.FailedBackupPlayerTypes?.clear?.();
                 if (streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType.clear();
                 streamInfo.LoggedContamReorderThisBreak = false;
                 streamInfo.CleanPlaylistCount = 0;
+                streamInfo.PendingAdEndAt = 0;
+                streamInfo.AdEndBounceCount = 0;
                 streamInfo.ConsecutiveAllStrippedPolls = 0;
                 streamInfo.EarlyReloadTriggered = false;
                 streamInfo.EarlyReloadAwaitingResult = false;

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -91,6 +91,8 @@ twitch-videoad.js text/javascript
             RecoverySegments: [],
             RecoveryStartSeq: undefined,
             CleanPlaylistCount: 0,
+            PendingAdEndAt: 0,
+            AdEndBounceCount: 0,
             ConsecutiveZeroStripBreaks: 0,
             UseFallbackStream: false,
             LastCleanNativeM3U8: null,
@@ -754,10 +756,24 @@ twitch-videoad.js text/javascript
                 const streamM3u8 = await streamM3u8Response.text();
                 if (streamM3u8 != null) {
                     if (!hasAdTags(streamM3u8) && SimulatedAdsDepth == 0) {
+                        // Mirrors TTV-AB v6.6.7 #1: mark first candidate-end timestamp on the first
+                        // clean main-stream poll, so the slow-path max-wait gate below can fire even
+                        // if subsequent polls bounce back to ad-marked.
+                        if (!streamInfo.PendingAdEndAt) {
+                            streamInfo.PendingAdEndAt = Date.now();
+                        }
                         streamInfo.CleanPlaylistCount++;
                         // Check if the current playlist has live segments — if not, backup stream is dead
                         const hasLiveSegments = textStr.includes(LIVE_SIGNIFIER);
-                        if (streamInfo.CleanPlaylistCount >= 2 || !hasLiveSegments) {
+                        // Mirrors TTV-AB v6.6.7 #4: independent slow-path max-wait escalation gate so
+                        // bouncing markers can't wedge the player on backup indefinitely.
+                        const adEndMaxWaitMs = 12000;
+                        const elapsedSinceCandidate = Date.now() - streamInfo.PendingAdEndAt;
+                        const slowPathReady = streamInfo.PendingAdEndAt > 0 && elapsedSinceCandidate >= adEndMaxWaitMs;
+                        if (streamInfo.CleanPlaylistCount >= 2 || !hasLiveSegments || slowPathReady) {
+                            if (slowPathReady && streamInfo.CleanPlaylistCount < 2) {
+                                console.log('[AD DEBUG] Slow-path ad-end escalation — ' + (streamInfo.AdEndBounceCount || 0) + ' marker bounces, ' + (elapsedSinceCandidate / 1000).toFixed(1) + 's since first clean poll');
+                            }
                             if (!hasLiveSegments) {
                                 console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
                             }
@@ -777,17 +793,29 @@ twitch-videoad.js text/javascript
                             streamInfo.HasLoggedCsaiFastPath = false;
                             streamInfo.HasLoggedAdAttributes = false;
                             streamInfo.HasLoggedUnknownSignifiers = false;
-                            streamInfo.RequestedAds.clear();
+                            streamInfo.RequestedAds?.clear?.();
                             streamInfo.ConsecutiveAllStrippedPolls = 0;
                             streamInfo.EarlyReloadTriggered = false;
                             streamInfo.IsMovingOffBackupEncodings = true;
                             streamInfo.BackupEncodings = null;
-                            streamInfo.BackupEncodingsStatus.clear();
+                            streamInfo.BackupEncodingsStatus?.clear?.();
                             streamInfo.BackupEncodingsPlayerTypeIndex = -1;
                             streamInfo.CleanPlaylistCount = 0;
+                            streamInfo.PendingAdEndAt = 0;
+                            streamInfo.AdEndBounceCount = 0;
                             postMessage({key: ReloadPlayerAfterAd ? 'UboReloadPlayer' : 'UboPauseResumePlayer'});
                         }
                     } else {
+                        // Mirrors TTV-AB v6.6.7 #1: bounce-tolerant reset keeps PendingAdEndAt alive
+                        // across short flips back to ad-marked, so the slow-path max-wait gate can
+                        // still fire when bouncing markers prevent CleanPlaylistCount progress.
+                        const adEndStalenessMs = 12000;
+                        if (streamInfo.PendingAdEndAt && (Date.now() - streamInfo.PendingAdEndAt) < adEndStalenessMs) {
+                            streamInfo.AdEndBounceCount = (streamInfo.AdEndBounceCount || 0) + 1;
+                        } else {
+                            streamInfo.PendingAdEndAt = 0;
+                            streamInfo.AdEndBounceCount = 0;
+                        }
                         streamInfo.CleanPlaylistCount = 0;
                         if (!streamM3u8.includes('"MIDROLL"') && !streamM3u8.includes('"midroll"')) {
                             const lines = streamM3u8.split(/\r?\n/);

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -102,6 +102,8 @@
             RecoverySegments: [],
             RecoveryStartSeq: undefined,
             CleanPlaylistCount: 0,
+            PendingAdEndAt: 0,// Timestamp of first clean backup-poll seen this break — drives the bounce-tolerant max-wait escalation gate (TTV-AB v6.6.7 #1/#4)
+            AdEndBounceCount: 0,// Count of ad-marker bounces while PendingAdEndAt is alive — telemetry only
             ConsecutiveZeroStripBreaks: 0,
             UseFallbackStream: false,
             LastCleanNativeM3U8: null,
@@ -768,10 +770,27 @@
                 const streamM3u8 = await streamM3u8Response.text();
                 if (streamM3u8 != null) {
                     if (!hasAdTags(streamM3u8) && SimulatedAdsDepth == 0) {
+                        // Mark first candidate-end timestamp on the first clean main-stream poll seen this
+                        // break, so the slow-path max-wait gate below can fire even if subsequent polls
+                        // bounce back to ad-marked. Mirrors TTV-AB v6.6.7 #1.
+                        if (!streamInfo.PendingAdEndAt) {
+                            streamInfo.PendingAdEndAt = Date.now();
+                        }
                         streamInfo.CleanPlaylistCount++;
                         // Check if the current playlist has live segments — if not, backup stream is dead
                         const hasLiveSegments = textStr.includes(LIVE_SIGNIFIER);
-                        if (streamInfo.CleanPlaylistCount >= 2 || !hasLiveSegments) {
+                        // Independent slow-path max-wait escalation — ends the visible ad cycle even
+                        // when marker bouncing keeps CleanPlaylistCount below threshold. Without this,
+                        // the player can be wedged on backup indefinitely on channels where Twitch flips
+                        // markers in/out faster than 2 consecutive clean polls can land. Mirrors TTV-AB
+                        // v6.6.7 #4 ("Decoupled Slow-Path Recovery from Clean-Count").
+                        const adEndMaxWaitMs = 12000;
+                        const elapsedSinceCandidate = Date.now() - streamInfo.PendingAdEndAt;
+                        const slowPathReady = streamInfo.PendingAdEndAt > 0 && elapsedSinceCandidate >= adEndMaxWaitMs;
+                        if (streamInfo.CleanPlaylistCount >= 2 || !hasLiveSegments || slowPathReady) {
+                            if (slowPathReady && streamInfo.CleanPlaylistCount < 2) {
+                                console.log('[AD DEBUG] Slow-path ad-end escalation — ' + (streamInfo.AdEndBounceCount || 0) + ' marker bounces, ' + (elapsedSinceCandidate / 1000).toFixed(1) + 's since first clean poll');
+                            }
                             if (!hasLiveSegments) {
                                 console.log('[AD DEBUG] Backup stream has no live segments — forcing immediate reload');
                             }
@@ -791,17 +810,29 @@
                             streamInfo.HasLoggedCsaiFastPath = false;
                             streamInfo.HasLoggedAdAttributes = false;
                             streamInfo.HasLoggedUnknownSignifiers = false;
-                            streamInfo.RequestedAds.clear();
+                            streamInfo.RequestedAds?.clear?.();
                             streamInfo.ConsecutiveAllStrippedPolls = 0;
                             streamInfo.EarlyReloadTriggered = false;
                             streamInfo.IsMovingOffBackupEncodings = true;
                             streamInfo.BackupEncodings = null;
-                            streamInfo.BackupEncodingsStatus.clear();
+                            streamInfo.BackupEncodingsStatus?.clear?.();
                             streamInfo.BackupEncodingsPlayerTypeIndex = -1;
                             streamInfo.CleanPlaylistCount = 0;
+                            streamInfo.PendingAdEndAt = 0;
+                            streamInfo.AdEndBounceCount = 0;
                             postMessage({key: ReloadPlayerAfterAd ? 'UboReloadPlayer' : 'UboPauseResumePlayer'});
                         }
                     } else {
+                        // Bounce-tolerant reset: keep PendingAdEndAt alive across short flips back to ad-marked
+                        // so the slow-path max-wait gate can still fire when bouncing markers prevent
+                        // CleanPlaylistCount from reaching threshold. Mirrors TTV-AB v6.6.7 #1.
+                        const adEndStalenessMs = 12000;
+                        if (streamInfo.PendingAdEndAt && (Date.now() - streamInfo.PendingAdEndAt) < adEndStalenessMs) {
+                            streamInfo.AdEndBounceCount = (streamInfo.AdEndBounceCount || 0) + 1;
+                        } else {
+                            streamInfo.PendingAdEndAt = 0;
+                            streamInfo.AdEndBounceCount = 0;
+                        }
                         streamInfo.CleanPlaylistCount = 0;
                         if (!streamM3u8.includes('"MIDROLL"') && !streamM3u8.includes('"midroll"')) {
                             const lines = streamM3u8.split(/\r?\n/);


### PR DESCRIPTION
## Summary

Two-part fix for the field-observed "wedged on backup forever" symptom (issue #129 and similar reports): when Twitch flips ad markers in/out of the playlist faster than `CleanPlaylistCount` reaches its threshold, `IsShowingAd` stays stuck true for the entire ad break and the player remains on the backup stream silently.

Ports TTV-AB v6.6.7 #1 (Bouncing-marker candidate-end preservation) and #4 (Decoupled Slow-Path Recovery from Clean-Count) to all four release scripts.

**Stacked on PR #184** — vaft uses `CleanPlaylistCount >= 3` from #184; the slow-path gate works regardless of the threshold value.

## The two fixes

### #1 — Bounce-tolerant candidate-end preservation

New `StreamInfo` fields: `PendingAdEndAt` (timestamp of first clean poll seen this break) + `AdEndBounceCount` (telemetry counter).

Previously every ad-marked poll reset `CleanPlaylistCount = 0`, and the candidate-end state was lost entirely on a single bounce — so the slow-path escalation could never arm. The new haveAdTags reset keeps `PendingAdEndAt` alive when the gap between candidate-end and the bounce is under a 12s staleness window.

```js
// before:
if (haveAdTags) {
    streamInfo.CleanPlaylistCount = 0;
    ...

// after:
if (haveAdTags) {
    const adEndStalenessMs = 12000;
    if (streamInfo.PendingAdEndAt && (Date.now() - streamInfo.PendingAdEndAt) < adEndStalenessMs) {
        streamInfo.AdEndBounceCount = (streamInfo.AdEndBounceCount || 0) + 1;
    } else {
        streamInfo.PendingAdEndAt = 0;
        streamInfo.AdEndBounceCount = 0;
    }
    streamInfo.CleanPlaylistCount = 0;
    ...
```

### #4 — Decoupled slow-path max-wait escalation

Independent escalation gate in the clean-poll branch: if `PendingAdEndAt` is set and elapsed ≥ 12s, declare ad-end regardless of `CleanPlaylistCount`. Without this, channels where Twitch oscillates markers faster than the per-poll cadence (~2s) can pin the player on the backup stream indefinitely because `CleanPlaylistCount` never reaches 3 (vaft) or 2 (video-swap-new).

```js
// added before existing threshold check:
if (!streamInfo.PendingAdEndAt) {
    streamInfo.PendingAdEndAt = Date.now();
}
streamInfo.CleanPlaylistCount++;
const adEndMaxWaitMs = 12000;
const elapsedSinceCandidate = Date.now() - streamInfo.PendingAdEndAt;
const slowPathReady = streamInfo.PendingAdEndAt > 0 && elapsedSinceCandidate >= adEndMaxWaitMs;
if (streamInfo.CleanPlaylistCount >= N || !hasLiveSegments || slowPathReady) {
    if (slowPathReady && streamInfo.CleanPlaylistCount < N) {
        console.log('[AD DEBUG] Slow-path ad-end escalation — ' + ... + ' marker bounces, ' + ... + 's since first clean poll');
    }
    ...
```

The diagnostic log fires only when the slow-path gate is what triggered the end (not when the clean-count would have been enough on its own), so field reports have a clear signal that this path engaged.

### Side fix — optional chaining on resets

Switched `RequestedAds.clear()`, `FailedBackupPlayerTypes.clear()`, and `BackupEncodingsStatus.clear()` to optional chaining (`?.clear?.()`) in the end-of-break reset blocks. Mirrors TTV-AB v6.6.7 #3's defensive pattern. Cheap insurance against any future StreamInfo initialization race.

## Why 12s for both windows

TTV-AB uses `MAX_WAIT_MS = 4000ms` measured against their native-recovery probe cadence (500ms). For vaft/video-swap-new, the m3u8 polling cadence is ~2s naturally, so `MAX_WAIT_MS = 12000ms` ≈ 6 polls — gives the clean-count path enough time to win normally, escalates only on persistent bouncing. Staleness window matches at 12s so the bounce-tolerant reset has the same lifetime as the gate it feeds.

## What this changes for users

- **SSAI-uniform / bouncing-marker channels** (warn / pge4 / dafran / channels in issue #129): ad-end declares within ~12s of first clean poll instead of "never until break ends naturally." User exits the silent-backup state and the player either resumes native (clean) or reloads (per existing logic).
- **Normal channels**: no change — clean-count path wins well within 12s.
- **Strip-success path**: no change — `CleanPlaylistCount >= N` typically fires within ~6s anyway.

## Scope

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js`
- `video-swap-new/video-swap-new-ublock-origin.js`

Testing variants will be ported in a follow-up direct-to-master commit (per the testing-vs-release split).

## Note on #3 (try/catch)

TTV-AB v6.6.7 #3 also added try/catch around `_isAdEndStable` and backup-refresh awaits inside `_processM3U8`. vaft and video-swap-new have no awaits at the equivalent locations (the clean-branch is sync), so that part of #3 is N/A here. Only the optional-chaining pattern applies.

## Test plan

- [x] `npx acorn --ecma2022` passes all four files
- [ ] Field test on warn / pge4 / SSAI-uniform channels: confirm `Slow-path ad-end escalation` log fires when previously-stuck breaks end
- [ ] Verify normal-channel behavior unchanged (clean-count path wins, no slow-path log)
- [ ] Confirm `AdEndBounceCount` telemetry shows reasonable numbers (1-5 per stuck break, 0 for normal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)