### PR TITLE
vaft + video-swap-new: add twitch-trigger DATERANGE class to ad signifiers

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -51,7 +51,7 @@ twitch-videoad.js text/javascript
         // prefixed so we don't re-introduce the PR #120 false-positive from bare
         // 'stitched' substring match. The specific twitch-stitched-ad DATERANGE
         // marker is a subset of this prefix.
-        scope.AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
+        scope.AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"'];
         scope.AdSegmentURLPatterns = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -61,7 +61,7 @@
         // prefixed so we don't re-introduce the PR #120 false-positive from bare
         // 'stitched' substring match. The specific twitch-stitched-ad DATERANGE
         // marker is a subset of this prefix.
-        scope.AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
+        scope.AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"'];
         scope.AdSegmentURLPatterns = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -53,7 +53,7 @@ twitch-videoad.js text/javascript
         // (-ad, -mid, -pod, etc.) without requiring an exact -ad suffix. Twitch-
         // prefixed so we don't re-introduce the PR #120 false-positive from bare
         // 'stitched' substring match.
-        scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
+        scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"'];
         scope.AD_SEGMENT_URL_PATTERNS = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -64,7 +64,7 @@
         // (-ad, -mid, -pod, etc.) without requiring an exact -ad suffix. Twitch-
         // prefixed so we don't re-introduce the PR #120 false-positive from bare
         // 'stitched' substring match.
-        scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"'];
+        scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"'];
         scope.AD_SEGMENT_URL_PATTERNS = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals


### PR DESCRIPTION
## Summary
Adds `EXT-X-DATERANGE:CLASS="twitch-trigger"` to the AdSignifiers list in vaft and AD_SIGNIFIERS in video-swap-new. This DATERANGE class consistently appears in ad-context m3u8s on SSAI-uniform channels and lets `hasAdTags()` recognize ad m3u8s on the first poll instead of waiting for `stitched-ad` / `twitch-stitched` markers to materialize.

## Field evidence
The "Potential ad markers seen but not in AdSignifiers: ... twitch-trigger" diagnostic log has been firing across field reports on multiple channels for weeks:
- `mande`, `nicewigg`, `thatmartinkidtv`, `fifakillvizualz`, `warn`, `slvm`, `imnio`, `timthetatman`

In every captured field log, `twitch-trigger` appears **only in ad-detected polls** — never observed outside an active ad break.

## Why this is safe to ship to release
1. **Sibling DATERANGE classes are purpose-distinct**: `twitch-session` (session ID metadata), `twitch-stream-source` (source metadata), `twitch-maf-ad` (already in AdSignifiers as ad marker). Twitch's CLASS namespace is fine-grained — `twitch-trigger` belongs to the ad-trigger family.
2. **Bounded blast radius if wrong**: false positive = backup search runs when not needed → autoplay 360p commit if all backups also "have ads" → annoying for one break, easily reverted.
3. **Currently soaking on testing variant** (commits `5293a27` + `4f0334a`, vaft testing v628). Soak surfaced no false-positive reports.

## Concrete benefits
- **FastAutoplayFirstTry hybrid skip path actually fires** ([PR #205](https://github.com/ryanbr/TwitchAdSolutions/pull/205)). Previously dead code on canonical SSAI-uniform target channels because site appeared clean on poll 1 of armed breaks. With `twitch-trigger` recognized, site reports dirty immediately → hybrid jumps to autoplay → ~1s probe-loop savings per armed break.
- **Earlier ad detection on these channels for all users** (not just hybrid-enabled ones). `hasAdTags` returns true on poll 1 instead of poll 2.

## Test plan
- [ ] On a heavy SSAI-uniform channel (warn / mande / slvm / nicewigg) with `twitchAdSolutions_fastAutoplayFirstTry=true`, watch through 2+ ad breaks. The second break should fire `[AD DEBUG] FastAutoplayFirstTry hybrid: site contaminated — skipping [popout, mobile_web, embed] and jumping to autoplay (SSAI-uniform pattern continues)` — proving the hybrid skip path is now active.
- [ ] Field-watch for `[AD DEBUG] Backup stream (X) also has ads` firing on streams without real ad breaks. If observed, `twitch-trigger` is too broad and we should revert.
- [ ] No regression in `hadStrippedSegments` accounting on regular ad breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)