### PR TITLE
v66.4.0: skip CSAI-only Source-tier post-escape reload; add twitch-ad-quartile to known-non-ad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+## v66.4.0 (2026-05-09)
+
+### Bug Fixes
+- **Skip post-escape MSE-flush reload on Source-tier 0-stripped breaks** — followup to v66.3.0 (#213). Field log on emongg / sinatraa showed that even though the autoplay-360p escape hatch is now correctly avoided on CSAI-only-but-marked breaks, a hard reload still fires at break end (`Post-escape reload: X — flushing MediaSource to prevent A/V desync accumulation`) producing a visible loading circle. The "mixed-source MSE drift" rationale for the flush assumes strip activity injected synthetic timestamps; on pure CSAI-only breaks (`stripped 0`) no segments were modified or replaced, so there's nothing to flush. Skip the reload when the committed backup is Source-tier (autoplay 360p commits still reload — autoplay-scoped access token only serves the 360p variant ladder, must be exchanged for a fresh Source-tier token) (vaft) (#TBD)
+
+### Detection Improvements
+- **Add `twitch-ad-quartile` to KnownNonAdSignifiers** — observed in field logs as `EXT-X-DATERANGE:CLASS="twitch-ad-quartile"`. Analytics cue for ad-quartile-completion events (25/50/75/100% watch progress) — ad-related metadata, not a signal that a break is starting. Filtered from the candidate-marker diagnostic so the log stays focused on genuinely new markers (vaft + video-swap-new) (#TBD)
+
 ## v66.1.0 (2026-05-09)
 
 ### Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ uBlock files have `twitch-videoad.js text/javascript` as line 1 (not valid JS â€
 
 ## Versions
 
-Bump `@version` (userscript header) and `ourTwitchAdSolutionsVersion` together for functional changes. Current: vaft 66.1.0/74, video-swap-new 1.85/53, strip 1.9/26. Testing: vaft 630.0.0/630, video-swap-new -/618.
+Bump `@version` (userscript header) and `ourTwitchAdSolutionsVersion` together for functional changes. Current: vaft 66.4.0/77, video-swap-new 1.85/53, strip 1.9/26. Testing: vaft 631.0.0/631, video-swap-new -/618.
 
 ## localStorage Config
 

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -37,7 +37,7 @@ twitch-videoad.js text/javascript
         }
     }
     'use strict';
