### PR TITLE
vaft + video-swap-new: fix pre-mute restore listener targeting wrong <video> element

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -2089,9 +2089,24 @@ twitch-videoad.js text/javascript
                     const v = document.querySelector('video');
                     if (v && !v.muted) {
                         v.muted = true;
-                        const restore = () => { try { document.querySelector('video').muted = false; } catch {} };
-                        v.addEventListener('canplay', restore, { once: true });
-                        setTimeout(restore, 1500);
+                        // setSrc replaces the <video>, so a canplay listener on the original
+                        // `v` never fires — listen on document (capture) so we catch canplay
+                        // on whichever element Twitch attaches the new MediaSource to.
+                        let done = false;
+                        const restore = () => {
+                            if (done) return;
+                            done = true;
+                            document.removeEventListener('canplay', listener, true);
+                            try {
+                                const cur = document.querySelector('video');
+                                if (cur) cur.muted = false;
+                            } catch {}
+                        };
+                        const listener = (e) => {
+                            if (e.target && e.target.tagName === 'VIDEO') restore();
+                        };
+                        document.addEventListener('canplay', listener, true);
+                        setTimeout(restore, 2500);
                     }
                 } catch {}
             }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -2173,9 +2173,28 @@
                     const v = document.querySelector('video');
                     if (v && !v.muted) {
                         v.muted = true;
-                        const restore = () => { try { document.querySelector('video').muted = false; } catch {} };
-                        v.addEventListener('canplay', restore, { once: true });
-                        setTimeout(restore, 1500);
+                        // setSrc({isNewMediaPlayerInstance:true}) replaces the <video> element,
+                        // so a `canplay` listener on the original `v` never fires — the event
+                        // fires on the new element. Listen on document (capture phase) instead
+                        // so we catch canplay regardless of which <video> Twitch attaches the
+                        // new MediaSource to. Idempotent guard prevents double-fire from the
+                        // safety-net setTimeout racing the listener (Edge MSE init can be
+                        // slower than Chrome — bumped 1500ms→2500ms for that slack).
+                        let done = false;
+                        const restore = () => {
+                            if (done) return;
+                            done = true;
+                            document.removeEventListener('canplay', listener, true);
+                            try {
+                                const cur = document.querySelector('video');
+                                if (cur) cur.muted = false;
+                            } catch {}
+                        };
+                        const listener = (e) => {
+                            if (e.target && e.target.tagName === 'VIDEO') restore();
+                        };
+                        document.addEventListener('canplay', listener, true);
+                        setTimeout(restore, 2500);
                     }
                 } catch {}
             }

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -1390,9 +1390,23 @@ twitch-videoad.js text/javascript
             const v = document.querySelector('video');
             if (v && !v.muted) {
                 v.muted = true;
-                const restore = () => { try { document.querySelector('video').muted = false; } catch {} };
-                v.addEventListener('canplay', restore, { once: true });
-                setTimeout(restore, 1500);
+                // setSrc replaces the <video>, so a canplay listener on the original
+                // `v` never fires — listen on document (capture) instead.
+                let done = false;
+                const restore = () => {
+                    if (done) return;
+                    done = true;
+                    document.removeEventListener('canplay', listener, true);
+                    try {
+                        const cur = document.querySelector('video');
+                        if (cur) cur.muted = false;
+                    } catch {}
+                };
+                const listener = (e) => {
+                    if (e.target && e.target.tagName === 'VIDEO') restore();
+                };
+                document.addEventListener('canplay', listener, true);
+                setTimeout(restore, 2500);
             }
         } catch {}
         playerState.setSrc({ isNewMediaPlayerInstance: true, refreshAccessToken: true });

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -1413,9 +1413,23 @@
             const v = document.querySelector('video');
             if (v && !v.muted) {
                 v.muted = true;
-                const restore = () => { try { document.querySelector('video').muted = false; } catch {} };
-                v.addEventListener('canplay', restore, { once: true });
-                setTimeout(restore, 1500);
+                // setSrc replaces the <video>, so a canplay listener on the original
+                // `v` never fires — listen on document (capture) instead.
+                let done = false;
+                const restore = () => {
+                    if (done) return;
+                    done = true;
+                    document.removeEventListener('canplay', listener, true);
+                    try {
+                        const cur = document.querySelector('video');
+                        if (cur) cur.muted = false;
+                    } catch {}
+                };
+                const listener = (e) => {
+                    if (e.target && e.target.tagName === 'VIDEO') restore();
+                };
+                document.addEventListener('canplay', listener, true);
+                setTimeout(restore, 2500);
             }
         } catch {}
         playerState.setSrc({ isNewMediaPlayerInstance: true, refreshAccessToken: true });


### PR DESCRIPTION
## Summary
- PR #189 (v64.1.0) added a pre-mute through hard reload to hide the MSE-teardown audio click. Restore was wired via `v.addEventListener('canplay', restore, { once: true })` on the current `<video>` element with a 1500ms safety setTimeout backstop.
- `setSrc({ isNewMediaPlayerInstance: true })` tears down MSE and Twitch creates a **new** `<video>` element. The `canplay` listener was on the now-detached original element, so the event fired on the new element with no listener attached — the listener path never restored unmute.
- The 1500ms safety setTimeout did fire, but on browsers with slower MSE init (Edge especially) it could land before the new element was attached/decoded, leaving the player muted until manually toggled.

## Field signal
[Issue #200](https://github.com/ryanbr/TwitchAdSolutions/issues/200) — Edge / Tampermonkey / vaft v71. User on heavy SSAI-uniform channels (`fifakillvizualz`, `imnio`) where every ad break ends with a post-escape hard reload. Manifested as "self-mute every few minutes" — every ad break triggered the bug. User reported the classic Twitch-after-setSrc audio-state desync recovery: "you have to unmute and mute and unmute to get audio back".

## Fix
- Listen on `document` (capture phase) so the `canplay` event from **any** `<video>` element triggers the restore. Catches the new MediaSource attach regardless of when Twitch creates the element.
- Idempotent guard (`done` flag) prevents the safety setTimeout from re-applying unmute if the listener already fired (race where Edge's autoplay policy can re-mute briefly during MSE init — re-applying our unmute on top of that doesn't help, but also doesn't hurt).
- Safety net bumped `1500ms` → `2500ms` for Edge/MSE-init slack. Still well within "user notices a click" tolerance if the listener path fails.

Applied to all 4 release files: `vaft.user.js`, `vaft-ublock-origin.js`, `video-swap-new.user.js`, `video-swap-new-ublock-origin.js`. Testing variants ported direct-to-master per the testing/release split.

## Test plan
- [ ] On Edge with vaft, watch an SSAI-uniform channel through 2-3 ad breaks. Confirm audio stays unmuted across post-escape hard reloads (no manual toggle required).
- [ ] On Chrome with vaft, confirm no regression — listener path should fire faster than safety net (no 2500ms silence on hard reload).
- [ ] Confirm pre-mute still suppresses the audio click on hard reload (the original PR #189 fix).
- [ ] Confirm user-mute intent preserved when the user already muted before the reload (`if (v && !v.muted)` guard unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)