### PR TITLE
In-ad frozen-buffer-gap seek to fix mid-break loading circle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Fixed
+- **Loading circle during ad breaks — in-ad frozen-buffer-gap seek** — the buffer monitor's stall recovery is gated `!inAdBreak`, and the strip-recovery path only fires while actively stripping segments. On a CSAI break (`stripped 0`) neither applies, so when the autoplay 360p backup developed a buffered hole ahead of the playhead (field logs showed 18-24s gaps — a timeline discontinuity from the native↔backup swap), the player froze at the gap with **no recovery** until the gap filled or the break ended — a multi-second loading circle mid-break. Added a narrow in-ad recovery mirroring GosuDRM/TTV-AB's `_trySeekPastFrozenBufferGap` (#33 / v9.3.6 / v9.7.5): during a **live** CSAI break, once the playhead is confirmed **frozen** (no advance for 3 monitor ticks **and** `readyState < 3`, i.e. genuinely starved), seek past the buffered hole to the next range. **Seek-only and confirmed-frozen** — it can't fire a reload, can't skip VOD content (live-gated), and won't fire while the player is still progressing; the strip-recovery path is untouched. Logs each seek (#NN)
+
 ## v68.4.0 (2026-06-06)
 
 ### Fixed

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -1978,6 +1978,38 @@ twitch-videoad.js text/javascript
                 playerForMonitoringBuffering = null;
             }
         }
+        // In-ad frozen-buffer-gap seek (mirrors GosuDRM/TTV-AB _trySeekPastFrozenBufferGap, #33 / v9.7.5):
+        // the main buffer-stall recovery is gated !inAdBreak and the strip-recovery only fires while
+        // stripping, so on a CSAI break a frozen-at-gap autoplay backup has no recovery (loading circle).
+        // Confirm the playhead is genuinely frozen — no advance for 3 monitor ticks AND readyState < 3
+        // (starved) — then seek past the buffered hole. Live-only + confirmed-frozen, so it can't skip
+        // VOD content or fire while the player is still progressing.
+        if (playerBufferState.inAdBreak && !isActivelyStrippingAds && playerForMonitoringBuffering
+            && playerForMonitoringBuffering.state?.props?.content?.type === 'live') {
+            try {
+                const v = playerForMonitoringBuffering.player?.getHTMLVideoElement?.();
+                const ct = v ? v.currentTime : 0;
+                const last = playerBufferState.gapJumpLastPosition;
+                if (!v || last === undefined || last < 0 || ct > last + 0.2 || ct < last) {
+                    playerBufferState.gapJumpStuckTicks = 0;
+                } else {
+                    playerBufferState.gapJumpStuckTicks = (playerBufferState.gapJumpStuckTicks || 0) + 1;
+                }
+                playerBufferState.gapJumpLastPosition = ct;
+                if (v && !v.paused && !v.ended && (playerBufferState.gapJumpStuckTicks || 0) >= 3 && (v.readyState ?? 4) < 3 && v.buffered && v.buffered.length > 1) {
+                    for (let i = 0; i < v.buffered.length; i++) {
+                        const gapStart = v.buffered.start(i);
+                        if (gapStart > ct + 0.25) {
+                            console.log('[AD DEBUG] In-ad buffer-gap seek — playhead ' + ct.toFixed(1) + 's frozen ' + playerBufferState.gapJumpStuckTicks + ' ticks (readyState ' + v.readyState + '); seeking ' + (gapStart - ct).toFixed(1) + 's past gap to ' + gapStart.toFixed(1) + 's (mirrors TTV-AB #33)');
+                            v.currentTime = gapStart + 0.05;
+                            playerBufferState.gapJumpStuckTicks = 0;
+                            playerBufferState.gapJumpLastPosition = -1;
+                            break;
+                        }
+                    }
+                }
+            } catch {}
+        }
         // Loading-circle health check: during an ad strip+recovery loop the normal buffer monitor
         // is gated off (isActivelyStrippingAds), so a visibly stalled player would otherwise wait
         // for the worker's poll-based early reload (~10s). This catches the visible stall ~3s after

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -2114,6 +2114,38 @@
                 playerForMonitoringBuffering = null;
             }
         }