-    const ourTwitchAdSolutionsVersion = 74;// Used to prevent conflicts with outdated versions of the scripts
+    const ourTwitchAdSolutionsVersion = 77;// Used to prevent conflicts with outdated versions of the scripts
     console.log('[AD DEBUG] TwitchAdSolutions vaft v' + ourTwitchAdSolutionsVersion + ' loading');
     if (typeof window.twitchAdSolutionsVersion !== 'undefined' && window.twitchAdSolutionsVersion >= ourTwitchAdSolutionsVersion) {
         console.log('[AD DEBUG] CONFLICT: vaft v' + ourTwitchAdSolutionsVersion + ' skipped — another script already active (v' + window.twitchAdSolutionsVersion + '). Remove duplicate scripts.');
@@ -53,7 +53,7 @@ twitch-videoad.js text/javascript
         // marker is a subset of this prefix.
         scope.AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"'];
         // Confirmed session/source metadata, never ad markers — filter from candidate log.
-        scope.KnownNonAdSignifiers = ['twitch-session', 'twitch-stream-source'];
+        scope.KnownNonAdSignifiers = ['twitch-session', 'twitch-stream-source', 'twitch-ad-quartile'];
         scope.AdSegmentURLPatterns = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals
@@ -1415,23 +1415,22 @@ twitch-videoad.js text/javascript
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');
                     streamInfo.IsUsingModifiedM3U8 = false;
-                    // Exception: if ANY backup was committed during this break (escape hatch
-                    // or cycle rescue that didn't meet cycleRescuedCleanly criteria), the
-                    // MediaSource buffer has accumulated mixed-source segments (backup-fetched
-                    // via alternate player-type access token + native-fetched). Mixing can
-                    // cause audio/video track timestamps to diverge, and without a reload the
-                    // drift compounds across subsequent escape-hatch breaks. Force a hard reload
-                    // to flush the MediaSource buffer + refresh the access token.
-                    // For autoplay (360p) specifically, the reload also restores Source
-                    // quality (autoplay-scoped token only serves 360p variant ladder).
+                    // autoplay (360p) commit MUST reload — autoplay-scoped access token only
+                    // serves the 360p variant ladder. Source-tier backup with 0 stripped: no
+                    // synthetic segments injected, no strip activity → no MSE drift to flush.
+                    // Skip the reload to avoid a loading circle on CSAI-only-but-marked
+                    // channels (emongg / sinatraa).
                     if (streamInfo.LastCommittedBackupPlayerType) {
                         const isAutoplay = streamInfo.LastCommittedBackupPlayerType === 'autoplay';
-                        const reason = isAutoplay ? 'autoplay (360p) — restoring Source quality' : streamInfo.LastCommittedBackupPlayerType + ' — flushing MediaSource to prevent A/V desync accumulation';
-                        console.log('[AD DEBUG] Post-escape reload: ' + reason);
-                        streamInfo.LastPlayerReload = Date.now();
-                        if (!streamInfo.ReloadTimestamps) streamInfo.ReloadTimestamps = [];
-                        streamInfo.ReloadTimestamps.push(Date.now());
-                        postMessage({ key: 'ReloadPlayer', kind: 'early' });
+                        if (isAutoplay) {
+                            console.log('[AD DEBUG] Post-escape reload: autoplay (360p) — restoring Source quality');
+                            streamInfo.LastPlayerReload = Date.now();
+                            if (!streamInfo.ReloadTimestamps) streamInfo.ReloadTimestamps = [];
+                            streamInfo.ReloadTimestamps.push(Date.now());
+                            postMessage({ key: 'ReloadPlayer', kind: 'early' });
+                        } else {
+                            console.log('[AD DEBUG] Skipping post-escape reload — Source-tier backup ' + streamInfo.LastCommittedBackupPlayerType + ' with 0 stripped, no synthetic-segment injection, no MSE drift to flush');
+                        }
                     }
                 } else {
                 // Auto-escalate cooldown: if 3+ reloads in last 5 min, triple the cooldown

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TwitchAdSolutions (vaft)
 // @namespace    https://github.com/ryanbr/TwitchAdSolutions
-// @version      66.1.0
+// @version      66.4.0
 // @description  Multiple solutions for blocking Twitch ads (vaft)
 // @updateURL    https://github.com/ryanbr/TwitchAdSolutions/raw/master/vaft/vaft.user.js
 // @downloadURL  https://github.com/ryanbr/TwitchAdSolutions/raw/master/vaft/vaft.user.js
@@ -47,7 +47,7 @@
         }
     }
     'use strict';
