### PR TITLE
vaft + video-swap-new: per-link try-catch around Worker.prototype manipulation

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -212,7 +212,8 @@ twitch-videoad.js text/javascript
             const workerString = proto.toString();
             if (workerStringConflicts.some((x) => workerString.includes(x))) {
                 if (parent !== null) {
-                    Object.setPrototypeOf(parent, Object.getPrototypeOf(proto));
+                    // Foreign extension may have frozen Worker.prototype; per-link try-catch.
+                    try { Object.setPrototypeOf(parent, Object.getPrototypeOf(proto)); } catch {}
                 }
             } else {
                 if (root === null) {
@@ -239,7 +240,8 @@ twitch-videoad.js text/javascript
     function reinsertWorkers(worker, reinsert) {
         let parent = worker;
         for (let i = 0; i < reinsert.length; i++) {
-            Object.setPrototypeOf(reinsert[i], parent);
+            // Per-link try-catch: foreign-frozen entry shouldn't abort the chain.
+            try { Object.setPrototypeOf(reinsert[i], parent); } catch {}
             parent = reinsert[i];
         }
         return parent;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -236,7 +236,10 @@
             const workerString = proto.toString();
             if (workerStringConflicts.some((x) => workerString.includes(x))) {
                 if (parent !== null) {
-                    Object.setPrototypeOf(parent, Object.getPrototypeOf(proto));
+                    // Another extension may have frozen Worker.prototype or set non-configurable
+                    // [[Prototype]]; setPrototypeOf throws TypeError in that case. Catch per-link
+                    // so a single foreign-frozen ring doesn't abort the whole chain walk.
+                    try { Object.setPrototypeOf(parent, Object.getPrototypeOf(proto)); } catch {}
                 }
             } else {
                 if (root === null) {
@@ -263,7 +266,9 @@
     function reinsertWorkers(worker, reinsert) {
         let parent = worker;
         for (let i = 0; i < reinsert.length; i++) {
-            Object.setPrototypeOf(reinsert[i], parent);
+            // Per-link try-catch: a foreign extension that froze a single proto entry
+            // shouldn't break the whole reinsertion chain. Skip the failing link, keep going.
+            try { Object.setPrototypeOf(reinsert[i], parent); } catch {}
             parent = reinsert[i];
         }
         return parent;

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -156,7 +156,8 @@ twitch-videoad.js text/javascript
             const workerString = proto.toString();
             if (workerStringConflicts.some((x) => workerString.includes(x)) && !workerStringAllow.some((x) => workerString.includes(x))) {
                 if (parent !== null) {
-                    Object.setPrototypeOf(parent, Object.getPrototypeOf(proto));
+                    // Foreign extension may have frozen Worker.prototype; per-link try-catch.
+                    try { Object.setPrototypeOf(parent, Object.getPrototypeOf(proto)); } catch {}
                 }
             } else {
                 if (root === null) {
@@ -184,7 +185,8 @@ twitch-videoad.js text/javascript
     function reinsertWorkers(worker, reinsert) {
         let parent = worker;
         for (let i = 0; i < reinsert.length; i++) {
-            Object.setPrototypeOf(reinsert[i], parent);
+            // Per-link try-catch: foreign-frozen entry shouldn't abort the chain.
+            try { Object.setPrototypeOf(reinsert[i], parent); } catch {}
             parent = reinsert[i];
         }
         return parent;

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -168,7 +168,8 @@
             const workerString = proto.toString();
             if (workerStringConflicts.some((x) => workerString.includes(x)) && !workerStringAllow.some((x) => workerString.includes(x))) {
                 if (parent !== null) {
-                    Object.setPrototypeOf(parent, Object.getPrototypeOf(proto));
+                    // Foreign extension may have frozen Worker.prototype; per-link try-catch.
+                    try { Object.setPrototypeOf(parent, Object.getPrototypeOf(proto)); } catch {}
                 }
             } else {
                 if (root === null) {
@@ -196,7 +197,8 @@
     function reinsertWorkers(worker, reinsert) {
         let parent = worker;
         for (let i = 0; i < reinsert.length; i++) {
-            Object.setPrototypeOf(reinsert[i], parent);
+            // Per-link try-catch: foreign-frozen entry shouldn't abort the chain.
+            try { Object.setPrototypeOf(reinsert[i], parent); } catch {}
             parent = reinsert[i];
         }
         return parent;


### PR DESCRIPTION
## Summary
- `getCleanWorker()` and `reinsertWorkers()` walk the `Worker` prototype chain calling `Object.setPrototypeOf()` on each link to splice out conflicting (foreign-extension) Worker subclasses and reinsert friendlies.
- If a foreign extension or page script has frozen `Worker.prototype` or made `[[Prototype]]` non-configurable, `Object.setPrototypeOf()` throws `TypeError`. The exception propagates up out of `hookWindowWorker`, the Worker hook installation fails entirely, and ad blocking is silently disabled for the session — no debug log explains why.
- Wrap each `setPrototypeOf()` in its own try-catch so a single foreign-frozen ring doesn't abort the chain walk. Skip the failing link, keep processing the rest. Worst case: that one link isn't rerouted as intended, but the remaining cleanup still applies and the Worker hook installs.

Two sites per file: `getCleanWorker()` (chain cleanup) and `reinsertWorkers()` (post-extension reinsertion). Total +6 try-catch wrappers across 4 release files (`vaft.user.js`, `vaft-ublock-origin.js`, `video-swap-new.user.js`, `video-swap-new-ublock-origin.js`).

Mirrors [TTV-AB v7.0.1](https://github.com/GosuDRM/TTV-AB/blob/main/CHANGELOG.md#701---2026-05-05)'s "Worker Hook Crash Resilience" fix — same defensive pattern. No field report yet, defensive only.

## Test plan
- [ ] No regression in normal Worker hook installation (no foreign Worker.prototype freezing) — should behave identically.
- [ ] If you can reproduce a foreign-frozen Worker.prototype scenario (other extensions / userscripts that hook Worker too), confirm vaft now installs cleanly instead of failing silently.
- [ ] Validate JS syntax (already passing in this branch via the existing GitHub Actions Validate JS workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)