+        // In-ad frozen-buffer-gap seek (mirrors GosuDRM/TTV-AB _trySeekPastFrozenBufferGap, #33 / v9.7.5):
+        // the main buffer-stall recovery is gated !inAdBreak and the strip-recovery only fires while
+        // stripping, so on a CSAI break a frozen-at-gap autoplay backup has no recovery (loading circle).
+        // Confirm the playhead is genuinely frozen — no advance for 3 monitor ticks AND readyState < 3
+        // (starved) — then seek past the buffered hole. Live-only + confirmed-frozen, so it can't skip
+        // VOD content or fire while the player is still progressing.
+        if (playerBufferState.inAdBreak && !isActivelyStrippingAds && playerForMonitoringBuffering
+            && playerForMonitoringBuffering.state?.props?.content?.type === 'live') {
+            try {
+                const v = playerForMonitoringBuffering.player?.getHTMLVideoElement?.();
+                const ct = v ? v.currentTime : 0;
+                const last = playerBufferState.gapJumpLastPosition;
+                if (!v || last === undefined || last < 0 || ct > last + 0.2 || ct < last) {
+                    playerBufferState.gapJumpStuckTicks = 0;
+                } else {
+                    playerBufferState.gapJumpStuckTicks = (playerBufferState.gapJumpStuckTicks || 0) + 1;
+                }
+                playerBufferState.gapJumpLastPosition = ct;
+                if (v && !v.paused && !v.ended && (playerBufferState.gapJumpStuckTicks || 0) >= 3 && (v.readyState ?? 4) < 3 && v.buffered && v.buffered.length > 1) {
+                    for (let i = 0; i < v.buffered.length; i++) {
+                        const gapStart = v.buffered.start(i);
+                        if (gapStart > ct + 0.25) {
+                            console.log('[AD DEBUG] In-ad buffer-gap seek — playhead ' + ct.toFixed(1) + 's frozen ' + playerBufferState.gapJumpStuckTicks + ' ticks (readyState ' + v.readyState + '); seeking ' + (gapStart - ct).toFixed(1) + 's past gap to ' + gapStart.toFixed(1) + 's (mirrors TTV-AB #33)');
+                            v.currentTime = gapStart + 0.05;
+                            playerBufferState.gapJumpStuckTicks = 0;
+                            playerBufferState.gapJumpLastPosition = -1;
+                            break;
+                        }
+                    }
+                }
+            } catch {}
+        }
         // Loading-circle health check: during an ad strip+recovery loop the normal buffer monitor
         // is gated off (isActivelyStrippingAds), so a visibly stalled player would otherwise wait
         // for the worker's poll-based early reload (~10s). This catches the visible stall ~3s after


### PR DESCRIPTION
## Problem

Field logs (heavy-CSAI channels like `hiimsky`/`aspen`) showed a loading circle **mid-ad-break**. The autoplay 360p backup develops a buffered hole ahead of the playhead:

```
<video> 350–380, then 398–404   (18s gap 380→398)
<video> 326–356, then 380–386   (24s gap — same on a break with no re-probe)
```

A timeline discontinuity (native↔backup swap) leaves the playhead with nothing buffered across the gap → it freezes. vaft has **no recovery for this on a CSAI break**: the main buffer-stall recovery is gated `!inAdBreak`, and the `isActivelyStrippingAds` early-reload only fires while stripping (CSAI = `stripped 0`). So the player sat on a loading circle until the gap filled or the break ended.

## Fix

A narrow in-ad recovery that **mirrors TTV-AB's `_trySeekPastFrozenBufferGap`** (#33 / v9.3.6 / v9.7.5) — confirmed-frozen, not gap-edge-guessing:

```js
if (inAdBreak && !isActivelyStrippingAds && state?.props?.content?.type === 'live') {
    // track playhead; count ticks where it hasn't advanced >0.2s
    if (stuckTicks >= 3 && video.readyState < 3 && video.buffered.length > 1) {
        // seek to the first buffered range starting > currentTime + 0.25
        video.currentTime = gapStart + 0.05;
    }
}
```

## Why it's safe

- **Confirmed-frozen, not single-tick:** seeks only after the playhead hasn't advanced for **3 monitor ticks** AND `readyState < 3` (genuinely starved) — matches TTV-AB. Won't fire while the player is still progressing toward the gap.
- **Live-gated** (`content?.type === 'live'`) — can't skip VOD content.
- **Seek-only** (no reload/teardown), **forward-only**, scoped to CSAI breaks (`!isActivelyStrippingAds`), wrapped in try/catch inside the crash-safe monitor (#242). Failure mode is no-op.
- Strip-recovery and the `!inAdBreak` recovery paths are untouched.

## Scope

vaft release pair; mirrored to the testing pair (v659 → **v660**, the frozen-confirmed revision). `npx acorn` clean on both; blocks byte-identical. No version bump (accumulates under `## Unreleased`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)