### PR TITLE
v66.5.0: clear LastBreakUsedEscapeHatch when break ends CSAI-only (stripped 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## v66.5.0 (2026-05-09)
+
+### Bug Fixes
+- **Clear `LastBreakUsedEscapeHatch` when break ends CSAI-only** — followup to v66.4.0 field testing on emongg. The FastAutoplayFirstTry signal was set whenever the escape hatch fired with `sourceTried >= 4` (4 Source-tier backups had real strippable markers at probe time), but didn't account for whether actual SSAI segments were *delivered* during the break. On CSAI-only-but-marked channels the Source-tier m3u8s contain real `,stitched-ad` segments yet the actual break is delivered via Twitch's CSAI path — escape hatch fires, autoplay commits, but the break ends `stripped 0`. Carrying the signal forward caused FastAutoplay to engage on the next break, committing autoplay 360p first-try and forcing a 10s post-escape Source restore reload on every break (field-observed). Now: when a break ends CSAI-only (`stripped 0`), clear `LastBreakUsedEscapeHatch`. Logs `[AD DEBUG] Clearing LastBreakUsedEscapeHatch — break ended CSAI-only (stripped 0), no real SSAI confirmed`. Confirmed real-SSAI breaks (`stripped > 0`) still arm the signal. Loading circle on emongg-style channels reduced from "every break" to "first break of an SSAI-uniform sequence" (vaft) (#TBD)
+
 ## v66.4.0 (2026-05-09)
 
 ### Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ uBlock files have `twitch-videoad.js text/javascript` as line 1 (not valid JS â€
 
 ## Versions
 
-Bump `@version` (userscript header) and `ourTwitchAdSolutionsVersion` together for functional changes. Current: vaft 66.4.0/77, video-swap-new 1.85/53, strip 1.9/26. Testing: vaft 631.0.0/631, video-swap-new -/618.
+Bump `@version` (userscript header) and `ourTwitchAdSolutionsVersion` together for functional changes. Current: vaft 66.5.0/78, video-swap-new 1.85/53, strip 1.9/26. Testing: vaft 633.0.0/633, video-swap-new -/618.
 
 ## localStorage Config
 

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -37,7 +37,7 @@ twitch-videoad.js text/javascript
         }
     }
     'use strict';
-    const ourTwitchAdSolutionsVersion = 77;// Used to prevent conflicts with outdated versions of the scripts
+    const ourTwitchAdSolutionsVersion = 78;// Used to prevent conflicts with outdated versions of the scripts
     console.log('[AD DEBUG] TwitchAdSolutions vaft v' + ourTwitchAdSolutionsVersion + ' loading');
     if (typeof window.twitchAdSolutionsVersion !== 'undefined' && window.twitchAdSolutionsVersion >= ourTwitchAdSolutionsVersion) {
         console.log('[AD DEBUG] CONFLICT: vaft v' + ourTwitchAdSolutionsVersion + ' skipped — another script already active (v' + window.twitchAdSolutionsVersion + '). Remove duplicate scripts.');
@@ -1415,6 +1415,14 @@ twitch-videoad.js text/javascript
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');
                     streamInfo.IsUsingModifiedM3U8 = false;
+                    // Clear FastAutoplayFirstTry signal when CSAI-only — even if Source-tier
+                    // backups had real markers at probe time, 0 stripped proves no real SSAI
+                    // was delivered through MSE. Prevents FastAutoplay from engaging on the
+                    // next break and forcing an unnecessary autoplay 360p restore reload.
+                    if (streamInfo.LastBreakUsedEscapeHatch) {
+                        console.log('[AD DEBUG] Clearing LastBreakUsedEscapeHatch — break ended CSAI-only (stripped 0), no real SSAI confirmed');
+                        streamInfo.LastBreakUsedEscapeHatch = false;
+                    }
                     // autoplay (360p) commit MUST reload — autoplay-scoped access token only
                     // serves the 360p variant ladder. Source-tier backup with 0 stripped: no
                     // synthetic segments injected, no strip activity → no MSE drift to flush.

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TwitchAdSolutions (vaft)
 // @namespace    https://github.com/ryanbr/TwitchAdSolutions
-// @version      66.4.0
+// @version      66.5.0
 // @description  Multiple solutions for blocking Twitch ads (vaft)
 // @updateURL    https://github.com/ryanbr/TwitchAdSolutions/raw/master/vaft/vaft.user.js
 // @downloadURL  https://github.com/ryanbr/TwitchAdSolutions/raw/master/vaft/vaft.user.js
@@ -47,7 +47,7 @@
         }
     }
     'use strict';
