### PR TITLE
Disable ad spoofing by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Detection Evasion
+- **Ad spoofing default flipped on → off** — was previously on by default with a localStorage opt-out (`twitchAdSolutions_disableAdSpoofing='true'` to disable); now off by default with a localStorage opt-IN (`twitchAdSolutions_disableAdSpoofing='false'` to re-enable). Rationale: convergent signals that the spoof's always-100%-watched + audible + visible beacon pattern (fires before a human would plausibly have watched the ad) may itself fingerprint as anomalous in Twitch's anti-adblock heuristics — silent fingerprinting that vaft's `GQL response status` surveillance line (which only catches loud rejections) cannot detect. Field signal: an in-stream ad reaching the committed autoplay 360p backup on `warn` despite full vaft pod coverage and 100% Twitch acceptance of the spoof beacons (i.e., consistent with detection escalation rather than spoof rejection). Convergent with the TTV-AB maintainer's hypothesis. Mechanism retained intact: users who want to A/B test or explicitly opt in can set `twitchAdSolutions_disableAdSpoofing='false'`. vaft only (#NN)
+
 ## v68.2.0 (2026-05-21)
 
 ### Performance

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -81,7 +81,7 @@ twitch-videoad.js text/javascript
         scope.PreferLowQualityBackup = true;// Hybrid safety net for SSAI-heavy breaks: sticky escape hatch (fires after ~8s stuck in all-stripped state) + autoplay (360p) as last-resort backup when all Source types are ad-laden. Default on; set twitchAdSolutions_preferLowQualityBackup=false to disable.
         scope.FastAutoplayFirstTry = true;// Prepend autoplay (360p) to the iteration when the prior break exhausted all 4 Source types — saves ~1.5s of probe buffering on every break. Auto-resets on Source-tier recovery. Default on as of v67.1.0 (every observed channel is CSAI-only-but-marked). Opt-out: twitchAdSolutions_fastAutoplayFirstTry=false.
         scope.BackupSwapFirst = true;// On ad detect, immediately swap to a backup player-type m3u8 (TTV-AB-style). Avoids MediaSource mixing from strip activity — fewer loading circles in field. Cost: extra fetches on every ad break. Default on; set twitchAdSolutions_backupSwapFirst=false to disable.
-        scope.DisableAdSpoofing = false;// On ad-detect, fire GQL ad-tracking beacons that Twitch's player would have sent if the ad played. May reduce detection escalation. Default on; set twitchAdSolutions_disableAdSpoofing=true to disable.
+        scope.DisableAdSpoofing = true;// Default OFF (was ON through v68.2.0). The always-100%-watched + audible + visible spoof beacon pattern may itself fingerprint as anomalous and trigger detection escalation (CSAI reaching the committed backup). Spoof-accepted does NOT prove not-fingerprinted. Opt in via twitchAdSolutions_disableAdSpoofing=false.
         scope.RecoverFromSilentMute = true;// On hard reload, if the element is already muted but vaft has successfully unmuted at any point earlier this session, treat it as a silent Twitch re-mute and recover via the backstop. Default on; set twitchAdSolutions_recoverFromSilentMute=false to disable (useful for users who deliberately mute mid-session).
         scope.SkipPlayerReloadOnHevc = false;// If true this will skip player reload on streams which have 2k/4k quality (if you enable this and you use the 2k/4k quality setting you'll get error #4000 / #3000 / spinning wheel on chrome based browsers)
         scope.AlwaysReloadPlayerOnAd = false;// Always pause/play when entering/leaving ads
@@ -2626,9 +2626,9 @@ twitch-videoad.js text/javascript
             console.log('[AD DEBUG] BackupSwapFirst disabled via localStorage — using sticky CSAI path (strip on native stream)');
         }
         const lsDisableAdSpoofing = localStorage.getItem('twitchAdSolutions_disableAdSpoofing');
