### PR TITLE
v68.4.0: circuit-breaker for IVS WASM crash recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## v68.4.0 (2026-05-18)
+
+### Robustness
+- **Circuit-breaker for IVS WASM crash recovery** — the Amazon IVS WASM worker can throw a `RuntimeError` (`indirect call signature mismatch`, `index out of bounds`, etc.) and die. Not vaft-caused (it is inside Amazon's compiled WASM) and already recovered via detect→hard-reload — but that path had a latent loop: the per-worker `crashed` dedupe flag does **not** survive the reload (a re-spawned worker gets a fresh flag), and the handler calls `doTwitchPlayerTask` directly, **bypassing** the worker-side reload cooldown (which lives in the processM3U8 reload-decision path it never traverses — the old "existing reload cooldown prevents runaway restart loops" comment was inaccurate). A persistently-crashing WASM (bad codec/stream state) would therefore tight-loop `crash → uncooled hard reload → fresh worker → crash → …`, strictly worse for the user than the crash itself. Now crash times are tracked in a `playerBufferState`-held 60s rolling window (survives reloads); at **3+ crashes within 60s** auto-reload is suppressed and `[AD DEBUG] IVS WASM worker crashed: … — N crashes in 60s; auto-recovery paused (Amazon IVS-side instability — reloading is not helping)` is logged instead of looping. Self-healing: the window empties after a quiet period, so an isolated later crash still gets a recovery attempt. Single-crash behavior is unchanged (still detect→reload→recover, now annotated `(1/3 in 60s)`). vaft-only (#NN)
+
 ## v68.1.0 (2026-05-18)
 
 ### Performance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ uBlock files have `twitch-videoad.js text/javascript` as line 1 (not valid JS â€
 
 ## Versions
 
-Bump `@version` (userscript header) and `ourTwitchAdSolutionsVersion` together for functional changes. Current: vaft 68.1.0/82, video-swap-new 1.86/54, strip 1.9/26. Testing: vaft 651.0.0/651, video-swap-new -/619.
+Bump `@version` (userscript header) and `ourTwitchAdSolutionsVersion` together for functional changes. Current: vaft 68.4.0/85, video-swap-new 1.86/54, strip 1.9/26. Testing: vaft 651.0.0/651, video-swap-new -/619.
 
 ## localStorage Config
 

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -37,7 +37,7 @@ twitch-videoad.js text/javascript
         }
     }
     'use strict';
-    const ourTwitchAdSolutionsVersion = 82;// Used to prevent conflicts with outdated versions of the scripts
+    const ourTwitchAdSolutionsVersion = 85;// Used to prevent conflicts with outdated versions of the scripts
     console.log('[AD DEBUG] TwitchAdSolutions vaft v' + ourTwitchAdSolutionsVersion + ' loading');
     if (typeof window.twitchAdSolutionsVersion !== 'undefined' && window.twitchAdSolutionsVersion >= ourTwitchAdSolutionsVersion) {
         console.log('[AD DEBUG] CONFLICT: vaft v' + ourTwitchAdSolutionsVersion + ' skipped — another script already active (v' + window.twitchAdSolutionsVersion + '). Remove duplicate scripts.');
@@ -449,17 +449,34 @@ twitch-videoad.js text/javascript
                         });
                     }
                 });
