### PR TITLE
Guard worker fetch relay against null-body-status Response throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Fixed
+- **Worker fetch relay no longer throws on null-body HTTP statuses** — the relay reconstructs the worker's fetch responses on the worker side via `new Response(body, { status })`. The `Response` constructor throws a `RangeError` when a non-null body is paired with a null-body status (101/204/205/304), and the main-thread relay passes the body as `await response.text()` — which is an empty string `''` (not `null`) for those statuses. So a **304 Not Modified** (or 204) returned through the relay — e.g. a conditional playlist/token request — would throw, the relayed fetch would never resolve, and the worker would hang on it until the relay timeout. The relay now drops the body for null-body statuses. Mirrors GosuDRM/TTV-AB v9.7.1 / v9.9.0 (shared relay lineage; upstream hit it in the field). vaft (#NN)
+
 ## v68.4.0 (2026-06-06)
 
 ### Fixed

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -362,7 +362,13 @@ twitch-videoad.js text/javascript
                                     // Response constructor only takes status/statusText/headers — url/redirected/type
                                     // must be defined on the instance. IVS WASM validates these (Spade/tracking
                                     // requests) and throws NetworkError if they're missing — TTV-AB v6.3.5 fix.
-                                    const response = new Response(responseData.body, {
+                                    // A null-body status (101/204/205/304) paired with a non-null body
+                                    // makes the Response constructor throw — and a 304/204 relayed here
+                                    // carries an empty-string ('') body (not null), which would throw and
+                                    // hang the relayed fetch. Drop the body for those statuses.
+                                    // Mirrors GosuDRM/TTV-AB v9.7.1 / v9.9.0.
+                                    const _nullBodyStatus = responseData.status === 101 || responseData.status === 204 || responseData.status === 205 || responseData.status === 304;
+                                    const response = new Response(_nullBodyStatus ? null : responseData.body, {
                                         status: responseData.status,
                                         statusText: responseData.statusText,
                                         headers: responseData.headers

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -391,7 +391,13 @@
                                     // Response constructor only takes status/statusText/headers — url/redirected/type
                                     // must be defined on the instance. IVS WASM validates these (Spade/tracking
                                     // requests) and throws NetworkError if they're missing — TTV-AB v6.3.5 fix.
-                                    const response = new Response(responseData.body, {
+                                    // A null-body status (101/204/205/304) paired with a non-null body
+                                    // makes the Response constructor throw — and a 304/204 relayed here
+                                    // carries an empty-string ('') body (not null), which would throw and
+                                    // hang the relayed fetch. Drop the body for those statuses.
+                                    // Mirrors GosuDRM/TTV-AB v9.7.1 / v9.9.0.
+                                    const _nullBodyStatus = responseData.status === 101 || responseData.status === 204 || responseData.status === 205 || responseData.status === 304;
+                                    const response = new Response(_nullBodyStatus ? null : responseData.body, {
                                         status: responseData.status,
                                         statusText: responseData.statusText,
                                         headers: responseData.headers


### PR DESCRIPTION
## Problem

The worker fetch relay reconstructs the worker's fetch responses on the worker side:

```js
const response = new Response(responseData.body, { status: responseData.status, … });
```

`new Response(body, { status })` throws a `RangeError` when a **non-null body** is paired with a **null-body status** (101 / 204 / 205 / 304). The main-thread relay supplies the body as `await response.text()` — which is an **empty string `''` (not `null`)** for those statuses. So a **304 Not Modified** or **204** returned through the relay (e.g. a conditional playlist/token request) makes the worker-side reconstruction throw: the relayed fetch never resolves, and the worker hangs on it until the relay timeout fires.

## Fix

Drop the body for null-body statuses before constructing the Response:

```js
const _nullBodyStatus = responseData.status === 101 || responseData.status === 204 || responseData.status === 205 || responseData.status === 304;
const response = new Response(_nullBodyStatus ? null : responseData.body, { status: responseData.status, … });
```

Status/statusText/headers are unchanged, as is the `url`/`redirected`/`type` post-assignment the IVS WASM validation needs.

## Scope

- Real-but-low-frequency: most relay fetches are 200; **304 is the realistic trigger**. The relay timeout already bounds the hang, so this is a robustness fix, not a crash.
- Mirrors GosuDRM/TTV-AB v9.7.1 ("responses with status 101, 204, 205, or 304 are now rebuilt without a body") and v9.9.0 ("exhausted token fetches return a real network-error response instead of throwing from the Response constructor") — shared relay lineage, upstream hit it in the field.
- vaft release pair; mirrored to the testing pair (direct to master, v658). `npx acorn` clean on all four files. No version bump (accumulates under `## Unreleased`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)