### PR TITLE
Don't back off buffer monitor during ad break on hidden tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Fixed
+- **Buffer monitor no longer backs off during an active ad break on a hidden tab** — the visibility-aware backoff polls the buffer monitor 3× slower when the tab is hidden (to save CPU on backgrounded tabs). That backoff now skips while `playerBufferState.inAdBreak` is true, so stall detection stays at full cadence during the recovery-critical window (backup search → reload) even on a backgrounded tab. Motivated by issue #129 (Firefox): a break starting on a hidden tab could leave the stream "stuck loading" until the user refocused the tab, because recovery polling had dropped to 3-9s. **Workaround, not a full fix** — the deeper cause is browser-level hidden-tab timer clamping + media/network deprioritization, which a page-context script can't override; this just removes vaft's own compounding backoff during the window that matters. Negligible cost (faster polling only while hidden *and* mid-break). N=1 field signal — shipping as a low-risk hardening that's also defensible on its own merits (don't throttle stall detection during an ad break). vaft only — video-swap-new has no visibility-aware backoff to gate (#NN)
+
 ## v68.3.0 (2026-05-21)
 
 ### Detection Evasion

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -2037,8 +2037,12 @@ twitch-videoad.js text/javascript
         // lifecycle and stay visible afterwards. Running here on every monitor tick
         // (1-3s cadence) keeps them hidden without a dedicated interval.
         try { hideTwitchAdOverlays(); } catch {}
-        // Visibility-aware backoff: poll 3x slower when tab is hidden (but NOT during PiP — user is still watching)
-        const shouldThrottle = typeof document !== 'undefined' && document.hidden && !document.pictureInPictureElement;
+        // Visibility-aware backoff: poll 3x slower when tab is hidden (but NOT during PiP — user is still watching).
+        // Exception: don't back off during an active ad break — hidden-tab recovery (backup search → reload) is
+        // already slowed by browser timer clamping; the 3x backoff compounds the "stuck loading until refocus"
+        // stall some users hit when a break starts on a backgrounded tab (issue #129). Workaround, not a full fix:
+        // background media deprioritization is browser-level. Negligible cost — only polls faster while hidden + in-break.
+        const shouldThrottle = typeof document !== 'undefined' && document.hidden && !document.pictureInPictureElement && !playerBufferState.inAdBreak;
         const nextDelay = shouldThrottle ? PlayerBufferingDelay * 3 : PlayerBufferingDelay;
         setTimeout(monitorPlayerBuffering, nextDelay);
     }

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -2173,8 +2173,12 @@
         // lifecycle and stay visible afterwards. Running here on every monitor tick
         // (1-3s cadence) keeps them hidden without a dedicated interval.
         try { hideTwitchAdOverlays(); } catch {}
-        // Visibility-aware backoff: poll 3x slower when tab is hidden (but NOT during PiP — user is still watching)
-        const shouldThrottle = typeof document !== 'undefined' && document.hidden && !document.pictureInPictureElement;
+        // Visibility-aware backoff: poll 3x slower when tab is hidden (but NOT during PiP — user is still watching).
+        // Exception: don't back off during an active ad break — hidden-tab recovery (backup search → reload) is
+        // already slowed by browser timer clamping; the 3x backoff compounds the "stuck loading until refocus"
+        // stall some users hit when a break starts on a backgrounded tab (issue #129). Workaround, not a full fix:
+        // background media deprioritization is browser-level. Negligible cost — only polls faster while hidden + in-break.
+        const shouldThrottle = typeof document !== 'undefined' && document.hidden && !document.pictureInPictureElement && !playerBufferState.inAdBreak;
         const nextDelay = shouldThrottle ? PlayerBufferingDelay * 3 : PlayerBufferingDelay;
         setTimeout(monitorPlayerBuffering, nextDelay);
     }


### PR DESCRIPTION
## What

One-condition change: the buffer monitor's visibility-aware 3× backoff no longer applies while an ad break is active.

```js
const shouldThrottle = ... && document.hidden && !document.pictureInPictureElement && !playerBufferState.inAdBreak;
```

## Why

The backoff polls the buffer monitor 3× slower on hidden tabs to save CPU. During an ad break that compounds with the browser's own hidden-tab timer clamping (Firefox clamps `setInterval` to ≥1000ms after 30s hidden), so the recovery sequence — backup search → reload — runs at 3-9s cadence on a backgrounded tab.

Per **issue #129** (Firefox/uBO), a break starting on a hidden tab can leave the stream "stuck loading (still image, no audio) until I tab back in." Keeping the monitor at full cadence during the in-break window lets stall detection + reload fire as fast as the browser allows, instead of vaft adding its own delay on top.

`playerBufferState.inAdBreak` is already maintained on the main thread (set from the worker's `hasAds` message), so no new state — just one added clause.

## Honest scope — workaround, not a full fix

- The **deeper cause is browser-level**: hidden tabs get timer clamping *and* media/network deprioritization, which a page-context userscript/scriptlet can't override. This removes vaft's *own* compounding backoff during the window that matters; it can't make a hidden tab buffer media at foreground priority.
- **N=1 field signal** (one report), and the symptom self-recovers on refocus — low severity. Shipping anyway because it's low-risk and **defensible on its own merits**: throttling stall detection *during an ad break* was never the intent of the idle-tab backoff.
- **Negligible cost**: faster polling only while the tab is hidden *and* mid-break.

## Scope

vaft only — video-swap-new has no visibility-aware backoff to gate. No version bump (accumulates under `## Unreleased`). `npx acorn` clean on both files. Mirrored to the testing pair (direct to master, per convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)