### PR TITLE
Correct misleading crash-recovery comment (release pair)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Documentation
+- **Crash-recovery comment corrected (release pair)** — the inline comment at the IVS WASM worker `error` handler in `vaft.user.js` + `vaft-ublock-origin.js` previously claimed *"existing reload cooldown prevents runaway restart loops"* — verifiably false; the crash-recovery `doTwitchPlayerTask(..., 'early')` call bypasses the worker-side cooldown logic that lives in `processM3U8`'s reload-decision path. Comment rewritten to accurately state: per-worker `crashed` flag dedupes the multi-event burst from one crash, no cross-worker storm guard is implemented (intentionally — observed crashes have all been single + recoverable; revisit only if field logs ever show clustered crashes ≥2 within ~60s in one session). Lists all three observed WASM-error message variants (`index out of bounds`, `indirect call signature mismatch`, `indirect call to null`). No behavioral change. Testing pair untouched — it already has the full circuit-breaker implementation with its own accurate comment (intentional release-vs-testing divergence, per CLAUDE.md "Testing files include experimental features") (vaft) (#NN)
+
 ## v68.3.0 (2026-05-21)
 
 ### Detection Evasion

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -449,12 +449,16 @@ twitch-videoad.js text/javascript
                         });
                     }
                 });
-                // Worker crash recovery — IVS WASM worker can fire RuntimeError
-                // (e.g. "index out of bounds") and die. A single crash fires multiple
-                // error events; dedupe via a local flag. On first error, trigger a
-                // hard reload via the main reload path — Twitch re-spawns the worker
-                // as part of the new player instance, and existing reload cooldown
-                // prevents runaway restart loops.
+                // Worker crash recovery — Amazon IVS WASM worker can fire RuntimeError
+                // (e.g. "index out of bounds", "indirect call signature mismatch",
+                // "indirect call to null") and die. A single crash fires multiple error
+                // events; the per-worker `crashed` flag dedupes those, then trigger a
+                // hard reload — Twitch re-spawns the worker in a fresh player instance.
+                // The `crashed` flag is per-closure (does NOT survive the reload) and
+                // this path calls doTwitchPlayerTask directly, bypassing the worker-side
+                // reload cooldown — so there is no cross-worker storm guard here.
+                // Observed crashes have been single + recoverable; revisit only if field
+                // logs ever show clustered crashes (>=2 within ~60s in one session).
                 let crashed = false;
                 this.addEventListener('error', (e) => {
                     if (crashed) return;

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -482,12 +482,16 @@
                         });
                     }
                 });
-                // Worker crash recovery — IVS WASM worker can fire RuntimeError
-                // (e.g. "index out of bounds") and die. A single crash fires multiple
-                // error events; dedupe via a local flag. On first error, trigger a
-                // hard reload via the main reload path — Twitch re-spawns the worker
-                // as part of the new player instance, and existing reload cooldown
-                // prevents runaway restart loops.
+                // Worker crash recovery — Amazon IVS WASM worker can fire RuntimeError
+                // (e.g. "index out of bounds", "indirect call signature mismatch",
+                // "indirect call to null") and die. A single crash fires multiple error
+                // events; the per-worker `crashed` flag dedupes those, then trigger a
+                // hard reload — Twitch re-spawns the worker in a fresh player instance.
+                // The `crashed` flag is per-closure (does NOT survive the reload) and
+                // this path calls doTwitchPlayerTask directly, bypassing the worker-side
+                // reload cooldown — so there is no cross-worker storm guard here.
+                // Observed crashes have been single + recoverable; revisit only if field
+                // logs ever show clustered crashes (>=2 within ~60s in one session).
                 let crashed = false;
                 this.addEventListener('error', (e) => {
                     if (crashed) return;


### PR DESCRIPTION
Comment-only docfix on the release pair. **No behavioral change**, no version bump (per the no-per-PR-version convention) — bullet added under `## Unreleased` for the next roll-up.

## What the old comment said (false)

The IVS WASM worker `error` handler in `vaft.user.js` + `vaft-ublock-origin.js` previously claimed:

> *"…and existing reload cooldown prevents runaway restart loops."*

That's verifiably false. The crash handler calls `doTwitchPlayerTask(false, true, 'early')` **directly on the main thread**. The reload-cooldown logic (`tooSoonSinceLastReload`, escalation, 30s/90s) lives in the worker's `processM3U8` reload-decision path — which crash-recovery never traverses. `doTwitchPlayerTask` itself has no throttle. So a hypothetical persistently-crashing WASM would currently produce an unbounded `crash → uncooled hard reload → fresh worker → crash` loop, *not* a cooldown-throttled one.

This misleading comment was what originally pulled me into the circuit-breaker thread (closed PR #230). Fixing the comment regardless removes the documented-but-absent safety property trap.

## What the new comment says (accurate)

- Lists all three observed WASM-error variants: `index out of bounds`, `indirect call signature mismatch`, `indirect call to null` (the v82 and v83 logs gave us the latter two).
- States the per-worker `crashed` flag dedupes the multi-event burst from one crash — and is per-closure (does NOT survive the reload).
- States honestly: **no cross-worker storm guard is implemented** here. Intentional — observed crashes have all been single + recoverable.
- Notes the trip-wire for revisiting: **clustered crashes ≥2 within ~60s in one session**. If that ever appears in field logs, the circuit-breaker design from closed PR #230 is the ready answer.

## Scope

- `vaft.user.js` + `vaft-ublock-origin.js`: comment block rewritten (6 lines → 10 lines, both files synced).
- `CHANGELOG.md`: bullet under `## Unreleased` → `### Documentation`.
- **Testing pair NOT touched.** The testing variant (from the v651 testing-direct work during #230, which was never reverted) already has the full circuit-breaker code + its own accurate comment. Leaving that as intentional release-vs-testing divergence, per CLAUDE.md *"Testing files include experimental features."*

acorn-clean on both release files. Single squashed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)