### PR TITLE
chore: defensive empty-string guard on signifier .some() iterations

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -628,7 +628,7 @@ twitch-videoad.js text/javascript
         return newServerTime ? encodingsM3u8.replace(/(SERVER-TIME=")[0-9.]+"/, `SERVER-TIME="${newServerTime}"`) : encodingsM3u8;
     }
     function hasAdTags(textStr) {
-        return AdSignifiers.some((s) => textStr.includes(s));
+        return AdSignifiers.some((s) => s && textStr.includes(s));
     }
     function getMatchedAdSignifiers(textStr) {
         return AdSignifiers.filter((s) => textStr.includes(s));
@@ -664,8 +664,8 @@ twitch-videoad.js text/javascript
             // appears within it. This handles prefix signifiers like 'twitch-stitched'
             // covering 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"' etc.
             const unknown = [...candidates].filter(c =>
-                !AdSignifiers.some(s => c.includes(s)) &&
-                !KnownNonAdSignifiers.some(s => c.includes(s))
+                !AdSignifiers.some(s => s && c.includes(s)) &&
+                !KnownNonAdSignifiers.some(s => s && c.includes(s))
             );
             if (unknown.length > 0) {
                 streamInfo.HasLoggedUnknownSignifiers = true;
@@ -882,7 +882,7 @@ twitch-videoad.js text/javascript
             streamInfo.HasCheckedUnknownTags = true;
             const unknownAdTags = textStr.match(/#EXT[^:\n]*(?:ad|cue|scte|sponsor)[^:\n]*/gi);
             if (unknownAdTags) {
-                const unknown = unknownAdTags.filter(t => !AdSignifiers.some(s => t.includes(s)));
+                const unknown = unknownAdTags.filter(t => !AdSignifiers.some(s => s && t.includes(s)));
                 if (unknown.length > 0) {
                     console.log('[AD DEBUG] Unknown ad-related tags found: ' + [...new Set(unknown)].join(', '));
                 }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -667,7 +667,7 @@
         return newServerTime ? encodingsM3u8.replace(/(SERVER-TIME=")[0-9.]+"/, `SERVER-TIME="${newServerTime}"`) : encodingsM3u8;
     }
     function hasAdTags(textStr) {
-        return AdSignifiers.some((s) => textStr.includes(s));
+        return AdSignifiers.some((s) => s && textStr.includes(s));
     }
     function getMatchedAdSignifiers(textStr) {
         return AdSignifiers.filter((s) => textStr.includes(s));
@@ -703,8 +703,8 @@
             // appears within it. This handles prefix signifiers like 'twitch-stitched'
             // covering 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"' etc.
             const unknown = [...candidates].filter(c =>
-                !AdSignifiers.some(s => c.includes(s)) &&
-                !KnownNonAdSignifiers.some(s => c.includes(s))
+                !AdSignifiers.some(s => s && c.includes(s)) &&
+                !KnownNonAdSignifiers.some(s => s && c.includes(s))
             );
             if (unknown.length > 0) {
                 streamInfo.HasLoggedUnknownSignifiers = true;
@@ -925,7 +925,7 @@
             streamInfo.HasCheckedUnknownTags = true;
             const unknownAdTags = textStr.match(/#EXT[^:\n]*(?:ad|cue|scte|sponsor)[^:\n]*/gi);
             if (unknownAdTags) {
-                const unknown = unknownAdTags.filter(t => !AdSignifiers.some(s => t.includes(s)));
+                const unknown = unknownAdTags.filter(t => !AdSignifiers.some(s => s && t.includes(s)));
                 if (unknown.length > 0) {
                     console.log('[AD DEBUG] Unknown ad-related tags found: ' + [...new Set(unknown)].join(', '));
                 }

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -546,7 +546,7 @@ twitch-videoad.js text/javascript
         return result;
     }
     function hasAdTags(textStr) {
-        return AD_SIGNIFIERS.some((s) => textStr.includes(s));
+        return AD_SIGNIFIERS.some((s) => s && textStr.includes(s));
     }
     function getMatchedAdSignifiers(textStr) {
         return AD_SIGNIFIERS.filter((s) => textStr.includes(s));
@@ -581,8 +581,8 @@ twitch-videoad.js text/javascript
             // appears within it. This handles prefix signifiers like 'twitch-stitched'
             // covering 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"' etc.
             const unknown = [...candidates].filter(c =>
-                !AD_SIGNIFIERS.some(s => c.includes(s)) &&
-                !KNOWN_NON_AD_SIGNIFIERS.some(s => c.includes(s))
+                !AD_SIGNIFIERS.some(s => s && c.includes(s)) &&
+                !KNOWN_NON_AD_SIGNIFIERS.some(s => s && c.includes(s))
             );
             if (unknown.length > 0) {
                 streamInfo.HasLoggedUnknownSignifiers = true;
@@ -755,7 +755,7 @@ twitch-videoad.js text/javascript
             streamInfo.HasCheckedUnknownTags = true;
             const unknownAdTags = textStr.match(/#EXT[^:\n]*(?:ad|cue|scte|sponsor)[^:\n]*/gi);
             if (unknownAdTags) {
-                const unknown = unknownAdTags.filter(t => !AD_SIGNIFIERS.some(s => t.includes(s)));
+                const unknown = unknownAdTags.filter(t => !AD_SIGNIFIERS.some(s => s && t.includes(s)));
                 if (unknown.length > 0) {
                     console.log('[AD DEBUG] Unknown ad-related tags found: ' + [...new Set(unknown)].join(', '));
                 }

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -558,7 +558,7 @@
         return result;
     }
     function hasAdTags(textStr) {
-        return AD_SIGNIFIERS.some((s) => textStr.includes(s));
+        return AD_SIGNIFIERS.some((s) => s && textStr.includes(s));
     }
     function getMatchedAdSignifiers(textStr) {
         return AD_SIGNIFIERS.filter((s) => textStr.includes(s));
@@ -593,8 +593,8 @@
             // appears within it. This handles prefix signifiers like 'twitch-stitched'
             // covering 'EXT-X-DATERANGE:CLASS="twitch-stitched-ad"' etc.
             const unknown = [...candidates].filter(c =>
-                !AD_SIGNIFIERS.some(s => c.includes(s)) &&
-                !KNOWN_NON_AD_SIGNIFIERS.some(s => c.includes(s))
+                !AD_SIGNIFIERS.some(s => s && c.includes(s)) &&
+                !KNOWN_NON_AD_SIGNIFIERS.some(s => s && c.includes(s))
             );
             if (unknown.length > 0) {
                 streamInfo.HasLoggedUnknownSignifiers = true;
@@ -772,7 +772,7 @@
             streamInfo.HasCheckedUnknownTags = true;
             const unknownAdTags = textStr.match(/#EXT[^:\n]*(?:ad|cue|scte|sponsor)[^:\n]*/gi);
             if (unknownAdTags) {
-                const unknown = unknownAdTags.filter(t => !AD_SIGNIFIERS.some(s => t.includes(s)));
+                const unknown = unknownAdTags.filter(t => !AD_SIGNIFIERS.some(s => s && t.includes(s)));
                 if (unknown.length > 0) {
                     console.log('[AD DEBUG] Unknown ad-related tags found: ' + [...new Set(unknown)].join(', '));
                 }


### PR DESCRIPTION
## Summary

Pure defensive guard. No functional change, no version bump.

Each call to \`AdSignifiers.some\` / \`AD_SIGNIFIERS.some\` now guards each element with \`s && ...\` before the \`.includes()\` check.

Before:
\`\`\`js
return AdSignifiers.some((s) => textStr.includes(s));
\`\`\`

After:
\`\`\`js
return AdSignifiers.some((s) => s && textStr.includes(s));
\`\`\`

## Why

If any element of the signifier array were ever an empty string, \`str.includes('')\` returns \`true\` unconditionally — every poll's m3u8 would be flagged as ad-laden, triggering the backup search on healthy streams. The arrays are hardcoded today (\`AdSignifiers = ['stitched-ad', 'EXT-X-CUE-OUT', ...]\`) so this is impossible-by-construction in current code, but the guard makes it impossible-by-construction even if a future edit accidentally introduces or computes an empty string into the array.

Single-character defensive change per call site. No behavior impact in normal operation.

## Files

4 \`.some()\` sites per release file × 4 files = 16 sites total:
- \`hasAdTags\`
- candidate-marker logger filter
- strip pre-check (when not using \`hasAdTags()\` directly)
- alternate candidate filter (unknown ad-related tags scan)

Files:
- \`vaft/vaft.user.js\`
- \`vaft/vaft-ublock-origin.js\`
- \`video-swap-new/video-swap-new.user.js\`
- \`video-swap-new/video-swap-new-ublock-origin.js\`

(Same change will mirror to testing variants direct on master.)

## Test plan

- [ ] vaft loads, ad detection works as before on real ad break.
- [ ] Healthy clean streams don't trigger false-positive ad detection.
- [ ] Acorn parse passes (CI).