-                // Worker crash recovery — IVS WASM worker can fire RuntimeError
-                // (e.g. "index out of bounds") and die. A single crash fires multiple
-                // error events; dedupe via a local flag. On first error, trigger a
-                // hard reload via the main reload path — Twitch re-spawns the worker
-                // as part of the new player instance, and existing reload cooldown
-                // prevents runaway restart loops.
+                // Worker crash recovery — the Amazon IVS WASM worker can fire a
+                // RuntimeError (e.g. "indirect call signature mismatch", "index out of
+                // bounds") and die. Not vaft-caused (it is inside Amazon's compiled
+                // WASM), but recoverable: a hard reload makes Twitch re-spawn the worker
+                // in a fresh player instance. One crash fires multiple error events —
+                // the per-worker `crashed` flag dedupes those.
+                // Circuit breaker: that flag does NOT survive the reload (new worker =
+                // fresh flag) and this path calls doTwitchPlayerTask directly, bypassing
+                // the worker-side reload cooldown — so a persistently-crashing WASM (bad
+                // codec/stream state) would otherwise become a tight, uncooled
+                // crash->reload->crash loop, worse than the crash itself.
+                // playerBufferState survives reloads; track crash times in a 60s rolling
+                // window and stop auto-reloading at 3+ (reloading clearly is not fixing
+                // it — leave the player for the user to act on). Self-healing: the window
+                // empties after a quiet period, so an isolated later crash still recovers.
                 let crashed = false;
                 this.addEventListener('error', (e) => {
                     if (crashed) return;
                     crashed = true;
-                    console.log('[AD DEBUG] IVS WASM worker crashed: ' + ((e && e.message) || 'unknown error') + ' — triggering hard reload to recover');
+                    const now = Date.now();
+                    const crashTimes = (playerBufferState.ivsCrashTimes = (playerBufferState.ivsCrashTimes || []).filter(t => now - t < 60000));
+                    crashTimes.push(now);
+                    const msg = (e && e.message) || 'unknown error';
+                    if (crashTimes.length >= 3) {
+                        console.log('[AD DEBUG] IVS WASM worker crashed: ' + msg + ' — ' + crashTimes.length + ' crashes in 60s; auto-recovery paused (Amazon IVS-side instability — reloading is not helping)');
+                        return;
+                    }
+                    console.log('[AD DEBUG] IVS WASM worker crashed: ' + msg + ' — triggering hard reload to recover (' + crashTimes.length + '/3 in 60s)');
                     try { doTwitchPlayerTask(false, true, 'early'); } catch (err) {
                         console.log('[AD DEBUG] Worker crash recovery failed: ' + err.message);
                     }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TwitchAdSolutions (vaft)
 // @namespace    https://github.com/ryanbr/TwitchAdSolutions
-// @version      68.1.0
+// @version      68.4.0
 // @description  Multiple solutions for blocking Twitch ads (vaft)
 // @updateURL    https://github.com/ryanbr/TwitchAdSolutions/raw/master/vaft/vaft.user.js
 // @downloadURL  https://github.com/ryanbr/TwitchAdSolutions/raw/master/vaft/vaft.user.js
@@ -47,7 +47,7 @@
         }
     }
     'use strict';
-    const ourTwitchAdSolutionsVersion = 82;// Used to prevent conflicts with outdated versions of the scripts
+    const ourTwitchAdSolutionsVersion = 85;// Used to prevent conflicts with outdated versions of the scripts
     console.log('[AD DEBUG] TwitchAdSolutions vaft v' + ourTwitchAdSolutionsVersion + ' loading');
     if (typeof window.twitchAdSolutionsVersion !== 'undefined' && window.twitchAdSolutionsVersion >= ourTwitchAdSolutionsVersion) {
         console.log('[AD DEBUG] CONFLICT: vaft v' + ourTwitchAdSolutionsVersion + ' skipped — another script already active (v' + window.twitchAdSolutionsVersion + '). Remove duplicate scripts.');
@@ -482,17 +482,34 @@
                         });
                     }
                 });
