### PR TITLE
Harden ad-spoof pod accounting (cap + unknown-length gating) + GQL body-read timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+- **Ad-spoof pod accounting hardened — cap at declared length + gate on declared length** — two related edge cases in the shared spoof code, both in the path that fires the GQL ad-completion beacons. (1) **Over-surface:** Twitch occasionally exposes more unique stitched-ad DATERANGEs in one poll than `X-TV-TWITCH-AD-POD-LENGTH` declares; the pre-loop early-out only caught that *across* polls, so within one poll vaft kept spoofing past the pod (beacons for more ads than the pod claims — the internally-inconsistent pattern the payload is built to avoid — and `5/2 pod` logs). A per-iteration `break` now stops at the declared length (mirrors GosuDRM/TTV-AB v9.4.1). (2) **Unknown length:** when Twitch *omits* `X-TV-TWITCH-AD-POD-LENGTH`, `podLength` falls back to the current poll's match count — so the size-vs-podLength checks were meaningless: the early-out would bail after the first ad (later ads in the pod left **unspoofed**) and `pod_complete` could fire on multiple polls. All three size comparisons (pre-loop early-out, in-loop cap, `pod_complete`) are now gated on `hasExplicitPodLength`: unknown length → never early-out (spoof every surfaced ad), never fabricate `pod_complete` (mirrors TTV-AB v9.6.4 + v9.7.3). Only affects opt-in spoof-on sessions — spoofing is default-off (vaft) (#NN)
+- **GQL relay abort timeout now covers the response body read** — the main-thread fetch relay (access tokens + spoof beacons for the worker) cleared its 5s AbortController timer as soon as headers arrived, leaving `response.text()` unbounded: a response hanging mid-body would never resolve. The worker-side per-request relay timeout already bounds the impact (backup search can't stall), so this was a leaked-promise nuisance rather than a stall — but the timer now clears after the body read, so an abort mid-body rejects through the existing catch. Mirrors GosuDRM/TTV-AB v9.6.1 (vaft) (#NN)
+
 ## v68.4.0 (2026-06-06)
 
 ### Fixed

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -677,15 +677,28 @@ twitch-videoad.js text/javascript
             const spoofedSet = (streamInfo && streamInfo.SpoofedAdIds) || null;
             const podLenMatch = textStr.match(/X-TV-TWITCH-AD-POD-LENGTH="(\d+)"/);
             const podLength = podLenMatch ? parseInt(podLenMatch[1], 10) : matches.length;
+            // Whether Twitch declared the pod size. When absent, podLength is just THIS poll's
+            // match count — so any size>=podLength check would bail after the first ad
+            // (under-spoofing later ads) and mis-fire pod_complete. Gate every size-vs-podLength
+            // check on this (mirrors GosuDRM/TTV-AB v9.6.4 + v9.7.3): unknown pod length → never
+            // early-out, never fabricate pod_complete.
+            const hasExplicitPodLength = !!podLenMatch;
             // Hot-path early-out: spoof runs every ad-laden poll; once the dedup set
             // covers the pod, every remaining poll is pure waste — bail before the loop.
-            if (spoofedSet && spoofedSet.size >= podLength) {
+            if (hasExplicitPodLength && spoofedSet && spoofedSet.size >= podLength) {
                 return;
             }
             let newSpoofed = 0;
             let firstRollType = '';
             let podCompleteSent = false;
             for (let i = 0; i < matches.length; i++) {
+                // Cap at the declared pod length (mirrors TTV-AB v9.4.1): Twitch occasionally
+                // surfaces more unique stitched-ad DATERANGEs in one poll than
+                // X-TV-TWITCH-AD-POD-LENGTH declares. Spoofing past the pod sends beacons for
+                // more ads than the pod claims — an internally-inconsistent pattern — and logs
+                // impossible totals like "5/2 pod". The pre-loop early-out only catches this
+                // across polls, not within a single poll's match list.
+                if (hasExplicitPodLength && spoofedSet && spoofedSet.size >= podLength) break;
                 // Cheap ID pre-extract — dedup-check before the full parseAttributes()
                 // so already-spoofed ads aren't re-parsed every poll.
                 const idMatch = matches[i][1].match(/^ID="([^"]+)"/);
@@ -744,7 +757,8 @@ twitch-videoad.js text/javascript
                 // pod_complete once per pod (not per ad) — attached to the ad that
                 // completes the true pod size. Per-ad pod_complete (6× for a 6-ad pod)
                 // is itself a fingerprint. Defensive fallback (no dedup set): per-ad.
-                if (!spoofedSet || spoofedSet.size === podLength) {
+                // Unknown pod length → never fire (podLength is only this poll's count), per TTV-AB v9.7.3.
+                if (!spoofedSet || (hasExplicitPodLength && spoofedSet.size === podLength)) {
                     batch.push(makePacket('video_ad_pod_complete'));
                     podCompleteSent = true;
                 }
@@ -2454,8 +2468,11 @@ twitch-videoad.js text/javascript
                 ...fetchRequest.options,
                 signal: controller.signal
             });
-            clearTimeout(timeoutId);
             const responseBody = await response.text();
+            // clearTimeout AFTER the body read (mirrors TTV-AB v9.6.1): the abort must also
+            // cover a response that hangs mid-body, not just slow headers. On abort, text()
+            // rejects with AbortError and the catch below clears the timer (no-op if fired).
+            clearTimeout(timeoutId);
             const responseObject = {
                 id: fetchRequest.id,
                 status: response.status,

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -727,19 +727,33 @@
             // all ads in the pod even though they surface one poll at a time.
             const podLenMatch = textStr.match(/X-TV-TWITCH-AD-POD-LENGTH="(\d+)"/);
             const podLength = podLenMatch ? parseInt(podLenMatch[1], 10) : matches.length;
+            // Whether Twitch declared the pod size. When absent, podLength above is just THIS
+            // poll's match count — NOT the true pod size — so any size>=podLength comparison is
+            // meaningless and would bail after the first ad (under-spoofing later ads) and
+            // mis-fire pod_complete. Gate every size-vs-podLength check on this (mirrors
+            // GosuDRM/TTV-AB v9.6.4 + v9.7.3): unknown pod length → never early-out, never
+            // fabricate pod_complete.
+            const hasExplicitPodLength = !!podLenMatch;
             // Hot-path early-out: notifyAdComplete now runs every ad-laden poll, and a
             // long multi-ad break has hundreds of polls AFTER the whole pod is already
             // spoofed. Once the dedup set covers the pod, every remaining poll is pure
             // waste — bail before the per-match parseAttributes loop. (size at entry is
             // before this poll's additions, so the poll that completes the pod still
             // runs and attaches pod_complete; only subsequent polls short-circuit.)
-            if (spoofedSet && spoofedSet.size >= podLength) {
+            if (hasExplicitPodLength && spoofedSet && spoofedSet.size >= podLength) {
                 return;
             }
             let newSpoofed = 0;
             let firstRollType = '';
             let podCompleteSent = false;
             for (let i = 0; i < matches.length; i++) {
+                // Cap at the declared pod length (mirrors TTV-AB v9.4.1): Twitch occasionally
+                // surfaces more unique stitched-ad DATERANGEs in one poll than
+                // X-TV-TWITCH-AD-POD-LENGTH declares. Spoofing past the pod sends beacons for
+                // more ads than the pod claims — an internally-inconsistent pattern — and logs
+                // impossible totals like "5/2 pod". The pre-loop early-out only catches this
+                // across polls, not within a single poll's match list.
+                if (hasExplicitPodLength && spoofedSet && spoofedSet.size >= podLength) break;
                 // Cheap ID pre-extract for the dedup check — the DATERANGE capture
                 // always starts with ID="stitched-ad-<UUID>". Checking the dedup set
                 // before the full parseAttributes() avoids re-parsing every already-
@@ -811,8 +825,10 @@
                 // the pod never fully surfaces (some DATERANGEs missed / break ended
                 // early) pod_complete is correctly never sent — a real player wouldn't
                 // claim pod completion it didn't reach either. Defensive fallback (no
-                // dedup set): keep per-ad pod_complete so the signal isn't lost.
-                if (!spoofedSet || spoofedSet.size === podLength) {
+                // dedup set): keep per-ad pod_complete so the signal isn't lost. When the pod
+                // length is UNKNOWN, podLength is only this poll's count — never fire
+                // pod_complete (it would mis-fire on multiple polls), per TTV-AB v9.7.3.
+                if (!spoofedSet || (hasExplicitPodLength && spoofedSet.size === podLength)) {
                     batch.push(makePacket('video_ad_pod_complete'));
                     podCompleteSent = true;
                 }
@@ -2612,8 +2628,11 @@
                 ...fetchRequest.options,
                 signal: controller.signal
             });
-            clearTimeout(timeoutId);
             const responseBody = await response.text();
+            // clearTimeout AFTER the body read (mirrors TTV-AB v9.6.1): the abort must also
+            // cover a response that hangs mid-body, not just slow headers. On abort, text()
+            // rejects with AbortError and the catch below clears the timer (no-op if fired).
+            clearTimeout(timeoutId);
             const responseObject = {
                 id: fetchRequest.id,
                 status: response.status,


### PR DESCRIPTION
Spoofing-code hardening mirroring upstream GosuDRM/TTV-AB — all in the shared `notifyAdComplete` lineage, where TTV-AB hit these in the field.

## 1. Pod accounting (TTV-AB v9.4.1 + v9.6.4 + v9.7.3)

Two related edge cases around `X-TV-TWITCH-AD-POD-LENGTH`, both producing internally-inconsistent ad-completion beacons (the cross-validation flag the payload is designed to avoid):

**(a) Over-surface — cap.** Twitch occasionally exposes more unique stitched-ad DATERANGEs in one poll than the pod declares. The pre-loop early-out only caught that *across* polls, so within one poll vaft kept spoofing past the pod (`5/2 pod` logs, beacons for more ads than the pod claims). A per-iteration `break` now stops at the declared length. *(v9.4.1)*

**(b) Unknown length — gate.** When Twitch **omits** the pod-length attribute, `podLength` falls back to the *current poll's* match count, making every `size`-vs-`podLength` comparison meaningless:
- the early-out bailed after the first ad → later ads in the pod left **unspoofed**;
- `pod_complete` could fire on **multiple** polls.

All three checks (pre-loop early-out, in-loop cap, `pod_complete`) are now gated on `hasExplicitPodLength = !!podLenMatch`. Unknown length → never early-out (spoof every surfaced ad), never fabricate `pod_complete`. *(v9.6.4 + v9.7.3)*

## 2. GQL relay abort timeout through body read (TTV-AB v9.6.1)

The main-thread fetch relay (worker's access tokens + spoof beacons) cleared its 5s AbortController timer at **headers**, leaving `await response.text()` unbounded on a mid-body hang. Worker-side relay timeout already bounded the impact (no stall — leaked promise), but the timer now clears **after** the body read so a mid-body abort rejects through the existing catch.

## Scope / validation

- Pod-accounting changes are **opt-in spoof-on territory** (spoofing default-off since v68.3.0). The relay-timeout is always-on but bounded.
- vaft release pair here; mirrored to the testing pair (direct to master, v656). Spoofing is vaft-only → no video-swap-new change.
- Worker-blob safe (pod logic uses loop locals + the new `hasExplicitPodLength`); relay change is main-thread.
- `npx acorn --ecma2022` clean on both; added lines byte-identical across the pair.
- No version bump (accumulates under `## Unreleased`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)