-    const ourTwitchAdSolutionsVersion = 74;// Used to prevent conflicts with outdated versions of the scripts
+    const ourTwitchAdSolutionsVersion = 77;// Used to prevent conflicts with outdated versions of the scripts
     console.log('[AD DEBUG] TwitchAdSolutions vaft v' + ourTwitchAdSolutionsVersion + ' loading');
     if (typeof window.twitchAdSolutionsVersion !== 'undefined' && window.twitchAdSolutionsVersion >= ourTwitchAdSolutionsVersion) {
         console.log('[AD DEBUG] CONFLICT: vaft v' + ourTwitchAdSolutionsVersion + ' skipped — another script already active (v' + window.twitchAdSolutionsVersion + '). Remove duplicate scripts.');
@@ -65,7 +65,7 @@
         // DATERANGE classes confirmed as session/source metadata over weeks of field
         // observation — surface as "candidates" otherwise. Filtered out by the candidate
         // logger so the diagnostic stays focused on genuinely new markers.
-        scope.KnownNonAdSignifiers = ['twitch-session', 'twitch-stream-source'];
+        scope.KnownNonAdSignifiers = ['twitch-session', 'twitch-stream-source', 'twitch-ad-quartile'];
         scope.AdSegmentURLPatterns = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals
@@ -1479,23 +1479,29 @@
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');
                     streamInfo.IsUsingModifiedM3U8 = false;
-                    // Exception: if ANY backup was committed during this break (escape hatch
-                    // or cycle rescue that didn't meet cycleRescuedCleanly criteria), the
-                    // MediaSource buffer has accumulated mixed-source segments (backup-fetched
-                    // via alternate player-type access token + native-fetched). Mixing can
-                    // cause audio/video track timestamps to diverge, and without a reload the
-                    // drift compounds across subsequent escape-hatch breaks. Force a hard reload
-                    // to flush the MediaSource buffer + refresh the access token.
-                    // For autoplay (360p) specifically, the reload also restores Source
-                    // quality (autoplay-scoped token only serves 360p variant ladder).
+                    // Reload requirement when a backup was committed during the break:
+                    //   - autoplay (360p): MUST reload — autoplay-scoped access token only
+                    //     serves the 360p variant ladder, so we need a fresh access token to
+                    //     return to Source quality.
+                    //   - Source-tier backup (site/popout/mobile_web/embed) with 0 stripped:
+                    //     no synthetic segments were injected and no segments were modified,
+                    //     so the "mixed-source MSE drift" rationale doesn't apply (it assumes
+                    //     strip activity produced artificial timestamps). Skip the reload to
+                    //     avoid a loading circle on CSAI-only-but-marked channels (emongg /
+                    //     sinatraa) where Source-tier backups are committed but no actual ad
+                    //     segments are ever delivered. The next m3u8 poll on the main stream
+                    //     resumes naturally without a hard reload.
                     if (streamInfo.LastCommittedBackupPlayerType) {
                         const isAutoplay = streamInfo.LastCommittedBackupPlayerType === 'autoplay';
-                        const reason = isAutoplay ? 'autoplay (360p) — restoring Source quality' : streamInfo.LastCommittedBackupPlayerType + ' — flushing MediaSource to prevent A/V desync accumulation';
-                        console.log('[AD DEBUG] Post-escape reload: ' + reason);
-                        streamInfo.LastPlayerReload = Date.now();
-                        if (!streamInfo.ReloadTimestamps) streamInfo.ReloadTimestamps = [];
-                        streamInfo.ReloadTimestamps.push(Date.now());
-                        postMessage({ key: 'ReloadPlayer', kind: 'early' });
+                        if (isAutoplay) {
+                            console.log('[AD DEBUG] Post-escape reload: autoplay (360p) — restoring Source quality');
+                            streamInfo.LastPlayerReload = Date.now();
+                            if (!streamInfo.ReloadTimestamps) streamInfo.ReloadTimestamps = [];
+                            streamInfo.ReloadTimestamps.push(Date.now());
+                            postMessage({ key: 'ReloadPlayer', kind: 'early' });
+                        } else {
+                            console.log('[AD DEBUG] Skipping post-escape reload — Source-tier backup ' + streamInfo.LastCommittedBackupPlayerType + ' with 0 stripped, no synthetic-segment injection, no MSE drift to flush');
+                        }
                     }
                 } else {
                 // Auto-escalate cooldown: if 3+ reloads in last 5 min, triple the cooldown

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -55,7 +55,7 @@ twitch-videoad.js text/javascript
         // 'stitched' substring match.
         scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"'];
         // Confirmed session/source metadata, never ad markers — filter from candidate log.
-        scope.KNOWN_NON_AD_SIGNIFIERS = ['twitch-session', 'twitch-stream-source'];
+        scope.KNOWN_NON_AD_SIGNIFIERS = ['twitch-session', 'twitch-stream-source', 'twitch-ad-quartile'];
         scope.AD_SEGMENT_URL_PATTERNS = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -66,7 +66,7 @@
         // 'stitched' substring match.
         scope.AD_SIGNIFIERS = ['stitched-ad', 'EXT-X-CUE-OUT', 'twitch-stitched', 'EXT-X-DATERANGE:CLASS="twitch-maf-ad"', 'EXT-X-DATERANGE:CLASS="twitch-trigger"'];
         // Confirmed session/source metadata, never ad markers — filter from candidate log.
-        scope.KNOWN_NON_AD_SIGNIFIERS = ['twitch-session', 'twitch-stream-source'];
+        scope.KNOWN_NON_AD_SIGNIFIERS = ['twitch-session', 'twitch-stream-source', 'twitch-ad-quartile'];
         scope.AD_SEGMENT_URL_PATTERNS = ['/adsquared/', '/_404/', '/processing'];
         // Precompiled regexes shared across the stripAdSegments hot path. Declared
         // here (serialized into the worker blob with declareOptions) so literals


### PR DESCRIPTION
## Summary

Followup to PR #213 driven by field testing on emongg / sinatraa.

**Stacked on PR #212** (depends on `KnownNonAdSignifiers` introduced there). Once #212 merges, retarget this PR's base to `master`.

## What changed

### (a) `twitch-ad-quartile` added to `KnownNonAdSignifiers`

Field log on emongg surfaced this DATERANGE class:

```
[AD DEBUG] Potential ad markers seen but not in AdSignifiers: 
EXT-X-DATERANGE:CLASS="twitch-ad-quartile" (candidates for future inclusion)
```

It's an analytics cue for ad-quartile-completion events (25/50/75/100% watch progress) — ad-RELATED metadata, but not a signal that an ad break is starting. Adding it to `AdSignifiers` would create false positives during ad ticks. Adding it to `KnownNonAdSignifiers` filters it out of the candidate-marker diagnostic so the log stays focused on genuinely new markers.

### (b) Skip post-escape MSE-flush reload on Source-tier 0-stripped breaks

Field log on emongg with v631 (PR #213) showed the autoplay-360p escape hatch is now correctly avoided — quality stays at Source-tier throughout the break. But a hard reload still fires at break end:

```
[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action
[AD DEBUG] Post-escape reload: mobile_web — flushing MediaSource to prevent A/V desync accumulation
[AD DEBUG] Reloading Twitch player (hard)
```

This produces a visible loading circle.

The MSE-flush rationale (`mixed-source segments... track timestamps to diverge`) assumes strip activity injected synthetic timestamps. On a pure CSAI-only break (`stripped 0`), no segments were modified, replaced, or synthetically generated — the backup m3u8s pointed to identical upstream `.ts` files, just fetched via different access tokens. There's no drift to flush.

Refined logic:
- **autoplay (360p) commit:** STILL reload (mandatory) — autoplay-scoped access token only serves 360p variant ladder, must exchange for fresh Source-tier token.
- **Source-tier backup with 0 stripped:** skip the reload. Logs `[AD DEBUG] Skipping post-escape reload — Source-tier backup X with 0 stripped, no synthetic-segment injection, no MSE drift to flush`.

Real SSAI breaks (`stripped > 0`) hit the existing `else` path — reload still fires there as before.

## Versions

vaft 66.1.0/74 → 66.4.0/77 (66.2.0 reserved for #209's branch, 66.3.0 for #213's branch).

## Files

- `vaft/vaft.user.js` (b)
- `vaft/vaft-ublock-origin.js` (b)
- `vaft/vaft.user.js` + `vaft/vaft-ublock-origin.js` + `video-swap-new/video-swap-new.user.js` + `video-swap-new/video-swap-new-ublock-origin.js` (a)
- `CLAUDE.md` + `CHANGELOG.md`

(b) is vaft-only because v-s-n doesn't have the autoplay-360p escape hatch / post-escape reload mechanic.

(Same changes will mirror to testing variants direct on master.)

## Test plan

- [ ] On emongg / sinatraa during a midroll: backup commits at Source-tier, break ends, `[AD DEBUG] Skipping post-escape reload` log appears, no `Reloading Twitch player (hard)` follow-up, no visible loading circle.
- [ ] On a channel where autoplay 360p commits via escape hatch (real SSAI-uniform): post-escape reload still fires with `autoplay (360p) — restoring Source quality` reason — quality restoration unchanged.
- [ ] On a real SSAI break with `stripped > 0`: existing reload path unchanged.
- [ ] On a channel that previously surfaced `twitch-ad-quartile` in the candidate log, confirm the line no longer appears.
- [ ] Acorn parse passes (CI).