### PR TITLE
chore: remove commented-out debug probes; use hasAdTags() consistently (no behavior change)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -739,7 +739,7 @@ twitch-videoad.js text/javascript
         // no line-level state — it just flips hasStrippedAdSegments = true on first
         // match. One scan instead of N_lines * N_signifiers scans (~100x fewer
         // includes() calls on a typical 100-line m3u8).
-        if (!hasStrippedAdSegments && AdSignifiers.some((s) => textStr.includes(s))) {
+        if (!hasStrippedAdSegments && hasAdTags(textStr)) {
             hasStrippedAdSegments = true;
         }
         if (hasStrippedAdSegments) {
@@ -941,7 +941,6 @@ twitch-videoad.js text/javascript
                     if (line.startsWith('#EXTINF') && lines.length > i + 1) {
                         if (!line.includes(',live') && !streamInfo.RequestedAds.has(lines[i + 1])) {
                             // Only request one .ts file per .m3u8 request to avoid making too many requests
-                            //console.log('Fetch ad .ts file');
                             streamInfo.RequestedAds.add(lines[i + 1]);
                             fetch(lines[i + 1]).then((response) => response.blob()).catch(() => {});
                             break;
@@ -1659,7 +1658,6 @@ twitch-videoad.js text/javascript
                               playerBufferState.recoveryReloadUsed = false;
                               playerBufferState.userPauseIntent = false;
                               playerBufferState.loggedPauseIntent = false;
-                              //console.log('Channel changed to ' + channelName);
                           }
                       }
                     }
@@ -1675,7 +1673,6 @@ twitch-videoad.js text/javascript
                     const videoEl = player.getHTMLVideoElement?.();
                     const videoCurrentTime = videoEl?.currentTime;
                     if (position !== undefined && bufferedPosition !== undefined) {
-                        //console.log('position:' + position + ' bufferDuration:' + bufferDuration + ' bufferPosition:' + bufferedPosition + ' state: ' + player.core?.state?.state + ' started: ' + playerBufferState.hasStreamStarted);
                         // NOTE: This could be improved. It currently lets the player fully eat the full buffer before it triggers pause/play
                         // Skip the buffer-stall check while the <video> element isn't actively trying
                         // to play: readyState < 2 (MSE init / seek) or paused=true (autoplay-policy /

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -776,7 +776,7 @@
         // no line-level state — it just flips hasStrippedAdSegments = true on first
         // match. One scan instead of N_lines * N_signifiers scans (~100x fewer
         // includes() calls on a typical 100-line m3u8).
-        if (!hasStrippedAdSegments && AdSignifiers.some((s) => textStr.includes(s))) {
+        if (!hasStrippedAdSegments && hasAdTags(textStr)) {
             hasStrippedAdSegments = true;
         }
         if (hasStrippedAdSegments) {
@@ -982,7 +982,6 @@
                     if (line.startsWith('#EXTINF') && lines.length > i + 1) {
                         if (!line.includes(',live') && !streamInfo.RequestedAds.has(lines[i + 1])) {
                             // Only request one .ts file per .m3u8 request to avoid making too many requests
-                            //console.log('Fetch ad .ts file');
                             streamInfo.RequestedAds.add(lines[i + 1]);
                             fetch(lines[i + 1]).then((response) => response.blob()).catch(() => {});
                             break;
@@ -1725,7 +1724,6 @@
                               playerBufferState.recoveryReloadUsed = false;
                               playerBufferState.userPauseIntent = false;
                               playerBufferState.loggedPauseIntent = false;
-                              //console.log('Channel changed to ' + channelName);
                           }
                       }
                     }
@@ -1744,7 +1742,6 @@
                     const videoEl = player.getHTMLVideoElement?.();
                     const videoCurrentTime = videoEl?.currentTime;
                     if (position !== undefined && bufferedPosition !== undefined) {
-                        //console.log('position:' + position + ' bufferDuration:' + bufferDuration + ' bufferPosition:' + bufferedPosition + ' state: ' + player.core?.state?.state + ' started: ' + playerBufferState.hasStreamStarted);
                         // NOTE: This could be improved. It currently lets the player fully eat the full buffer before it triggers pause/play
                         // Skip the buffer-stall check entirely while the <video> element isn't actively
                         // trying to play. Two states this catches:

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -507,7 +507,6 @@ twitch-videoad.js text/javascript
                                                 const lowResInf = encodingsM3u8.match(new RegExp(`^.*(?=\n.*${lowResUrl})`, 'm'))?.[0];
                                                 if (!lowResInf) continue;
                                                 const lowResSettings = parseAttributes(lowResInf.substring(lowResInf.indexOf(':') + 1));
-                                                //console.log('map ' + resSettings['RESOLUTION'] + ' to ' + lowResSettings['RESOLUTION']);
                                                 const codecsKey = 'CODECS';
                                                 if (typeof resSettings[codecsKey] === 'string' && typeof lowResSettings[codecsKey] === 'string' &&
                                                     resSettings[codecsKey].length >= 3 && lowResSettings[codecsKey].length >= 3 &&
@@ -653,7 +652,7 @@ twitch-videoad.js text/javascript
         // no line-level state — it just flips hasStrippedAdSegments = true on first
         // match. One scan instead of N_lines * N_signifiers scans (~100x fewer
         // includes() calls on a typical 100-line m3u8).
-        if (!hasStrippedAdSegments && AD_SIGNIFIERS.some((s) => textStr.includes(s))) {
+        if (!hasStrippedAdSegments && hasAdTags(textStr)) {
             hasStrippedAdSegments = true;
         }
         if (hasStrippedAdSegments) {
@@ -846,7 +845,6 @@ twitch-videoad.js text/javascript
                                 if (line.startsWith('#EXTINF') && lines.length > i + 1) {
                                     if (!line.includes(LIVE_SIGNIFIER) && !streamInfo.RequestedAds.has(lines[i + 1])) {
                                         // Only request one .ts file per .m3u8 request to avoid making too many requests
-                                        //console.log('Fetch ad .ts file');
                                         streamInfo.RequestedAds.add(lines[i + 1]);
                                         fetch(lines[i + 1]).then((response) => response.blob()).catch(() => {});
                                         break;

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -519,7 +519,6 @@
                                                 const lowResInf = encodingsM3u8.match(new RegExp(`^.*(?=\n.*${lowResUrl})`, 'm'))?.[0];
                                                 if (!lowResInf) continue;
                                                 const lowResSettings = parseAttributes(lowResInf.substring(lowResInf.indexOf(':') + 1));
-                                                //console.log('map ' + resSettings['RESOLUTION'] + ' to ' + lowResSettings['RESOLUTION']);
                                                 const codecsKey = 'CODECS';
                                                 if (typeof resSettings[codecsKey] === 'string' && typeof lowResSettings[codecsKey] === 'string' &&
                                                     resSettings[codecsKey].length >= 3 && lowResSettings[codecsKey].length >= 3 &&
@@ -665,7 +664,7 @@
         // no line-level state — it just flips hasStrippedAdSegments = true on first
         // match. One scan instead of N_lines * N_signifiers scans (~100x fewer
         // includes() calls on a typical 100-line m3u8).
-        if (!hasStrippedAdSegments && AD_SIGNIFIERS.some((s) => textStr.includes(s))) {
+        if (!hasStrippedAdSegments && hasAdTags(textStr)) {
             hasStrippedAdSegments = true;
         }
         if (hasStrippedAdSegments) {
@@ -866,7 +865,6 @@
                                 if (line.startsWith('#EXTINF') && lines.length > i + 1) {
                                     if (!line.includes(LIVE_SIGNIFIER) && !streamInfo.RequestedAds.has(lines[i + 1])) {
                                         // Only request one .ts file per .m3u8 request to avoid making too many requests
-                                        //console.log('Fetch ad .ts file');
                                         streamInfo.RequestedAds.add(lines[i + 1]);
                                         fetch(lines[i + 1]).then((response) => response.blob()).catch(() => {});
                                         break;


### PR DESCRIPTION
## Summary

Pure cleanup follow-up to PR #210. No functional change, no version bump.

### A. Remove commented-out `console.log` debug probes

Old trace probes left from past debugging sessions. Re-adding them when needed takes seconds; keeping them in tree forever doesn't pay rent.

- vaft pair (3 each): "Fetch ad .ts file", "Channel changed to ...", "position:... bufferDuration:..."
- video-swap-new pair (2 each): "map RESOLUTION to RESOLUTION", "Fetch ad .ts file"

### B. Use `hasAdTags(textStr)` instead of the inlined `AdSignifiers.some((s) => textStr.includes(s))` pattern

Inside `stripAdSegments`, the same single-line pattern was inlined that the `hasAdTags` helper already implements. Both `stripAdSegments` and `hasAdTags` are serialized into the worker blob (via `.toString()`), so the call resolves correctly in worker context.

Before:
```js
if (!hasStrippedAdSegments && AdSignifiers.some((s) => textStr.includes(s))) {
```

After:
```js
if (!hasStrippedAdSegments && hasAdTags(textStr)) {
```

Same effect; reads better and stays consistent with the other call sites of `hasAdTags()` elsewhere in the file.

## Files

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`
- `video-swap-new/video-swap-new.user.js`
- `video-swap-new/video-swap-new-ublock-origin.js`

(Same cleanups will be mirrored to the testing variants as a separate direct-to-master commit.)

## Test plan

- [ ] vaft loads, ad-block hooks install, normal playback works.
- [ ] Strip activity during an SSAI break still flips `hasStrippedAdSegments` correctly (via `hasAdTags` call instead of the inline form).
- [ ] No new console errors on session init.
- [ ] Acorn parse passes (CI).