### PR TITLE
Clear leaked pre-mute when restore resolves a different <video> (#248)

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -2446,6 +2446,18 @@ twitch-videoad.js text/javascript
                                     cur.muted = false;
                                     playerBufferState.vaftEverUnmuted = true;
                                 }
+                                // Undo OUR pre-mute if it landed on a different element than `cur`.
+                                // `cur` is whichever <video> is first in the DOM — not necessarily the one
+                                // we muted, now that Twitch renders extra <video> elements for side/chat
+                                // ads (#249), and Firefox's PiP is browser-native so the
+                                // document.pictureInPictureElement reload guard never fires there (#248).
+                                // Gated on wasInitiallyUnmuted so it only ever clears a mute we set —
+                                // it can never unmute an ad video. No-op on a normal hard reload, where
+                                // the old element is disconnected.
+                                if (v && v !== cur && v.isConnected && v.muted && wasInitiallyUnmuted) {
+                                    v.muted = false;
+                                    console.log('[AD DEBUG] Restore — cleared leaked pre-mute on the original element (cur resolved to a different <video>) — issue #248');
+                                }
                             } catch {}
                         };
                         const listener = (e) => {
@@ -2468,6 +2480,12 @@ twitch-videoad.js text/javascript
                                         playerBufferState.vaftEverUnmuted = true;
                                         console.log('[AD DEBUG] Hard reload backstop unmute fired — element was still muted at 5500ms (initial: ' + (wasInitiallyUnmuted ? 'unmuted, we pre-muted' : 'already-muted on entry — recovering from silent Twitch re-mute') + ')');
                                     }
+                                }
+                                // Same leaked-pre-mute catch as in restore(), at the backstop — see #248.
+                                if (v && v !== cur && v.isConnected && v.muted && wasInitiallyUnmuted
+                                    && !playerBufferState.userPauseIntent) {
+                                    v.muted = false;
+                                    console.log('[AD DEBUG] Backstop — cleared leaked pre-mute on the original element (cur resolved to a different <video>) — issue #248');
                                 }
                             } catch {}
                         }, 5500);

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -2593,6 +2593,18 @@
                                     cur.muted = false;
                                     playerBufferState.vaftEverUnmuted = true;
                                 }
+                                // Undo OUR pre-mute if it landed on a different element than `cur`.
+                                // `cur` is whichever <video> is first in the DOM — not necessarily the one
+                                // we muted, now that Twitch renders extra <video> elements for side/chat
+                                // ads (#249), and Firefox's PiP is browser-native so the
+                                // document.pictureInPictureElement reload guard never fires there (#248).
+                                // Gated on wasInitiallyUnmuted so it only ever clears a mute we set —
+                                // it can never unmute an ad video. No-op on a normal hard reload, where
+                                // the old element is disconnected.
+                                if (v && v !== cur && v.isConnected && v.muted && wasInitiallyUnmuted) {
+                                    v.muted = false;
+                                    console.log('[AD DEBUG] Restore — cleared leaked pre-mute on the original element (cur resolved to a different <video>) — issue #248');
+                                }
                             } catch {}
                         };
                         const listener = (e) => {
@@ -2620,6 +2632,12 @@
                                         playerBufferState.vaftEverUnmuted = true;
                                         console.log('[AD DEBUG] Hard reload backstop unmute fired — element was still muted at 5500ms (initial: ' + (wasInitiallyUnmuted ? 'unmuted, we pre-muted' : 'already-muted on entry — recovering from silent Twitch re-mute') + ')');
                                     }
+                                }
+                                // Same leaked-pre-mute catch as in restore(), at the backstop — see #248.
+                                if (v && v !== cur && v.isConnected && v.muted && wasInitiallyUnmuted
+                                    && !playerBufferState.userPauseIntent) {
+                                    v.muted = false;
+                                    console.log('[AD DEBUG] Backstop — cleared leaked pre-mute on the original element (cur resolved to a different <video>) — issue #248');
                                 }
                             } catch {}
                         }, 5500);


### PR DESCRIPTION
Release port of the fix already shipped in testing **v668.0.0** (cdb00de). Fixes #248 (*"randomly muting while in PIP mode"*).

## The bug
The hard-reload pre-mute sets `muted = true` on `document.querySelector('video')`, but `restore()` and the 5500ms backstop **re-query** `document.querySelector('video')` instead of reusing that reference.

The re-query is deliberate and necessary — `setSrc({isNewMediaPlayerInstance:true})` replaces the `<video>` element, so the original reference is dead (see the existing comment at that site). But it returns whichever `<video>` is **first in the DOM**, which isn't necessarily the one we muted. When those differ, vaft unmutes one element and leaves its mute on another → **the video actually being watched stays silent.**

## Why it's surfacing now
- Twitch has started rendering **extra `<video>` elements** for the new separate side/chat ads (#249), so `querySelector('video')` can resolve to an ad element.
- **Firefox's PiP is browser-native and never sets `document.pictureInPictureElement`**, so the PiP reload-guard in `doTwitchPlayerTask` silently never fires there — Firefox PiP users get the hard reload (and the pre-mute) that Chrome PiP users are shielded from. That's what makes it present as "in PiP mode".

## The fix
In `restore()` and the backstop, also clear the mute on the element we *actually* pre-muted, if it's still connected and still muted:

```js
if (v && v !== cur && v.isConnected && v.muted && wasInitiallyUnmuted) { v.muted = false; ... }
```

- Gated on `wasInitiallyUnmuted`, so it **only ever clears a mute vaft itself set** — it can never unmute an ad video.
- **No-op on the normal hard-reload path**, where the old element is disconnected (`isConnected === false`).
- Logs an explicit `cleared leaked pre-mute` line so the leak becomes visible in field logs.

Purely additive (**+36/−0**), no behaviour change when `v === cur` (the single-`<video>` case).

## Notes
- **No version bump**, matching the other open release backports (#240/#242/#243/#244) — bump at rollup.
- **Does not** attempt to detect Firefox PiP — not reliably possible from page context. A hard reload will still exit Firefox PiP; this only guarantees we never leave audio muted.
- Root cause is still a **hypothesis** pending reporter confirmation (browser + whether they see the #249 side-ad player) — asked on the issue. The fix is safe regardless, since it only undoes vaft's own mute.