### PR TITLE
Spoofing-on debug instrumentation (counters + startup log)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Diagnostics
+- **Spoofing-on debug instrumentation** — makes the opt-in spoofing path easier to diagnose / A/B against the now-default-off state. Three small additions: (1) at startup, when `DisableAdSpoofing === false`, a clear log line surfaces the enabled state and names the source (`localStorage opt-in` vs `modified default`) so it's unmistakable in the log header; (2) a worker session counter (`notifyAdComplete.sessionAdsSpoofed`, function-property pattern matching existing `loggedNoMatch`/`loggedBadStatus`) is appended to the existing `Spoofed ad completion` line as `[session: N ads spoofed]`; (3) a main-thread session counter (`sessionCsaiRequests`) is appended to the `CSAI ad request detected` line as `[session: K CSAI requests so far]` (counts every `edge.ads.twitch.tv` request, not gated by the once-per-type dedup — so the visible count is the running total at first-of-each-type emission). Pure observability — no behavioral change to spoofing, ad-blocking, or the GQL beacon flow. Lets two sessions on the same channel (one spoof-on opt-in, one spoof-off default) be directly compared on total ads spoofed + total CSAI requests delivered to the session, which is the data any future spoofing-default decision should be based on (vaft) (#NN)
+
 ## v68.3.0 (2026-05-21)
 
 ### Detection Evasion

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -190,6 +190,7 @@ twitch-videoad.js text/javascript
         return fn;
     }
     const loggedCsaiTypes = new Set();
+    let sessionCsaiRequests = 0;// instrumentation: cumulative count of edge.ads.twitch.tv CSAI requests this page-load; surfaced in the CSAI-detected log for A/B comparison vs spoof-off sessions
     let isActivelyStrippingAds = false;
     let localStorageHookFailed = false;
     const twitchWorkers = [];
@@ -763,7 +764,8 @@ twitch-videoad.js text/javascript
                 // src= primary vs committed backup player-type (surfaces stream-swap
                 // ad-ID mixing). pod-complete= whether the single pod_complete fired.
                 const src = (streamInfo && streamInfo.ActiveBackupPlayerType) || 'primary';
-                console.log('[AD DEBUG] Spoofed ad completion for ' + newSpoofed + ' new ad(s) (' + total + '/' + podLength + ' pod) — roll: ' + firstRollType + ', src: ' + src + ', pod-complete: ' + (podCompleteSent ? 'yes' : 'no'));
+                notifyAdComplete.sessionAdsSpoofed = (notifyAdComplete.sessionAdsSpoofed || 0) + newSpoofed;
+                console.log('[AD DEBUG] Spoofed ad completion for ' + newSpoofed + ' new ad(s) (' + total + '/' + podLength + ' pod) — roll: ' + firstRollType + ', src: ' + src + ', pod-complete: ' + (podCompleteSent ? 'yes' : 'no') + ' [session: ' + notifyAdComplete.sessionAdsSpoofed + ' ads spoofed]');
             }
         } catch (err) {
             console.log('[AD DEBUG] Ad completion spoof failed: ' + err.message);
@@ -2506,10 +2508,11 @@ twitch-videoad.js text/javascript
                     }
                 }
                 if (url.includes('edge.ads.twitch.tv')) {
+                    sessionCsaiRequests++;
                     const csaiType = url.includes('bp=midroll') ? 'midroll' : url.includes('bp=preroll') ? 'preroll' : 'unknown';
                     if (!loggedCsaiTypes.has(csaiType)) {
                         loggedCsaiTypes.add(csaiType);
-                        console.log('[AD DEBUG] CSAI ad request detected — type: ' + csaiType + ' (client-side ad insertion, not blockable via m3u8)');
+                        console.log('[AD DEBUG] CSAI ad request detected — type: ' + csaiType + ' (client-side ad insertion, not blockable via m3u8) [session: ' + sessionCsaiRequests + ' CSAI requests so far]');
                     }
                 }
             }
@@ -2628,7 +2631,10 @@ twitch-videoad.js text/javascript
         const lsDisableAdSpoofing = localStorage.getItem('twitchAdSolutions_disableAdSpoofing');
         if (lsDisableAdSpoofing === 'false') {
             DisableAdSpoofing = false;
-            console.log('[AD DEBUG] AdSpoofing enabled via localStorage opt-in — firing GQL ad-tracking beacons');
+        }
+        if (!DisableAdSpoofing) {
+            const spoofSrc = (lsDisableAdSpoofing === 'false') ? 'localStorage opt-in' : 'modified default';
+            console.log('[AD DEBUG] AdSpoofing ENABLED (' + spoofSrc + ') — firing GQL ad-tracking beacons on every ad-laden poll. Default is OFF as of v68.3.0; opt-in mode for A/B testing. Watch session counters appended to "Spoofed ad completion" / "CSAI ad request detected" lines to compare with a spoof-off session on the same channel.');
         }
         const lsRecoverFromSilentMute = localStorage.getItem('twitchAdSolutions_recoverFromSilentMute');
         if (lsRecoverFromSilentMute === 'false') {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -216,6 +216,7 @@
         return fn;
     }
     const loggedCsaiTypes = new Set();
+    let sessionCsaiRequests = 0;// instrumentation: cumulative count of edge.ads.twitch.tv CSAI requests this page-load; surfaced in the CSAI-detected log for A/B comparison vs spoof-off sessions
     let isActivelyStrippingAds = false;
     let localStorageHookFailed = false;
     const twitchWorkers = [];
@@ -839,7 +840,8 @@
                 // single video_ad_pod_complete (lets you confirm pod completion
                 // explicitly instead of inferring it from the total/POD ratio).
                 const src = (streamInfo && streamInfo.ActiveBackupPlayerType) || 'primary';