-                // Worker crash recovery — IVS WASM worker can fire RuntimeError
-                // (e.g. "index out of bounds") and die. A single crash fires multiple
-                // error events; dedupe via a local flag. On first error, trigger a
-                // hard reload via the main reload path — Twitch re-spawns the worker
-                // as part of the new player instance, and existing reload cooldown
-                // prevents runaway restart loops.
+                // Worker crash recovery — the Amazon IVS WASM worker can fire a
+                // RuntimeError (e.g. "indirect call signature mismatch", "index out of
+                // bounds") and die. Not vaft-caused (it is inside Amazon's compiled
+                // WASM), but recoverable: a hard reload makes Twitch re-spawn the worker
+                // in a fresh player instance. One crash fires multiple error events —
+                // the per-worker `crashed` flag dedupes those.
+                // Circuit breaker: that flag does NOT survive the reload (new worker =
+                // fresh flag) and this path calls doTwitchPlayerTask directly, bypassing
+                // the worker-side reload cooldown — so a persistently-crashing WASM (bad
+                // codec/stream state) would otherwise become a tight, uncooled
+                // crash->reload->crash loop, worse than the crash itself.
+                // playerBufferState survives reloads; track crash times in a 60s rolling
+                // window and stop auto-reloading at 3+ (reloading clearly is not fixing
+                // it — leave the player for the user to act on). Self-healing: the window
+                // empties after a quiet period, so an isolated later crash still recovers.
                 let crashed = false;
                 this.addEventListener('error', (e) => {
                     if (crashed) return;
                     crashed = true;
-                    console.log('[AD DEBUG] IVS WASM worker crashed: ' + ((e && e.message) || 'unknown error') + ' — triggering hard reload to recover');
+                    const now = Date.now();
+                    const crashTimes = (playerBufferState.ivsCrashTimes = (playerBufferState.ivsCrashTimes || []).filter(t => now - t < 60000));
+                    crashTimes.push(now);
+                    const msg = (e && e.message) || 'unknown error';
+                    if (crashTimes.length >= 3) {
+                        console.log('[AD DEBUG] IVS WASM worker crashed: ' + msg + ' — ' + crashTimes.length + ' crashes in 60s; auto-recovery paused (Amazon IVS-side instability — reloading is not helping)');
+                        return;
+                    }
+                    console.log('[AD DEBUG] IVS WASM worker crashed: ' + msg + ' — triggering hard reload to recover (' + crashTimes.length + '/3 in 60s)');
                     try { doTwitchPlayerTask(false, true, 'early'); } catch (err) {
                         console.log('[AD DEBUG] Worker crash recovery failed: ' + err.message);
                     }


### PR DESCRIPTION
## What

Adds a self-healing circuit-breaker to the existing IVS WASM crash recovery (all 4 vaft files).

## Why (a verified latent gap, not speculation)

The Amazon IVS WASM worker can `RuntimeError` (`indirect call signature mismatch`, `index out of bounds`, …) and die. **Not vaft-caused** — it is inside Amazon's compiled WASM. vaft already detects any worker `error` and hard-reloads to recover, which works for a single crash (field-confirmed: crash → reload → next break clean).

But tracing the code: the per-worker `crashed` dedupe flag does **not** survive the reload (a re-spawned worker gets a fresh closure), and the handler calls `doTwitchPlayerTask(false, true, 'early')` **directly on the main thread** — it never traverses the worker-side reload-cooldown path (processM3U8, the `tooSoonSinceLastReload`/escalation logic). `doTwitchPlayerTask` itself has no throttle. So the old comment *"existing reload cooldown prevents runaway restart loops"* was **inaccurate** — a persistently-crashing WASM (bad codec/stream state) would tight-loop `crash → uncooled hard reload → fresh worker → crash → …`, strictly worse for the user than the crash.

This isn't speculative mitigation for an unobserved failure mode — it's a documented safety property the code did not actually have.

## Fix

Track crash timestamps in a `playerBufferState`-held 60s rolling window (main-thread singleton — survives reloads, unlike the per-worker flag; verified in scope and not in the `.toString()`-serialized set). At **3+ crashes within 60s**, suppress the auto-reload and log `… N crashes in 60s; auto-recovery paused (Amazon IVS-side instability — reloading is not helping)`. **Self-healing:** the window empties after a quiet period, so an isolated later crash still gets a recovery attempt. **Single-crash behavior unchanged** (still detect→reload→recover, now annotated `(1/3 in 60s)`). The inaccurate comment is corrected.

## Scope / risk

Additive guard on the crash-recovery path only — the load-bearing normal reload/cooldown logic is untouched. vaft-only (the IVS worker wrapper; video-swap-new N/A). acorn-clean. Testing pair shipped direct to master (`v651.0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)