-    const ourTwitchAdSolutionsVersion = 77;// Used to prevent conflicts with outdated versions of the scripts
+    const ourTwitchAdSolutionsVersion = 78;// Used to prevent conflicts with outdated versions of the scripts
     console.log('[AD DEBUG] TwitchAdSolutions vaft v' + ourTwitchAdSolutionsVersion + ' loading');
     if (typeof window.twitchAdSolutionsVersion !== 'undefined' && window.twitchAdSolutionsVersion >= ourTwitchAdSolutionsVersion) {
         console.log('[AD DEBUG] CONFLICT: vaft v' + ourTwitchAdSolutionsVersion + ' skipped — another script already active (v' + window.twitchAdSolutionsVersion + '). Remove duplicate scripts.');
@@ -1479,6 +1479,19 @@
                 if (!hadStrippedSegments) {
                     console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');
                     streamInfo.IsUsingModifiedM3U8 = false;
+                    // Clear FastAutoplayFirstTry signal when the break ended CSAI-only:
+                    // even if 4 Source-tier backups had real strippable markers at probe
+                    // time (sourceTried >= 4 → set the flag at autoplay commit), 0 stripped
+                    // proves no real SSAI was actually delivered through MSE this break.
+                    // Carrying the flag forward causes FastAutoplay to engage on the next
+                    // break, committing autoplay 360p first-try and forcing the post-escape
+                    // restore reload — visible loading circle on every break of a CSAI-only-
+                    // but-marked channel (emongg). Only confirmed real-SSAI breaks (stripped
+                    // > 0) should arm the signal for the next break.
+                    if (streamInfo.LastBreakUsedEscapeHatch) {
+                        console.log('[AD DEBUG] Clearing LastBreakUsedEscapeHatch — break ended CSAI-only (stripped 0), no real SSAI confirmed');
+                        streamInfo.LastBreakUsedEscapeHatch = false;
+                    }
                     // Reload requirement when a backup was committed during the break:
                     //   - autoplay (360p): MUST reload — autoplay-scoped access token only
                     //     serves the 360p variant ladder, so we need a fresh access token to


### PR DESCRIPTION
## Summary

Field-driven follow-up to PR #214 (v66.4.0). Stacked on **PR #214** (depends on its base; retarget to `master` once #214 lands).

## Problem

Field log on emongg with v632:

```
... 7-ad pod break ...
[AD DEBUG] Backup stream (site) also has ads          ← real strippable
[AD DEBUG] Backup stream (popout) also has ads        ← real strippable
[AD DEBUG] Backup stream (mobile_web) also has ads    ← real strippable
[AD DEBUG] Backup stream (embed) also has ads         ← real strippable
[AD DEBUG] Autoplay backup committed — 360p fallback after 4 Source type(s) ad-laden
... break ends ...
[AD DEBUG] Finished blocking ads — stripped 0 ad segments, duration: 149.3s
[AD DEBUG] Post-escape reload: autoplay (360p) — restoring Source quality
... ~10s loading circle ...

... 30s later, next break (1 ad, ~30s expected) ...
[AD DEBUG] Fast-autoplay first-try — prior break exhausted Source-tier; probing autoplay first
[AD DEBUG] Autoplay backup committed — 360p pinned from prior break
... break ends stripped 0 ...
[AD DEBUG] Post-escape reload: autoplay (360p) — restoring Source quality
... another ~10s loading circle ...
```

The pattern: prior break committed autoplay via escape hatch with `sourceTried >= 4` → `LastBreakUsedEscapeHatch=true`. Next break, FastAutoplayFirstTry sees the flag, prepends autoplay → autoplay commits first-try → 0 stripped → post-escape reload to restore Source → 10s loading circle.

This repeats on every break of a CSAI-only-but-marked channel because the flag is never cleared (no Source-tier ever wins to reset it, and FastAutoplay keeps preventing Source-tier from being tried first).

## Root cause

`LastBreakUsedEscapeHatch` is set when 4 Source-tier backups had real strippable markers at probe time. But that doesn't mean real SSAI was *delivered* — on emongg, the markers are in the m3u8 yet the break is delivered via Twitch's CSAI path (`edge.ads.twitch.tv`). `stripped 0` at break end is the ground truth.

The signal should mean "channel reliably delivers real strippable SSAI segments." `stripped 0` says it does not.

## Fix

When a break ends CSAI-only (`stripped 0`), clear `LastBreakUsedEscapeHatch` regardless of how the backup was committed. One small addition in the existing CSAI-only branch:

```js
if (!hadStrippedSegments) {
    console.log('[AD DEBUG] CSAI-only ad break (stripped 0) — clearing backup without player action');
    streamInfo.IsUsingModifiedM3U8 = false;
    if (streamInfo.LastBreakUsedEscapeHatch) {
        console.log('[AD DEBUG] Clearing LastBreakUsedEscapeHatch — break ended CSAI-only (stripped 0), no real SSAI confirmed');
        streamInfo.LastBreakUsedEscapeHatch = false;
    }
    // ... existing reload logic ...
}
```

## Effect on emongg flow

- **Big break (7-ad pod):** all 4 Source-tier markers → escape hatch → autoplay committed → `LastBreakUsedEscapeHatch=true`. Break ends `stripped 0` → **cleared**. The unavoidable autoplay→Source loading circle still fires for this break (autoplay was already committed).
- **Next break:** FastAutoplay does NOT engage (flag cleared) → iteration starts at site → if marked-but-empty (PR #213 path), commit Source-tier → no loading circle.
- **Real SSAI break (`stripped > 0`):** flag stays set, FastAutoplayFirstTry continues to engage as designed on actual SSAI-uniform channels (warn).

Net: loading circle frequency on emongg-style channels drops from "every break" to "first break of an SSAI-uniform sequence" (the one where escape hatch initially fires).

## Versions

vaft 66.4.0/77 → 66.5.0/78.

## Files

- `vaft/vaft.user.js`
- `vaft/vaft-ublock-origin.js`
- `CLAUDE.md`
- `CHANGELOG.md`

(Same change will mirror to testing variants direct on master.)

## Test plan

- [ ] On emongg: first heavy break commits autoplay, ends `stripped 0`, `[AD DEBUG] Clearing LastBreakUsedEscapeHatch` log appears.
- [ ] On the next emongg break: no `Fast-autoplay first-try` log → iteration tries Source-tier first → likely marked-but-empty commit (PR #213 path) → no autoplay 360p → no loading circle.
- [ ] On a real SSAI-uniform channel like warn (where `stripped > 0` consistently): FastAutoplayFirstTry still engages on subsequent breaks, probe-time savings preserved.
- [ ] Acorn parse passes (CI).