### PR TITLE
chore: drop unused params and stale commented entries (no behavior change)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -73,7 +73,6 @@ twitch-videoad.js text/javascript
             // 'autoplay' (360p) removed: when committed as cycle backup, the player gets stuck
             // in an endless loading circle after the CSAI-only path releases the backup —
             // autoplay variants don't transition cleanly back to main stream variants.
-            //'picture-by-picture-CACHED'//360p (-CACHED is an internal suffix and is removed)
         ];
         scope.FallbackPlayerType = 'site';// was 'embed' — site is more reliable when all Source types end up ad-laden
         scope.ForceAccessTokenPlayerType = 'popout';
@@ -1517,10 +1516,10 @@ twitch-videoad.js text/javascript
                 }
             }
         };
-        return gqlRequest(body, playerType);
+        return gqlRequest(body);
     }
     // Send a GQL request to Twitch via the main thread (workers can't make credentialed requests)
-    function gqlRequest(body, playerType) {
+    function gqlRequest(body) {
         if (!GQLDeviceID) {
             GQLDeviceID = '';
             const dcharacters = 'abcdefghijklmnopqrstuvwxyz0123456789';
@@ -2219,7 +2218,7 @@ twitch-videoad.js text/javascript
         let hasLoggedHeaders = false;
         const realFetch = window.fetch;
         window.realFetch = realFetch;
-        window.fetch = maskAsNative(function(url, init, ...args) {
+        window.fetch = maskAsNative(function(url, init) {
             if (typeof url === 'string') {
                 if (url.includes('gql')) {
                     let deviceId = init.headers['X-Device-Id'];

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -83,7 +83,6 @@
             // 'autoplay' (360p) removed: when committed as cycle backup, the player gets stuck
             // in an endless loading circle after the CSAI-only path releases the backup —
             // autoplay variants don't transition cleanly back to main stream variants.
-            //'picture-by-picture-CACHED'//360p (-CACHED is an internal suffix and is removed)
         ];
         scope.FallbackPlayerType = 'site';// was 'embed' — site is more reliable when all Source types end up ad-laden
         scope.ForceAccessTokenPlayerType = 'popout';
@@ -1583,10 +1582,10 @@
                 }
             }
         };
-        return gqlRequest(body, playerType);
+        return gqlRequest(body);
     }
     // Send a GQL request to Twitch via the main thread (workers can't make credentialed requests)
-    function gqlRequest(body, playerType) {
+    function gqlRequest(body) {
         if (!GQLDeviceID) {
             GQLDeviceID = '';
             const dcharacters = 'abcdefghijklmnopqrstuvwxyz0123456789';
@@ -2318,7 +2317,7 @@
         let hasLoggedHeaders = false;
         const realFetch = window.fetch;
         window.realFetch = realFetch;
-        window.fetch = maskAsNative(function(url, init, ...args) {
+        window.fetch = maskAsNative(function(url, init) {
             if (typeof url === 'string') {
                 if (url.includes('gql')) {
                     let deviceId = init.headers['X-Device-Id'];

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -1056,9 +1056,9 @@ twitch-videoad.js text/javascript
                 }
             }
         };
-        return gqlRequest(body, playerType);
+        return gqlRequest(body);
     }
-    function gqlRequest(body, playerType) {
+    function gqlRequest(body) {
         if (!gql_device_id) {
             gql_device_id = '';
             const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
@@ -1157,7 +1157,7 @@ twitch-videoad.js text/javascript
         let hasLoggedHeaders = false;
         const realFetch = window.fetch;
         window.realFetch = realFetch;
-        window.fetch = maskAsNative(function(url, init, ...args) {
+        window.fetch = maskAsNative(function(url, init) {
             if (typeof url === 'string') {
                 if (url.includes('gql')) {
                     let deviceId = init.headers['X-Device-Id'];

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -1077,9 +1077,9 @@
                 }
             }
         };
-        return gqlRequest(body, playerType);
+        return gqlRequest(body);
     }
-    function gqlRequest(body, playerType) {
+    function gqlRequest(body) {
         if (!gql_device_id) {
             gql_device_id = '';
             const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
@@ -1178,7 +1178,7 @@
         let hasLoggedHeaders = false;
         const realFetch = window.fetch;
         window.realFetch = realFetch;
-        window.fetch = maskAsNative(function(url, init, ...args) {
+        window.fetch = maskAsNative(function(url, init) {
             if (typeof url === 'string') {
                 if (url.includes('gql')) {
                     let deviceId = init.headers['X-Device-Id'];


### PR DESCRIPTION
## Summary

Pure dead-code cleanup. No functional change, no version bump (per CLAUDE.md, version bumps are for functional changes only).

Three items, applied symmetrically across vaft + video-swap-new and their uBO twins:

1. **`gqlRequest`'s `playerType` parameter** was never read inside the function body. The playerType info is already encoded into the GQL body's `variables` object, so the parameter was redundant context. Dropped from both the signature and the single call site (inside `getAccessToken`).

2. **Commented-out `'picture-by-picture-CACHED'` entry** in `BackupPlayerTypes`. Stale leftover from an earlier removal. The adjacent comment block already documents the policy (autoplay/PiP variants don't transition cleanly back to main stream variants). If we ever want PiP back, a fresh entry after field-testing is cleaner than uncommenting a line whose `-CACHED` suffix may not match current cache-key conventions.

3. **`window.fetch` hook's `...args` rest parameter** was never read — the body forwards via `realFetch.apply(this, arguments)`. `arguments` still captures everything passed in regardless of formal-param count, so removing `...args` is a no-op.

## Files

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js`
- `video-swap-new/video-swap-new-ublock-origin.js`

(Same cleanups will be applied to the testing variants as a separate direct-to-master commit per the testing/release split.)

## Test plan

- [ ] vaft loads, ad-block hooks install, normal playback works.
- [ ] During an ad break, backup player-type cycling still produces a usable m3u8 (gqlRequest still functions with one fewer arg).
- [ ] No new console errors on session init.
- [ ] Acorn parse passes (CI).