### PR TITLE
vaft + video-swap-new: try-catch around worker eval(workerString) call

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -374,7 +374,9 @@ twitch-videoad.js text/javascript
                         }
                     });
                     hookWorkerFetch();
-                    eval(workerString);
+                    // Guard the eval — malformed workerString shouldn't silently break
+                    // Twitch's player logic without a diagnostic.
+                    try { eval(workerString); } catch (e) { console.error('[AD DEBUG] Worker eval failed — Twitch player logic not loaded:', e); }
                 `;
                 if (injectedBlobUrl && originalRevokeObjectURL) {
                     try { originalRevokeObjectURL.call(URL, injectedBlobUrl); } catch {}

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -398,7 +398,10 @@
                         }
                     });
                     hookWorkerFetch();
-                    eval(workerString);
+                    // Guard the eval — malformed workerString shouldn't silently break
+                    // Twitch's player logic without a diagnostic. Worker stays alive on
+                    // throw (vaft hooks installed above), but Twitch's logic wouldn't run.
+                    try { eval(workerString); } catch (e) { console.error('[AD DEBUG] Worker eval failed — Twitch player logic not loaded:', e); }
                 `;
                 // Revoke previous blob URL to prevent memory accumulation across worker replacements
                 if (injectedBlobUrl && originalRevokeObjectURL) {

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -307,7 +307,9 @@ twitch-videoad.js text/javascript
                         }
                     });
                     hookWorkerFetch();
-                    eval(workerString);
+                    // Guard the eval — malformed workerString shouldn't silently break
+                    // Twitch's player logic without a diagnostic.
+                    try { eval(workerString); } catch (e) { console.error('[AD DEBUG] Worker eval failed — Twitch player logic not loaded:', e); }
                 `
                 if (injectedBlobUrl && originalRevokeObjectURL) {
                     try { originalRevokeObjectURL.call(URL, injectedBlobUrl); } catch {}

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -319,7 +319,9 @@
                         }
                     });
                     hookWorkerFetch();
-                    eval(workerString);
+                    // Guard the eval — malformed workerString shouldn't silently break
+                    // Twitch's player logic without a diagnostic.
+                    try { eval(workerString); } catch (e) { console.error('[AD DEBUG] Worker eval failed — Twitch player logic not loaded:', e); }
                 `
                 if (injectedBlobUrl && originalRevokeObjectURL) {
                     try { originalRevokeObjectURL.call(URL, injectedBlobUrl); } catch {}


### PR DESCRIPTION
## Summary
- Inside the worker blob, `eval(workerString)` executes Twitch's fetched player logic. The workerString comes from `getWasmWorkerJs()` which is already wrapped in caller-side try-catch — but the eval itself isn't.
- If workerString is malformed (Twitch changes the blob format, network corruption returns partial JS, etc.), the throw goes **uncaught inside the worker**. Per the HTML spec, this fires an `error` event but doesn't kill the worker. Vaft's message handlers and fetch hook are installed **before** the eval, so they keep running — but Twitch's player logic never runs.
- Result: weird player init issues (no playback, missing UI, no ads served, etc.) with **no diagnostic** explaining why. The page-side `error` event handler for the worker may log noise, but it doesn't point at the eval failure.
- Wrap the eval in try-catch with `console.error('[AD DEBUG] Worker eval failed — Twitch player logic not loaded:', e)` so the failure mode surfaces. No behavior change in the happy path.

Same defensive pattern as PR #203's Worker.prototype try-catch and [TTV-AB v6.8.0](https://github.com/GosuDRM/TTV-AB/blob/main/CHANGELOG.md#680---2026-05-01)'s "Worker eval Crash Guard" fix.

Applied to all 4 release files (`vaft.user.js`, `vaft-ublock-origin.js`, `video-swap-new.user.js`, `video-swap-new-ublock-origin.js`). Testing variants ported direct-to-master per the testing/release split.

## Test plan
- [ ] Normal Twitch playback — no eval failures, no console error logged. Worker behaves identically to before.
- [ ] Validate JS syntax (already passing in this branch via the existing GitHub Actions Validate JS workflow).
- [ ] If reproducible, simulate a malformed workerString (e.g. corrupt the cache) and confirm the console error fires with the exception message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)