-        if (lsDisableAdSpoofing === 'true') {
-            DisableAdSpoofing = true;
-            console.log('[AD DEBUG] DisableAdSpoofing enabled via localStorage — skipping GQL ad-tracking beacons');
+        if (lsDisableAdSpoofing === 'false') {
+            DisableAdSpoofing = false;
+            console.log('[AD DEBUG] AdSpoofing enabled via localStorage opt-in — firing GQL ad-tracking beacons');
         }
         const lsRecoverFromSilentMute = localStorage.getItem('twitchAdSolutions_recoverFromSilentMute');
         if (lsRecoverFromSilentMute === 'false') {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -93,7 +93,7 @@
         scope.PreferLowQualityBackup = true;// Hybrid safety net for SSAI-heavy breaks: sticky escape hatch (fires after ~8s stuck in all-stripped state) + autoplay (360p) as last-resort backup when all Source types are ad-laden. Default on; set twitchAdSolutions_preferLowQualityBackup=false to disable.
         scope.FastAutoplayFirstTry = true;// When the prior break committed autoplay-via-escape-hatch, prepend autoplay (360p) to position 0 of playerTypesToTry on the next break — autoplay wins on first probe (~340ms) instead of cycling through 4 Source types (~1.5-2s). Auto-resets when a Source-tier type wins (channel recovered), so quality returns to full automatically if Twitch ever brings back non-ad-laden Source backups. Default on as of v67.1.0 — field data (project_all_channels_csai_only_marked) confirms every observed channel exhausts Source-tier on every break. Opt-out via localStorage twitchAdSolutions_fastAutoplayFirstTry=false.
         scope.BackupSwapFirst = true;// On ad detect, immediately swap to a backup player-type m3u8 (TTV-AB-style). Avoids MediaSource mixing from strip activity — fewer loading circles in field. Cost: extra fetches on every ad break. Default on; set twitchAdSolutions_backupSwapFirst=false to disable.
-        scope.DisableAdSpoofing = false;// On ad-detect, fire the GQL ad-tracking beacons (video_ad_impression, video_ad_quartile_complete, video_ad_pod_complete) that Twitch's player would have sent if the ad actually played. Spoof completes the ad-tracking signal Twitch expects, may avoid escalated detection. Default on; set twitchAdSolutions_disableAdSpoofing=true to disable.
+        scope.DisableAdSpoofing = true;// Default OFF (was ON through v68.2.0). The always-100%-watched + audible + visible spoof beacon pattern may itself fingerprint as anomalous and trigger detection escalation (CSAI reaching the committed backup) — observed correlation in field + TTV-AB maintainer hypothesis. Spoof-accepted (no GQL rejection) does NOT prove not-fingerprinted; Twitch can 200-OK while using the beacon pattern as silent detection input. Opt in by setting twitchAdSolutions_disableAdSpoofing=false to re-enable the GQL ad-tracking beacons (video_ad_impression, video_ad_quartile_complete x 4, video_ad_pod_complete).
         scope.RecoverFromSilentMute = true;// On hard reload, if the element is already muted but vaft has successfully unmuted at any point earlier this session, treat it as a silent Twitch re-mute and recover via the backstop. Default on; set twitchAdSolutions_recoverFromSilentMute=false to disable (useful for users who deliberately mute mid-session).
         scope.SkipPlayerReloadOnHevc = false;// If true this will skip player reload on streams which have 2k/4k quality (if you enable this and you use the 2k/4k quality setting you'll get error #4000 / #3000 / spinning wheel on chrome based browsers)
         scope.AlwaysReloadPlayerOnAd = false;// Always pause/play when entering/leaving ads
@@ -2784,9 +2784,9 @@
             console.log('[AD DEBUG] BackupSwapFirst disabled via localStorage — using sticky CSAI path (strip on native stream)');
         }
         const lsDisableAdSpoofing = localStorage.getItem('twitchAdSolutions_disableAdSpoofing');
-        if (lsDisableAdSpoofing === 'true') {
-            DisableAdSpoofing = true;
-            console.log('[AD DEBUG] DisableAdSpoofing enabled via localStorage — skipping GQL ad-tracking beacons on ad detect');
+        if (lsDisableAdSpoofing === 'false') {
+            DisableAdSpoofing = false;
+            console.log('[AD DEBUG] AdSpoofing enabled via localStorage opt-in — firing GQL ad-tracking beacons on ad detect');
         }
         const lsRecoverFromSilentMute = localStorage.getItem('twitchAdSolutions_recoverFromSilentMute');
         if (lsRecoverFromSilentMute === 'false') {


### PR DESCRIPTION
Flips `scope.DisableAdSpoofing false → true` on the release pair (`vaft.user.js` + `vaft-ublock-origin.js`), inverting the localStorage knob's semantics from **opt-out** (`twitchAdSolutions_disableAdSpoofing='true'` to disable) to **opt-IN** (`twitchAdSolutions_disableAdSpoofing='false'` to re-enable). No `@version` / `ourTwitchAdSolutionsVersion` bump — accumulates under `## Unreleased` per the new convention.

## Rationale (convergent signals, not reactive)

1. **A real user-visible in-stream ad reached the committed autoplay 360p backup on `warn`** despite vaft's logs showing the break fully covered (`3/3 pod, pod-complete: yes`), 100% Twitch acceptance of every spoof beacon (no `GQL response status` surveillance line), and no errors. That pattern is more consistent with **detection escalation** than with spoof rejection — Twitch can 200-OK the beacons while using their *pattern* as silent detection input, and vaft's existing surveillance line only catches loud rejections, not silent fingerprinting.
2. **Plausible mechanism, named clearly:** every spoof packet asserts `player_mute: false, player_volume: 1.0, visible: true, duration: <full>` + fires before a human would plausibly have watched the ad. That uniform "always 100% watched, audible, on-screen" pattern is itself a signature, and an account showing it consistently looks *unlike* a normal viewer — i.e., the spoof intended to mimic a real viewer may instead flag as the opposite.
3. **TTV-AB maintainer's hypothesis** (direct visibility across many users; authored the spoofing code) pointed at the spoof as the suspected cause.
4. **Upstream `ad7b8c3 fix: default ad spoofing to off`** experiment — earlier I read it as "product/UX, not technical signal" because there was no stated technical rationale. Re-examining with the field signal + maintainer hypothesis: that read should be downgraded; the flip-flop is also consistent with "tested off vs on, found mixed/inconclusive results, reverted to on as a UX default while remaining ambivalent."

The honest residue I called out earlier — *vaft's evidence proves spoofing is not loudly rejected; it does NOT prove spoofing is not silently fingerprinted* — is now turning into a concrete suspicion with field corroboration. Disabling by default is the right move.

## What this PR does (precisely)

- `scope.DisableAdSpoofing = false → true` in `vaft.user.js` and `vaft-ublock-origin.js`, with the inline comment rewritten to explain the rationale + how to opt in.
- localStorage handler inverted: `if (lsDisableAdSpoofing === 'true')` → `=== 'false'`, sets `DisableAdSpoofing = false`, log becomes `[AD DEBUG] AdSpoofing enabled via localStorage opt-in — firing GQL ad-tracking beacons on ad detect`.
- `## Unreleased` bullet under "Detection Evasion" with the same rationale.
- Mechanism (`notifyAdComplete` and all the multipoll / dedup / pod_complete / instrumentation work) **fully retained** — only the default flips.
- **No version bump.** Scripts stay at `@version 68.2.0/83`. The next published release will pick this up via the usual Unreleased-rollup pattern (the model PR #226 and #231 followed).

acorn-clean on both release files. Testing pair (`vaft_testing.user.js` + `vaft-testing-ublock-origin.js`) + `CLAUDE.md` doc-line update already shipped direct to master at `8cdd31d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)