### PR TITLE
v66.3.0: avoid autoplay-360p escape hatch on CSAI-only-but-marked breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## v66.3.0 (2026-05-09)
+
+### Bug Fixes
+- **Avoid autoplay-360p escape hatch on CSAI-only-but-marked breaks** — on channels like emongg / sinatraa where the m3u8 contains ad markers (DATERANGE/CUE-OUT) but no actual ad segments to strip, the backup search would treat each Source-tier backup as ad-laden (because `hasAdTags()` matched the markers), exhaust all 4 Source types, and fall through to the `PreferLowQualityBackup` escape hatch — committing autoplay 360p. After the break ended with `stripped 0` (recognized as CSAI-only), a post-escape hard reload fired to restore Source quality, producing a visible loading-circle. New `hasStrippableAdSegments()` helper mirrors the per-segment strip criteria (non-live `#EXTINF`, inside CUE-OUT, or matching `AdSegmentURLPatterns`); the backup-commit check now requires both `hasAdTags()` AND `hasStrippableAdSegments()` to reject a backup. On marked-but-empty backups, the FIRST Source-tier probe (`site`) commits immediately, no escape hatch fires, no post-escape reload. Real SSAI breaks (CUE-OUT-bracketed segments) behave identically to before. Side benefit: `LoggedBackupAdsByType` now only counts SSAI-confirmed contaminations, so the `sourceTried >= 4` signal driving `LastBreakUsedEscapeHatch` (FastAutoplayFirstTry trigger) is also more accurate (vaft) (#TBD)
+
 ## v66.1.0 (2026-05-09)
 
 ### Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ uBlock files have `twitch-videoad.js text/javascript` as line 1 (not valid JS â€
 
 ## Versions
 
-Bump `@version` (userscript header) and `ourTwitchAdSolutionsVersion` together for functional changes. Current: vaft 66.1.0/74, video-swap-new 1.85/53, strip 1.9/26. Testing: vaft 630.0.0/630, video-swap-new -/618.
+Bump `@version` (userscript header) and `ourTwitchAdSolutionsVersion` together for functional changes. Current: vaft 66.3.0/76, video-swap-new 1.85/53, strip 1.9/26. Testing: vaft 630.0.0/630, video-swap-new -/618.
 
 ## localStorage Config
 

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -37,7 +37,7 @@ twitch-videoad.js text/javascript
         }
     }
     'use strict';