-                console.log('[AD DEBUG] Spoofed ad completion for ' + newSpoofed + ' new ad(s) (' + total + '/' + podLength + ' pod) — roll: ' + firstRollType + ', src: ' + src + ', pod-complete: ' + (podCompleteSent ? 'yes' : 'no'));
+                notifyAdComplete.sessionAdsSpoofed = (notifyAdComplete.sessionAdsSpoofed || 0) + newSpoofed;
+                console.log('[AD DEBUG] Spoofed ad completion for ' + newSpoofed + ' new ad(s) (' + total + '/' + podLength + ' pod) — roll: ' + firstRollType + ', src: ' + src + ', pod-complete: ' + (podCompleteSent ? 'yes' : 'no') + ' [session: ' + notifyAdComplete.sessionAdsSpoofed + ' ads spoofed]');
             }
         } catch (err) {
             console.log('[AD DEBUG] Ad completion spoof failed: ' + err.message);
@@ -2664,10 +2666,11 @@
                     }
                 }
                 if (url.includes('edge.ads.twitch.tv')) {
+                    sessionCsaiRequests++;
                     const csaiType = url.includes('bp=midroll') ? 'midroll' : url.includes('bp=preroll') ? 'preroll' : 'unknown';
                     if (!loggedCsaiTypes.has(csaiType)) {
                         loggedCsaiTypes.add(csaiType);
-                        console.log('[AD DEBUG] CSAI ad request detected — type: ' + csaiType + ' (client-side ad insertion, not blockable via m3u8)');
+                        console.log('[AD DEBUG] CSAI ad request detected — type: ' + csaiType + ' (client-side ad insertion, not blockable via m3u8) [session: ' + sessionCsaiRequests + ' CSAI requests so far]');
                     }
                 }
             }
@@ -2786,7 +2789,10 @@
         const lsDisableAdSpoofing = localStorage.getItem('twitchAdSolutions_disableAdSpoofing');
         if (lsDisableAdSpoofing === 'false') {
             DisableAdSpoofing = false;
-            console.log('[AD DEBUG] AdSpoofing enabled via localStorage opt-in — firing GQL ad-tracking beacons on ad detect');
+        }
+        if (!DisableAdSpoofing) {
+            const spoofSrc = (lsDisableAdSpoofing === 'false') ? 'localStorage opt-in' : 'modified default';
+            console.log('[AD DEBUG] AdSpoofing ENABLED (' + spoofSrc + ') — firing GQL ad-tracking beacons on every ad-laden poll. Default is OFF as of v68.3.0; opt-in mode for A/B testing. Watch session counters appended to "Spoofed ad completion" / "CSAI ad request detected" lines to compare with a spoof-off session on the same channel.');
         }
         const lsRecoverFromSilentMute = localStorage.getItem('twitchAdSolutions_recoverFromSilentMute');
         if (lsRecoverFromSilentMute === 'false') {


### PR DESCRIPTION
Three small additions to make the opt-in spoofing path easier to diagnose and A/B against the now-default-off state. **Pure observability** — no behavioral change to spoofing, ad-blocking, or the GQL beacon flow. No version bump per the no-per-PR convention; `## Unreleased` bullet under `### Diagnostics`.

## What this PR does

**(1) Startup log when spoofing is enabled.** After the `twitchAdSolutions_disableAdSpoofing` localStorage handler, an additional `if (!DisableAdSpoofing)` block fires a clear startup line:
```
[AD DEBUG] AdSpoofing ENABLED (localStorage opt-in) — firing GQL ad-tracking beacons on every ad-laden poll. Default is OFF as of v68.3.0; opt-in mode for A/B testing. Watch session counters appended to "Spoofed ad completion" / "CSAI ad request detected" lines to compare with a spoof-off session on the same channel.
```
Source is named distinctly: `localStorage opt-in` vs `modified default` (in case someone patched the default in their own copy). Replaces the previous shorter "enabled via localStorage opt-in" log.

**(2) Worker session counter on `Spoofed ad completion`:**
```diff
- ... pod-complete: yes
+ ... pod-complete: yes [session: 7 ads spoofed]
```
Counter held on `notifyAdComplete.sessionAdsSpoofed` (function-property pattern matching the existing `loggedNoMatch` / `loggedBadStatus` style — survives across calls within one worker instance).

**(3) Main-thread session counter on `CSAI ad request detected`:**
```diff
- ... not blockable via m3u8)
+ ... not blockable via m3u8) [session: 4 CSAI requests so far]
```
Counter (`sessionCsaiRequests`) declared at module scope, incremented on **every** `edge.ads.twitch.tv` request (placed *before* the existing once-per-type dedup gate, so the value shown is the true running total at the point of first-of-each-type emission). Counts every CSAI request, not just unique types.

## What this enables

Two sessions on the same channel — one with `twitchAdSolutions_disableAdSpoofing='false'` (spoof-on opt-in), one with default-off — become directly comparable on:
- Total ads spoofed across the session
- Total CSAI requests delivered to the session

Whichever is bigger (or smaller) under spoof-on vs spoof-off is the actual empirical answer to *"does spoofing affect ad delivery"* — which the disable hypothesis (PR #232 / v68.3.0) has been unable to test without this kind of counter. The localStorage opt-in was already there; this just makes the A/B's output legible at a glance.

## Scope notes

- All 4 vaft files share the `Spoofed ad completion` line — same transform on each. (1) and (2) shipped to the testing pair already at master commit `73ee921`. The release pair adds (1) + (2) + (3); the testing pair doesn't have the `edge.ads.twitch.tv` fetch-hook detection, so the CSAI counter is release-only.
- `video-swap-new`: spoofing is vaft-only; no port needed.
- acorn-clean on both release files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)