### PR TITLE
Wrap buffer-monitor tick so it always reschedules (crash-safe loop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Fixed
+- **Buffer monitor always reschedules its next tick (crash-safe loop)** — `monitorPlayerBuffering` self-reschedules via `setTimeout(monitorPlayerBuffering, …)` as its last statement, but the ~250-line body (which walks Twitch's React/player internals every tick) had no top-level guard. A single unexpected throw — e.g. a Twitch-side player-shape change hitting an unguarded access — would skip the reschedule and **silently kill every stall / frozen-playhead / mute recovery for the rest of the session**, with no log and no way to recover short of a page reload. The body is now wrapped in `try { … } finally { setTimeout(…) }` so the loop always survives a tick exception. No happy-path behavior change (the body has no early returns; the reschedule was already the sole exit). Mirrors GosuDRM/TTV-AB v9.8.4 (#NN)
+
 ## v68.4.0 (2026-06-06)
 
 ### Fixed

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1816,6 +1816,12 @@ twitch-videoad.js text/javascript
     };
     // Poll the player state to detect and fix buffering caused by ad stream switching
     function monitorPlayerBuffering() {
+        // Always reschedule the next tick, even if the body throws — a single unexpected
+        // exception (e.g. a Twitch-side player-shape change) would otherwise silently kill
+        // every stall / frozen-playhead / mute recovery for the rest of the session.
+        // Mirrors GosuDRM/TTV-AB v9.8.4.
+        let rescheduleDelay = PlayerBufferingDelay;
+        try {
         // Fresh player lookup every tick (avoids stale ref when Twitch restarts its own player)
         playerForMonitoringBuffering = null;
         {
@@ -2048,8 +2054,10 @@ twitch-videoad.js text/javascript
         // stall some users hit when a break starts on a backgrounded tab (issue #129). Workaround, not a full fix:
         // background media deprioritization is browser-level. Negligible cost — only polls faster while hidden + in-break.
         const shouldThrottle = typeof document !== 'undefined' && document.hidden && !document.pictureInPictureElement && !playerBufferState.inAdBreak;
-        const nextDelay = shouldThrottle ? PlayerBufferingDelay * 3 : PlayerBufferingDelay;
-        setTimeout(monitorPlayerBuffering, nextDelay);
+        rescheduleDelay = shouldThrottle ? PlayerBufferingDelay * 3 : PlayerBufferingDelay;
+        } finally {
+            setTimeout(monitorPlayerBuffering, rescheduleDelay);
+        }
     }
     // Hide Twitch's ad break / Turbo promo / stream display ad overlays when we're already blocking ads
     function hideTwitchAdOverlays() {

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -1933,6 +1933,12 @@
     };
     // Poll the player state to detect and fix buffering caused by ad stream switching
     function monitorPlayerBuffering() {
+        // Always reschedule the next tick, even if the body throws — a single unexpected
+        // exception (e.g. a Twitch-side player-shape change) would otherwise silently kill
+        // every stall / frozen-playhead / mute recovery for the rest of the session.
+        // Mirrors GosuDRM/TTV-AB v9.8.4.
+        let rescheduleDelay = PlayerBufferingDelay;
+        try {
         // Fresh player lookup every tick (avoids stale ref when Twitch restarts its own player)
         playerForMonitoringBuffering = null;
         {
@@ -2184,8 +2190,10 @@
         // stall some users hit when a break starts on a backgrounded tab (issue #129). Workaround, not a full fix:
         // background media deprioritization is browser-level. Negligible cost — only polls faster while hidden + in-break.
         const shouldThrottle = typeof document !== 'undefined' && document.hidden && !document.pictureInPictureElement && !playerBufferState.inAdBreak;
-        const nextDelay = shouldThrottle ? PlayerBufferingDelay * 3 : PlayerBufferingDelay;
-        setTimeout(monitorPlayerBuffering, nextDelay);
+        rescheduleDelay = shouldThrottle ? PlayerBufferingDelay * 3 : PlayerBufferingDelay;
+        } finally {
+            setTimeout(monitorPlayerBuffering, rescheduleDelay);
+        }
     }
     // Hide Twitch's ad break / Turbo promo / stream display ad overlays when we're already blocking ads
     function hideTwitchAdOverlays() {


### PR DESCRIPTION
## Problem

`monitorPlayerBuffering()` self-reschedules with `setTimeout(monitorPlayerBuffering, …)` as its **last statement**, but its ~250-line body — which walks Twitch's React/player internals every tick (`player.core?.state`, fiber lookups, `getHTMLVideoElement`, etc.) — had **no top-level guard**. A single unexpected throw anywhere in the body (e.g. a Twitch-side player-shape change hitting an unguarded access) skips the reschedule, and the loop **dies permanently** — every stall, frozen-playhead, and mute recovery silently stops for the rest of the session, with no log and no way back short of a page reload.

## Fix

Wrap the body in `try { … } finally { setTimeout(monitorPlayerBuffering, rescheduleDelay) }` so the next tick is always scheduled even if this one throws:

```js
function monitorPlayerBuffering() {
    let rescheduleDelay = PlayerBufferingDelay;
    try {
        … existing body …
        rescheduleDelay = shouldThrottle ? PlayerBufferingDelay * 3 : PlayerBufferingDelay;
    } finally {
        setTimeout(monitorPlayerBuffering, rescheduleDelay);
    }
}
```

## Why it's safe / no behavior change on the happy path

- The body has **no early `return`s** (verified) and the `setTimeout` was already the sole exit, so wrapping changes nothing when no exception occurs.
- `rescheduleDelay` defaults to `PlayerBufferingDelay` and is set to the visibility-aware backoff value at the end of the body, so a normal tick reschedules exactly as before; only a *thrown* tick now falls back to the base delay instead of dying.
- The body is left at its existing indentation inside the `try` (keeps the diff to the wrap itself — 12 lines — rather than re-indenting 250 lines).

## Scope

vaft release pair; mirrored to the testing pair (direct to master). Mirrors GosuDRM/TTV-AB v9.8.4 ("one unexpected exception can no longer silently kill every stall, freeze, and mute protection"). `npx acorn` clean on both files. No version bump (accumulates under `## Unreleased`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)