-    const ourTwitchAdSolutionsVersion = 74;// Used to prevent conflicts with outdated versions of the scripts
+    const ourTwitchAdSolutionsVersion = 76;// Used to prevent conflicts with outdated versions of the scripts
     console.log('[AD DEBUG] TwitchAdSolutions vaft v' + ourTwitchAdSolutionsVersion + ' loading');
     if (typeof window.twitchAdSolutionsVersion !== 'undefined' && window.twitchAdSolutionsVersion >= ourTwitchAdSolutionsVersion) {
         console.log('[AD DEBUG] CONFLICT: vaft v' + ourTwitchAdSolutionsVersion + ' skipped — another script already active (v' + window.twitchAdSolutionsVersion + '). Remove duplicate scripts.');
@@ -293,6 +293,7 @@ twitch-videoad.js text/javascript
                 const newBlobStr = `
                     const pendingFetchRequests = new Map();
                     ${hasAdTags.toString()}
+                    ${hasStrippableAdSegments.toString()}
                     ${getMatchedAdSignifiers.toString()}
                     ${stripAdSegments.toString()}
                     ${getStreamUrlForResolution.toString()}
@@ -628,6 +629,23 @@ twitch-videoad.js text/javascript
     }
     function hasAdTags(textStr) {
         return AdSignifiers.some((s) => textStr.includes(s));
+    }
+    // Mirrors per-segment strip criteria — distinguish "marked but empty" CSAI-only
+    // m3u8s from real SSAI breaks. Avoids unnecessary autoplay-360p escape hatch.
+    function hasStrippableAdSegments(textStr) {
+        let inCueOut = false;
+        const lines = textStr.split(/\r?\n/);
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            if (line.includes('EXT-X-CUE-OUT')) inCueOut = true;
+            else if (line.includes('EXT-X-CUE-IN')) inCueOut = false;
+            else if (line.startsWith('#EXTINF') && i + 1 < lines.length) {
+                if (!line.includes(',live') || inCueOut) return true;
+                const segUrl = lines[i + 1];
+                if (typeof segUrl === 'string' && AdSegmentURLPatterns.some(p => segUrl.includes(p))) return true;
+            }
+        }
+        return false;
     }
     function getMatchedAdSignifiers(textStr) {
         return AdSignifiers.filter((s) => textStr.includes(s));
@@ -1174,8 +1192,11 @@ twitch-videoad.js text/javascript
                                     if (playerType == FallbackPlayerType) {
                                         fallbackM3u8 = m3u8Text;
                                     }
-                                    if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
-                                        if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !hasAdTags(m3u8Text)) {
+                                    // Treat marked-but-empty CSAI-only m3u8s as clean — commit Source-tier
+                                    // backup instead of falling through to autoplay 360p escape hatch.
+                                    const backupHasRealAds = hasAdTags(m3u8Text) && hasStrippableAdSegments(m3u8Text);
+                                    if ((!backupHasRealAds && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
+                                        if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !backupHasRealAds) {
                                             const prevType = streamInfo.LastCommittedBackupPlayerType;
                                             if (prevType && prevType !== playerType) {
                                                 console.log('[AD DEBUG] Cycle switched to different clean type (' + playerType + ', was ' + prevType + ') during freeze — recovered without reload');
@@ -1192,7 +1213,7 @@ twitch-videoad.js text/javascript
                                         backupM3u8 = m3u8Text;
                                         break;
                                     }
-                                    if (hasAdTags(m3u8Text)) {
+                                    if (backupHasRealAds) {
                                         if (!streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType = new Set();
                                         if (!streamInfo.LoggedBackupAdsByType.has(playerType)) {
                                             streamInfo.LoggedBackupAdsByType.add(playerType);

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TwitchAdSolutions (vaft)
 // @namespace    https://github.com/ryanbr/TwitchAdSolutions
-// @version      66.1.0
+// @version      66.3.0
 // @description  Multiple solutions for blocking Twitch ads (vaft)
 // @updateURL    https://github.com/ryanbr/TwitchAdSolutions/raw/master/vaft/vaft.user.js
 // @downloadURL  https://github.com/ryanbr/TwitchAdSolutions/raw/master/vaft/vaft.user.js
@@ -47,7 +47,7 @@
         }
     }
     'use strict';
-    const ourTwitchAdSolutionsVersion = 74;// Used to prevent conflicts with outdated versions of the scripts
+    const ourTwitchAdSolutionsVersion = 76;// Used to prevent conflicts with outdated versions of the scripts
     console.log('[AD DEBUG] TwitchAdSolutions vaft v' + ourTwitchAdSolutionsVersion + ' loading');
     if (typeof window.twitchAdSolutionsVersion !== 'undefined' && window.twitchAdSolutionsVersion >= ourTwitchAdSolutionsVersion) {
         console.log('[AD DEBUG] CONFLICT: vaft v' + ourTwitchAdSolutionsVersion + ' skipped — another script already active (v' + window.twitchAdSolutionsVersion + '). Remove duplicate scripts.');
@@ -320,6 +320,7 @@
                 const newBlobStr = `
                     const pendingFetchRequests = new Map();
                     ${hasAdTags.toString()}
+                    ${hasStrippableAdSegments.toString()}
                     ${getMatchedAdSignifiers.toString()}
                     ${stripAdSegments.toString()}
                     ${getStreamUrlForResolution.toString()}
@@ -665,6 +666,29 @@
     }
     function hasAdTags(textStr) {
         return AdSignifiers.some((s) => textStr.includes(s));
+    }
+    // Mirrors the per-segment strip criteria — non-live #EXTINF, inside CUE-OUT, or
+    // matching AdSegmentURLPatterns. Used by the backup-search loop to distinguish
+    // real SSAI breaks (segments that would actually be stripped) from "marked but
+    // empty" CSAI-only m3u8s (DATERANGE/CUE-OUT markers in headers but every #EXTINF
+    // is ',live'). On CSAI-only-but-marked channels this avoids exhausting the
+    // Source-tier probe and committing autoplay 360p via PreferLowQualityBackup,
+    // which then required a post-escape hard reload to restore quality (visible
+    // loading circle). Cheap single-pass scan; short-circuits on first match.
+    function hasStrippableAdSegments(textStr) {
+        let inCueOut = false;
+        const lines = textStr.split(/\r?\n/);
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            if (line.includes('EXT-X-CUE-OUT')) inCueOut = true;
+            else if (line.includes('EXT-X-CUE-IN')) inCueOut = false;
+            else if (line.startsWith('#EXTINF') && i + 1 < lines.length) {
+                if (!line.includes(',live') || inCueOut) return true;
+                const segUrl = lines[i + 1];
+                if (typeof segUrl === 'string' && AdSegmentURLPatterns.some(p => segUrl.includes(p))) return true;
+            }
+        }
+        return false;
     }
     function getMatchedAdSignifiers(textStr) {
         return AdSignifiers.filter((s) => textStr.includes(s));
@@ -1232,8 +1256,13 @@
                                     if (playerType == FallbackPlayerType) {
                                         fallbackM3u8 = m3u8Text;
                                     }
-                                    if ((!hasAdTags(m3u8Text) && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
-                                        if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !hasAdTags(m3u8Text)) {
+                                    // Treat "marked but empty" CSAI-only m3u8s (DATERANGE/CUE-OUT
+                                    // markers in headers but no strippable segments) as clean — same
+                                    // player_type cycling commits a Source-tier backup instead of
+                                    // exhausting the probe loop and falling through to autoplay 360p.
+                                    const backupHasRealAds = hasAdTags(m3u8Text) && hasStrippableAdSegments(m3u8Text);
+                                    if ((!backupHasRealAds && (SimulatedAdsDepth == 0 || playerTypeIndex >= SimulatedAdsDepth - 1)) || (!fallbackM3u8 && playerTypeIndex >= playerTypesToTry.length - 1)) {
+                                        if ((streamInfo.ConsecutiveAllStrippedPolls || 0) >= 1 && !backupHasRealAds) {
                                             const prevType = streamInfo.LastCommittedBackupPlayerType;
                                             if (prevType && prevType !== playerType) {
                                                 console.log('[AD DEBUG] Cycle switched to different clean type (' + playerType + ', was ' + prevType + ') during freeze — recovered without reload');
@@ -1250,7 +1279,7 @@
                                         backupM3u8 = m3u8Text;
                                         break;
                                     }
-                                    if (hasAdTags(m3u8Text)) {
+                                    if (backupHasRealAds) {
                                         if (!streamInfo.LoggedBackupAdsByType) streamInfo.LoggedBackupAdsByType = new Set();
                                         if (!streamInfo.LoggedBackupAdsByType.has(playerType)) {
                                             streamInfo.LoggedBackupAdsByType.add(playerType);


### PR DESCRIPTION
## Summary

Field-log-driven fix for the visible loading-circle on emongg / sinatraa style channels.

## Problem

On channels where the m3u8 contains ad markers (DATERANGE / CUE-OUT) but no actual segments to strip — i.e. CSAI-only ad delivery with an SSAI-shaped manifest — the backup-search loop misclassifies every Source-tier backup as "ad-laden" because `hasAdTags()` only checks for marker strings. The result, observed in field logs:

```
[AD DEBUG] Backup stream (site) also has ads
[AD DEBUG] Backup stream (popout) also has ads
[AD DEBUG] Backup stream (mobile_web) also has ads
[AD DEBUG] Backup stream (embed) also has ads
[AD DEBUG] Autoplay backup committed — 360p fallback after 4 Source type(s) ad-laden (PreferLowQualityBackup)
... break ends ...
[AD DEBUG] Finished blocking ads — stripped 0 ad segments, duration: 62.6s
[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action
[AD DEBUG] Post-escape reload: autoplay (360p) — restoring Source quality
Reloading Twitch player (hard)
```

Then a visible loading circle while MSE re-initializes for the new player_type session.

## Fix

New `hasStrippableAdSegments()` helper mirrors the per-segment strip criteria from `stripAdSegments`:

```js
function hasStrippableAdSegments(textStr) {
    let inCueOut = false;
    const lines = textStr.split(/\r?\n/);
    for (let i = 0; i < lines.length; i++) {
        const line = lines[i];
        if (line.includes('EXT-X-CUE-OUT')) inCueOut = true;
        else if (line.includes('EXT-X-CUE-IN')) inCueOut = false;
        else if (line.startsWith('#EXTINF') && i + 1 < lines.length) {
            if (!line.includes(',live') || inCueOut) return true;
            const segUrl = lines[i + 1];
            if (typeof segUrl === 'string' && AdSegmentURLPatterns.some(p => segUrl.includes(p))) return true;
        }
    }
    return false;
}
```

Cheap single-pass scan, short-circuits on first match. Serialized into the worker blob alongside `hasAdTags`.

The backup-commit check now requires **both** `hasAdTags` **and** `hasStrippableAdSegments` to reject a backup:

```js
const backupHasRealAds = hasAdTags(m3u8Text) && hasStrippableAdSegments(m3u8Text);
if (!backupHasRealAds && ...) { /* commit this backup */ }
if (backupHasRealAds) { /* "also has ads" log */ }
```

## Behavior change

**For CSAI-only-but-marked channels (emongg-style):**
- First Source-tier probe (`site`) commits immediately → Source quality preserved
- No autoplay 360p commit, no escape hatch fired
- After break: `stripped 0` → "CSAI-only ad break — clearing backup without player action" — but no post-escape reload because the player was already on Source-tier
- **No loading circle**

**For real SSAI breaks (CUE-OUT-bracketed actual segments):**
- `hasStrippableAdSegments()` returns true → existing logic unchanged
- Escape hatch still fires when all 4 Source types have real strippable ads

**Side benefit:** `LoggedBackupAdsByType` now only counts SSAI-confirmed contaminations, so the `sourceTried >= 4` signal driving `LastBreakUsedEscapeHatch` (FastAutoplayFirstTry trigger) is also more accurate. FastAutoplayFirstTry won't engage on channels that are CSAI-only-but-marked, so users on those channels won't unnecessarily get autoplay 360p prepended on next break either.

## Risk

If a backup m3u8 looks "marked but empty" on the poll where we check it but Twitch later fills in real ad segments, we've already committed that backup. Recovery: `stripAdSegments` runs on every subsequent poll and would strip the real ad segments when they appear — same recovery path as today. We're committing earlier, not differently.

## Versions

vaft 66.1.0/74 → 66.3.0/76 (66.2.0 reserved for PR #209's diagnostic-logging branch).

## Files

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`
- `CLAUDE.md`
- `CHANGELOG.md`

(Same change will be applied to `vaft_testing.user.js` + `vaft-testing-ublock-origin.js` direct-to-master per testing/release split.)

## Test plan

- [ ] On emongg / sinatraa during a midroll: backup-search commits at first Source-tier probe (likely `site`), no "Autoplay backup committed" log.
- [ ] No `Post-escape reload: autoplay (360p) — restoring Source quality` log after the break.
- [ ] No visible loading circle when the break ends.
- [ ] On a channel with real SSAI (e.g. heavy ad-laden popout backup that exhausts Source-tier): escape hatch still fires, autoplay still commits, post-escape reload still restores quality.
- [ ] `[AD DEBUG] Backup stream (X) also has ads` only appears when the backup actually has strippable ad segments.
- [ ] Acorn parse passes (CI).